### PR TITLE
BagInfo make SourceOrganisation optional

### DIFF
--- a/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/models/DisplayBagInfo.scala
+++ b/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/models/DisplayBagInfo.scala
@@ -6,8 +6,8 @@ import uk.ac.wellcome.platform.archive.common.models.bagit.BagInfo
 case class DisplayBagInfo(
   externalIdentifier: String,
   payloadOxum: String,
-  sourceOrganization: String,
   baggingDate: String,
+  sourceOrganization: Option[String] = None,
   externalDescription: Option[String] = None,
   internalSenderIdentifier: Option[String] = None,
   internalSenderDescription: Option[String] = None,
@@ -17,11 +17,16 @@ case class DisplayBagInfo(
 
 object DisplayBagInfo {
   def apply(bagInfo: BagInfo): DisplayBagInfo = DisplayBagInfo(
-    externalIdentifier = bagInfo.externalIdentifier.underlying,
-    payloadOxum = bagInfo.payloadOxum.toString,
-    sourceOrganization = bagInfo.sourceOrganisation.underlying,
-    baggingDate = bagInfo.baggingDate.toString,
-    externalDescription = bagInfo.externalDescription.map(_.underlying),
+    externalIdentifier =
+      bagInfo.externalIdentifier.underlying,
+    payloadOxum =
+      bagInfo.payloadOxum.toString,
+    baggingDate =
+      bagInfo.baggingDate.toString,
+    sourceOrganization =
+      bagInfo.sourceOrganisation.map(_.underlying),
+    externalDescription =
+      bagInfo.externalDescription.map(_.underlying),
     internalSenderIdentifier =
       bagInfo.internalSenderIdentifier.map(_.underlying),
     internalSenderDescription =

--- a/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/models/DisplayBagInfo.scala
+++ b/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/models/DisplayBagInfo.scala
@@ -17,16 +17,11 @@ case class DisplayBagInfo(
 
 object DisplayBagInfo {
   def apply(bagInfo: BagInfo): DisplayBagInfo = DisplayBagInfo(
-    externalIdentifier =
-      bagInfo.externalIdentifier.underlying,
-    payloadOxum =
-      bagInfo.payloadOxum.toString,
-    baggingDate =
-      bagInfo.baggingDate.toString,
-    sourceOrganization =
-      bagInfo.sourceOrganisation.map(_.underlying),
-    externalDescription =
-      bagInfo.externalDescription.map(_.underlying),
+    externalIdentifier = bagInfo.externalIdentifier.underlying,
+    payloadOxum = bagInfo.payloadOxum.toString,
+    baggingDate = bagInfo.baggingDate.toString,
+    sourceOrganization = bagInfo.sourceOrganisation.map(_.underlying),
+    externalDescription = bagInfo.externalDescription.map(_.underlying),
     internalSenderIdentifier =
       bagInfo.internalSenderIdentifier.map(_.underlying),
     internalSenderDescription =

--- a/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
+++ b/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
@@ -78,8 +78,8 @@ class BagsApiFeatureTest
                         DisplayBagInfo(
                           externalIdentifierString,
                           payloadOxum,
-                          sourceOrganization,
                           baggingDate,
+                          sourceOrganization,
                           _,
                           _,
                           _,
@@ -110,7 +110,7 @@ class BagsApiFeatureTest
                       storageSpaceName shouldBe space.underlying
                       externalIdentifierString shouldBe bagInfo.externalIdentifier.underlying
                       payloadOxum shouldBe s"${bagInfo.payloadOxum.payloadBytes}.${bagInfo.payloadOxum.numberOfPayloadFiles}"
-                      sourceOrganization shouldBe bagInfo.sourceOrganisation.underlying
+                      sourceOrganization shouldBe bagInfo.sourceOrganisation.map(_.underlying)
                       baggingDate shouldBe bagInfo.baggingDate.format(
                         DateTimeFormatter.ISO_LOCAL_DATE)
 

--- a/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
+++ b/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
@@ -110,7 +110,8 @@ class BagsApiFeatureTest
                       storageSpaceName shouldBe space.underlying
                       externalIdentifierString shouldBe bagInfo.externalIdentifier.underlying
                       payloadOxum shouldBe s"${bagInfo.payloadOxum.payloadBytes}.${bagInfo.payloadOxum.numberOfPayloadFiles}"
-                      sourceOrganization shouldBe bagInfo.sourceOrganisation.map(_.underlying)
+                      sourceOrganization shouldBe bagInfo.sourceOrganisation
+                        .map(_.underlying)
                       baggingDate shouldBe bagInfo.baggingDate.format(
                         DateTimeFormatter.ISO_LOCAL_DATE)
 

--- a/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/models/DisplayBagInfoTest.scala
+++ b/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/models/DisplayBagInfoTest.scala
@@ -12,8 +12,8 @@ class DisplayBagInfoTest extends FunSpec with RandomThings with Matchers {
     DisplayBagInfo(bagInfo) shouldBe DisplayBagInfo(
       bagInfo.externalIdentifier.underlying,
       s"${bagInfo.payloadOxum.payloadBytes}.${bagInfo.payloadOxum.numberOfPayloadFiles}",
-      bagInfo.sourceOrganisation.underlying,
       bagInfo.baggingDate.format(DateTimeFormatter.ISO_LOCAL_DATE),
+      Some(bagInfo.sourceOrganisation.get.underlying),
       Some(bagInfo.externalDescription.get.underlying),
       Some(bagInfo.internalSenderIdentifier.get.underlying),
       Some(bagInfo.internalSenderDescription.get.underlying),

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/models/bagit/BagInfo.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/models/bagit/BagInfo.scala
@@ -4,9 +4,9 @@ import java.time.LocalDate
 
 case class BagInfo(
   externalIdentifier: ExternalIdentifier,
-  sourceOrganisation: SourceOrganisation,
   payloadOxum: PayloadOxum,
   baggingDate: LocalDate,
+  sourceOrganisation: Option[SourceOrganisation] = None,
   externalDescription: Option[ExternalDescription] = None,
   internalSenderIdentifier: Option[InternalSenderIdentifier] = None,
   internalSenderDescription: Option[InternalSenderDescription] = None)
@@ -23,7 +23,6 @@ case class ExternalDescription(underlying: String) extends AnyVal {
 case class SourceOrganisation(underlying: String) extends AnyVal {
   override def toString: String = underlying
 }
-
 case class PayloadOxum(payloadBytes: Long, numberOfPayloadFiles: Int) {
   override def toString = s"$payloadBytes.$numberOfPayloadFiles"
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bag/BagInfoParserTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bag/BagInfoParserTest.scala
@@ -14,54 +14,42 @@ class BagInfoParserTest
   case class Thing(id: String)
   val t = Thing("a")
 
-  it("extracts a BagInfo object from a bagInfo file with required fields") {
+  it("extracts a BagInfo object from a bagInfo file with only required fields") {
     val externalIdentifier = randomExternalIdentifier
-    val sourceOrganisation = randomSourceOrganisation
     val payloadOxum = randomPayloadOxum
     val baggingDate = randomLocalDate
-    val bagInfoString = bagInfoFileContents(
-      externalIdentifier,
-      sourceOrganisation,
-      payloadOxum,
-      baggingDate,
-      None,
-      None,
-      None)
+    val bagInfoString =
+      bagInfoFileContents(externalIdentifier, payloadOxum, baggingDate)
 
     BagInfoParser.parseBagInfo(t, IOUtils.toInputStream(bagInfoString, "UTF-8")) shouldBe Right(
-      bagit.BagInfo(
-        externalIdentifier,
-        sourceOrganisation,
-        payloadOxum,
-        baggingDate))
+      bagit.BagInfo(externalIdentifier, payloadOxum, baggingDate))
   }
 
   it(
-    "extracts a BagInfo object from a bagInfo file with required and optional fields") {
+    "extracts a BagInfo object from a bagInfo file with all required and optional fields") {
     val externalIdentifier = randomExternalIdentifier
-    val sourceOrganisation = randomSourceOrganisation
     val payloadOxum = randomPayloadOxum
     val baggingDate = randomLocalDate
+    val sourceOrganisation = Some(randomSourceOrganisation)
     val externalDescription = Some(randomExternalDescription)
     val internalSenderIdentifier = Some(randomInternalSenderIdentifier)
     val internalSenderDescription = Some(randomInternalSenderDescription)
 
     val bagInfoString = bagInfoFileContents(
       externalIdentifier,
-      sourceOrganisation,
       payloadOxum,
       baggingDate,
+      sourceOrganisation,
       externalDescription,
       internalSenderIdentifier,
-      internalSenderDescription
-    )
+      internalSenderDescription)
 
     BagInfoParser.parseBagInfo(t, IOUtils.toInputStream(bagInfoString, "UTF-8")) shouldBe Right(
       bagit.BagInfo(
         externalIdentifier,
-        sourceOrganisation,
         payloadOxum,
         baggingDate,
+        sourceOrganisation,
         externalDescription,
         internalSenderIdentifier,
         internalSenderDescription))
@@ -76,17 +64,6 @@ class BagInfoParserTest
 
     BagInfoParser.parseBagInfo(t, IOUtils.toInputStream(bagInfoString, "UTF-8")) shouldBe Left(
       InvalidBagInfo(t, List("External-Identifier")))
-  }
-
-  it(
-    "returns a left of invalid bag info error if there is no source organization in bag-info.txt") {
-    val bagInfoString =
-      s"""|External-Identifier: $randomExternalIdentifier
-          |Payload-Oxum: ${randomPayloadOxum.payloadBytes}.${randomPayloadOxum.numberOfPayloadFiles}
-          |Bagging-Date: $randomLocalDate""".stripMargin
-
-    BagInfoParser.parseBagInfo(t, IOUtils.toInputStream(bagInfoString, "UTF-8")) shouldBe Left(
-      InvalidBagInfo(t, List("Source-Organization")))
   }
 
   it(
@@ -141,11 +118,7 @@ class BagInfoParserTest
     BagInfoParser.parseBagInfo(t, IOUtils.toInputStream(bagInfoString, "UTF-8")) shouldBe Left(
       InvalidBagInfo(
         t,
-        List(
-          "External-Identifier",
-          "Source-Organization",
-          "Payload-Oxum",
-          "Bagging-Date")))
+        List("External-Identifier", "Payload-Oxum", "Bagging-Date")))
   }
 
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagIt.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagIt.scala
@@ -56,9 +56,9 @@ trait BagIt extends RandomThings {
         s"bag-info.txt",
         bagInfoFileContents(
           bagInfo.externalIdentifier,
-          bagInfo.sourceOrganisation,
           bagInfo.payloadOxum,
           bagInfo.baggingDate,
+          bagInfo.sourceOrganisation,
           bagInfo.externalDescription,
           bagInfo.internalSenderIdentifier,
           bagInfo.internalSenderDescription
@@ -120,25 +120,29 @@ trait BagIt extends RandomThings {
 
   def bagInfoFileContents(
     bagIdentifier: ExternalIdentifier,
-    sourceOrganisation: SourceOrganisation,
     payloadOxum: PayloadOxum,
     baggingDate: LocalDate,
-    externalDescription: Option[ExternalDescription],
-    internalSenderIdentifier: Option[InternalSenderIdentifier],
-    internalSenderDescription: Option[InternalSenderDescription]) = {
+    sourceOrganisation: Option[SourceOrganisation] = None,
+    externalDescription: Option[ExternalDescription] = None,
+    internalSenderIdentifier: Option[InternalSenderIdentifier] = None,
+    internalSenderDescription: Option[InternalSenderDescription] = None)
+    : String = {
     def optionalLine[T](maybeValue: Option[T], fieldName: String) =
       maybeValue.map(value => s"$fieldName: $value").getOrElse("")
 
+    val sourceOrganisationLine =
+      optionalLine(sourceOrganisation, "Source-Organization")
     val descriptionLine =
       optionalLine(externalDescription, "External-Description")
     val internalSenderIdentifierLine =
       optionalLine(internalSenderIdentifier, "Internal-Sender-Identifier")
     val internalSenderDescriptionLine =
       optionalLine(internalSenderDescription, "Internal-Sender-Description")
-    s"""Source-Organization: $sourceOrganisation
-       |External-Identifier: $bagIdentifier
+
+    s"""External-Identifier: $bagIdentifier
        |Payload-Oxum: ${payloadOxum.payloadBytes}.${payloadOxum.numberOfPayloadFiles}
        |Bagging-Date: ${baggingDate.toString}
+       |$sourceOrganisationLine
        |$descriptionLine
        |$internalSenderIdentifierLine
        |$internalSenderDescriptionLine

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/RandomThings.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/RandomThings.scala
@@ -12,9 +12,9 @@ trait RandomThings {
   def randomBagInfo =
     BagInfo(
       randomExternalIdentifier,
-      randomSourceOrganisation,
       randomPayloadOxum,
       randomLocalDate,
+      Some(randomSourceOrganisation),
       Some(randomExternalDescription),
       Some(randomInternalSenderIdentifier),
       Some(randomInternalSenderDescription)

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/RandomThings.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/RandomThings.scala
@@ -11,13 +11,13 @@ import scala.util.Random
 trait RandomThings {
   def randomBagInfo =
     BagInfo(
-      randomExternalIdentifier,
-      randomPayloadOxum,
-      randomLocalDate,
-      Some(randomSourceOrganisation),
-      Some(randomExternalDescription),
-      Some(randomInternalSenderIdentifier),
-      Some(randomInternalSenderDescription)
+      externalIdentifier = randomExternalIdentifier,
+      payloadOxum = randomPayloadOxum,
+      baggingDate = randomLocalDate,
+      sourceOrganisation = Some(randomSourceOrganisation),
+      externalDescription = Some(randomExternalDescription),
+      internalSenderIdentifier = Some(randomInternalSenderIdentifier),
+      internalSenderDescription = Some(randomInternalSenderDescription)
     )
 
   def randomAlphanumeric(length: Int = 8) = {

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/BagInfoGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/BagInfoGenerators.scala
@@ -1,26 +1,33 @@
 package uk.ac.wellcome.platform.archive.common.generators
 
+import java.time.LocalDate
+
 import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
-import uk.ac.wellcome.platform.archive.common.models.bagit.{
-  BagInfo,
-  ExternalDescription,
-  ExternalIdentifier
-}
+import uk.ac.wellcome.platform.archive.common.models.bagit._
 
 trait BagInfoGenerators extends RandomThings {
+
   def createBagInfoWith(
     externalIdentifier: ExternalIdentifier = randomExternalIdentifier,
+    payloadOxum: PayloadOxum = randomPayloadOxum,
+    baggingDate: LocalDate = randomLocalDate,
+    sourceOrganisation: Option[SourceOrganisation] = Some(
+      randomSourceOrganisation),
     externalDescription: Option[ExternalDescription] = Some(
-      randomExternalDescription)
+      randomExternalDescription),
+    internalSenderIdentifier: Option[InternalSenderIdentifier] = Some(
+      randomInternalSenderIdentifier),
+    internalSenderDescription: Option[InternalSenderDescription] = Some(
+      randomInternalSenderDescription)
   ): BagInfo =
     BagInfo(
-      externalIdentifier = randomExternalIdentifier,
-      sourceOrganisation = randomSourceOrganisation,
-      payloadOxum = randomPayloadOxum,
-      baggingDate = randomLocalDate,
+      externalIdentifier = externalIdentifier,
+      payloadOxum = payloadOxum,
+      baggingDate = baggingDate,
+      sourceOrganisation = sourceOrganisation,
       externalDescription = externalDescription,
-      internalSenderIdentifier = Some(randomInternalSenderIdentifier),
-      internalSenderDescription = Some(randomInternalSenderDescription)
+      internalSenderIdentifier = internalSenderIdentifier,
+      internalSenderDescription = internalSenderDescription
     )
 
   def createBagInfo: BagInfo = createBagInfoWith()


### PR DESCRIPTION
### What is this PR trying to achieve?

Make the `SourceOrganisation` entry in bag-info.txt optional

---

Ported from https://github.com/wellcometrust/platform/pull/3427 using `git format-patch` and `git am`.