### PR TITLE
Add ECR repos and policy to publish from platform

### DIFF
--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -100,7 +100,7 @@ resource "aws_ecr_repository_policy" "callback_stub_server" {
 data "aws_iam_policy_document" "platform_put_images" {
   statement {
     actions = [
-      "ecr:*"
+      "ecr:*",
     ]
 
     principals {

--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -1,0 +1,111 @@
+module "ecr_repository_archivist" {
+  source    = "git::https://github.com/wellcometrust/terraform.git//ecr?ref=v19.5.1"
+  id        = "archivist"
+  namespace = "uk.ac.wellcome"
+}
+
+resource "aws_ecr_repository_policy" "archivist" {
+  repository = "${module.ecr_repository_archivist.name}"
+  policy     = "${data.aws_iam_policy_document.platform_put_images.json}"
+}
+
+module "ecr_repository_bags" {
+  source    = "git::https://github.com/wellcometrust/terraform.git//ecr?ref=v19.5.1"
+  id        = "bags"
+  namespace = "uk.ac.wellcome"
+}
+
+resource "aws_ecr_repository_policy" "bags" {
+  repository = "${module.ecr_repository_bags.name}"
+  policy     = "${data.aws_iam_policy_document.platform_put_images.json}"
+}
+
+module "ecr_repository_bags_api" {
+  source    = "git::https://github.com/wellcometrust/terraform.git//ecr?ref=v19.5.1"
+  id        = "bags_api"
+  namespace = "uk.ac.wellcome"
+}
+
+resource "aws_ecr_repository_policy" "bags_api" {
+  repository = "${module.ecr_repository_bags_api.name}"
+  policy     = "${data.aws_iam_policy_document.platform_put_images.json}"
+}
+
+module "ecr_repository_ingests" {
+  source    = "git::https://github.com/wellcometrust/terraform.git//ecr?ref=v19.5.1"
+  id        = "ingests"
+  namespace = "uk.ac.wellcome"
+}
+
+resource "aws_ecr_repository_policy" "ingests" {
+  repository = "${module.ecr_repository_ingests.name}"
+  policy     = "${data.aws_iam_policy_document.platform_put_images.json}"
+}
+
+module "ecr_repository_ingests_api" {
+  source    = "git::https://github.com/wellcometrust/terraform.git//ecr?ref=v19.5.1"
+  id        = "ingests_api"
+  namespace = "uk.ac.wellcome"
+}
+
+resource "aws_ecr_repository_policy" "ingests_api" {
+  repository = "${module.ecr_repository_ingests_api.name}"
+  policy     = "${data.aws_iam_policy_document.platform_put_images.json}"
+}
+
+module "ecr_repository_notifier" {
+  source    = "git::https://github.com/wellcometrust/terraform.git//ecr?ref=v19.5.1"
+  id        = "notifier"
+  namespace = "uk.ac.wellcome"
+}
+
+resource "aws_ecr_repository_policy" "notifier" {
+  repository = "${module.ecr_repository_notifier.name}"
+  policy     = "${data.aws_iam_policy_document.platform_put_images.json}"
+}
+
+module "ecr_repository_bag_replicator" {
+  source    = "git::https://github.com/wellcometrust/terraform.git//ecr?ref=v19.5.1"
+  id        = "bag_replicator"
+  namespace = "uk.ac.wellcome"
+}
+
+resource "aws_ecr_repository_policy" "bag_replicator" {
+  repository = "${module.ecr_repository_bag_replicator.name}"
+  policy     = "${data.aws_iam_policy_document.platform_put_images.json}"
+}
+
+module "ecr_repository_bagger" {
+  source    = "git::https://github.com/wellcometrust/terraform.git//ecr?ref=v19.5.1"
+  id        = "bagger"
+  namespace = "uk.ac.wellcome"
+}
+
+resource "aws_ecr_repository_policy" "bagger" {
+  repository = "${module.ecr_repository_bagger.name}"
+  policy     = "${data.aws_iam_policy_document.platform_put_images.json}"
+}
+
+module "ecr_repository_callback_stub_server" {
+  source    = "git::https://github.com/wellcometrust/terraform.git//ecr?ref=v19.5.1"
+  id        = "callback_stub_server"
+  namespace = "uk.ac.wellcome"
+}
+
+resource "aws_ecr_repository_policy" "callback_stub_server" {
+  repository = "${module.ecr_repository_callback_stub_server.name}"
+  policy     = "${data.aws_iam_policy_document.platform_put_images.json}"
+}
+
+data "aws_iam_policy_document" "platform_put_images" {
+  statement {
+    actions = [
+      "ecr:*"
+    ]
+
+    principals {
+      identifiers = ["arn:aws:iam::760097843905:root"]
+      type        = "AWS"
+    }
+  }
+}

--- a/terraform/stack/main.tf
+++ b/terraform/stack/main.tf
@@ -13,12 +13,12 @@ module "archivist" {
   aws_region                       = "${var.aws_region}"
 
   env_vars = {
-    queue_url                = "${module.archivist_queue.url}"
-    queue_parallelism        = "${var.archivist_queue_parallelism}"
-    archive_bucket           = "${var.archive_bucket_name}"
-    next_service_topic_arn   = "${module.bag_replicator_topic.arn}"
-    progress_topic_arn       = "${module.ingests_topic.arn}"
-    JAVA_OPTS                = "-Dcom.amazonaws.sdk.enableDefaultMetrics=cloudwatchRegion=${var.aws_region},metricNameSpace=${var.namespace}-archivist"
+    queue_url              = "${module.archivist_queue.url}"
+    queue_parallelism      = "${var.archivist_queue_parallelism}"
+    archive_bucket         = "${var.archive_bucket_name}"
+    next_service_topic_arn = "${module.bag_replicator_topic.arn}"
+    progress_topic_arn     = "${module.ingests_topic.arn}"
+    JAVA_OPTS              = "-Dcom.amazonaws.sdk.enableDefaultMetrics=cloudwatchRegion=${var.aws_region},metricNameSpace=${var.namespace}-archivist"
   }
 
   env_vars_length = 6

--- a/terraform/stack/messaging.tf
+++ b/terraform/stack/messaging.tf
@@ -36,7 +36,7 @@ module "ingests_queue" {
 module "ingest_requests_topic" {
   source = "../modules/topic"
 
-  name  = "${var.namespace}_ingest_requests"
+  name       = "${var.namespace}_ingest_requests"
   role_names = ["${module.api.ingests_role_name}"]
 }
 
@@ -93,7 +93,7 @@ module "bags_queue" {
 module "notifier_topic" {
   source = "../modules/topic"
 
-  name  = "${var.namespace}_notifier"
+  name       = "${var.namespace}_notifier"
   role_names = ["${module.ingests.task_role_name}"]
 }
 
@@ -116,7 +116,7 @@ module "notifier_queue" {
 module "bagger_topic" {
   source = "../modules/topic"
 
-  name  = "${var.namespace}_bagger"
+  name       = "${var.namespace}_bagger"
   role_names = []
 }
 
@@ -137,7 +137,7 @@ module "bagger_queue" {
 module "bagging_complete_topic" {
   source = "../modules/topic"
 
-  name  = "${var.namespace}_bagging_complete"
+  name       = "${var.namespace}_bagging_complete"
   role_names = ["${module.bagger.task_role_name}"]
 }
 


### PR DESCRIPTION
In order that we can place ECR repos for a project within the same account as the storage service and allow publication from the platform account.