### PR TITLE
 Add a metrics namespace to the bags and ingests APIs

### DIFF
--- a/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/ArchivistFeatureTest.scala
+++ b/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/ArchivistFeatureTest.scala
@@ -6,7 +6,6 @@ import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SNS.Topic
-import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.archive.archivist.fixtures.ArchivistFixtures
 import uk.ac.wellcome.platform.archive.common.models._
 import uk.ac.wellcome.storage.ObjectLocation
@@ -23,7 +22,6 @@ class ArchivistFeatureTest
     with Matchers
     with ScalaFutures
     with RandomThings
-    with MetricsSenderFixture
     with ArchivistFixtures
     with IntegrationPatience
     with ProgressUpdateAssertions {

--- a/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/TroubleshootArchivistLocalBagFileTest.scala
+++ b/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/TroubleshootArchivistLocalBagFileTest.scala
@@ -3,15 +3,13 @@ package uk.ac.wellcome.platform.archive.archivist
 import java.io.File
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.archive.archivist.fixtures.ArchivistFixtures
 
 // Useful test to troubleshoot running the archivist using a local bagfile
 class TroubleshootArchivistLocalBagFileTest
     extends FunSpec
     with Matchers
-    with ArchivistFixtures
-    with MetricsSenderFixture {
+    with ArchivistFixtures {
 
   ignore("downloads, uploads and verifies a known BagIt bag") {
     withArchivist() {

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.archive.bagreplicator
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.archive.bagreplicator.fixtures.BagReplicatorFixtures
 import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
 import uk.ac.wellcome.platform.archive.common.models.ReplicationResult
@@ -14,7 +13,6 @@ class BagReplicatorFeatureTest
     with Matchers
     with ScalaFutures
     with RandomThings
-    with MetricsSenderFixture
     with BagReplicatorFixtures
     with ProgressUpdateAssertions {
 

--- a/bags/src/test/scala/uk/ac/wellcome/platform/archive/registrar/async/RegistrarFeatureTest.scala
+++ b/bags/src/test/scala/uk/ac/wellcome/platform/archive/registrar/async/RegistrarFeatureTest.scala
@@ -11,7 +11,6 @@ import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{FunSpec, Inside, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
-import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
 import uk.ac.wellcome.platform.archive.common.models._
 import uk.ac.wellcome.platform.archive.common.models.bagit.{BagId, BagLocation}
@@ -28,7 +27,6 @@ class RegistrarFeatureTest
     extends FunSpec
     with Matchers
     with ScalaFutures
-    with MetricsSenderFixture
     with IntegrationPatience
     with RegistrarFixtures
     with Inside

--- a/bags/universal/conf/application.conf.template
+++ b/bags/universal/conf/application.conf.template
@@ -1,6 +1,0 @@
-aws.sqs.queue.url="${queue_url}"
-aws.sns.topic.arn="${progress_topic_arn}"
-aws.vhs.dynamo.tableName="${vhs_table_name}"
-aws.vhs.s3.bucketName="${vhs_bucket_name}"
-aws.vhs.s3.globalPrefix=archive
-metrics.namespace=bags

--- a/bags_api/src/main/resources/application.conf
+++ b/bags_api/src/main/resources/application.conf
@@ -5,3 +5,4 @@ http.externalBaseURL=${?app_base_url}
 http.host="0.0.0.0"
 http.port=9001
 contextURL=${?context_url}
+metrics.namespace=bags-api

--- a/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
+++ b/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
@@ -8,7 +8,6 @@ import io.circe.optics.JsonPath._
 import io.circe.parser._
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{FunSpec, Inside, Matchers}
-import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
 import uk.ac.wellcome.platform.archive.common.generators.BagInfoGenerators
 import uk.ac.wellcome.platform.archive.common.http.HttpMetricResults
@@ -31,7 +30,6 @@ class BagsApiFeatureTest
     extends FunSpec
     with Matchers
     with ScalaFutures
-    with MetricsSenderFixture
     with BagInfoGenerators
     with BagsApiFixture
     with RandomThings

--- a/ingests/src/test/scala/uk/ac/wellcome/platform/archive/progress_async/ProgressAsyncFeatureTest.scala
+++ b/ingests/src/test/scala/uk/ac/wellcome/platform/archive/progress_async/ProgressAsyncFeatureTest.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.archive.progress_async
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.archive.common.models.CallbackNotification
 import uk.ac.wellcome.platform.archive.common.progress.fixtures.ProgressTrackerFixture
 import uk.ac.wellcome.platform.archive.common.progress.models.Progress.Completed
@@ -15,7 +14,6 @@ class ProgressAsyncFeatureTest
     extends FunSpec
     with Matchers
     with ScalaFutures
-    with MetricsSenderFixture
     with ProgressTrackerFixture
     with ProgressFixture
     with IntegrationPatience {

--- a/ingests_api/src/main/resources/application.conf
+++ b/ingests_api/src/main/resources/application.conf
@@ -6,3 +6,4 @@ http.host="0.0.0.0"
 http.port=9001
 contextURL=${?context_url}
 aws.sns.topic.arn=${?topic_arn}
+metrics.namespace=ingests-api

--- a/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
+++ b/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
@@ -12,7 +12,6 @@ import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{FunSpec, Inside, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.json.utils.JsonAssertions
-import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
 import uk.ac.wellcome.platform.archive.common.http.HttpMetricResults
 import uk.ac.wellcome.platform.archive.common.models._
@@ -27,7 +26,6 @@ class IngestsApiFeatureTest
     extends FunSpec
     with Matchers
     with ScalaFutures
-    with MetricsSenderFixture
     with ProgressTrackerFixture
     with IngestsApiFixture
     with RandomThings

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
@@ -14,7 +14,6 @@ import org.apache.http.HttpStatus
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{FunSpec, Inside, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
 import uk.ac.wellcome.platform.archive.common.models._
 import uk.ac.wellcome.platform.archive.common.progress.fixtures.{
@@ -36,7 +35,6 @@ class NotifierFeatureTest
     extends FunSpec
     with Matchers
     with ScalaFutures
-    with MetricsSenderFixture
     with IntegrationPatience
     with LocalWireMockFixture
     with NotifierFixture


### PR DESCRIPTION
I suspect this is required for https://github.com/wellcometrust/platform/issues/3423.