### PR TITLE
Split an S3PrefixCopier out of BagStorage; improve the testing of this code

### DIFF
--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/BagStorage.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/BagStorage.scala
@@ -1,22 +1,16 @@
 package uk.ac.wellcome.platform.archive.bagreplicator.storage
 
 import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.model.{ObjectListing, S3ObjectSummary}
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.bagreplicator.config.ReplicatorDestinationConfig
-import uk.ac.wellcome.platform.archive.common.models.bagit.{
-  BagItemLocation,
-  BagItemPath,
-  BagLocation
-}
+import uk.ac.wellcome.platform.archive.common.models.bagit.BagLocation
 
-import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 
 class BagStorage(s3Client: AmazonS3)(implicit ec: ExecutionContext)
     extends Logging {
 
-  val s3Copier = new S3Copier(s3Client)
+  val s3PrefixCopier = new S3PrefixCopier(s3Client)
 
   def duplicateBag(
     sourceBagLocation: BagLocation,
@@ -24,90 +18,18 @@ class BagStorage(s3Client: AmazonS3)(implicit ec: ExecutionContext)
   ): Future[BagLocation] = {
     debug(s"duplicating bag from $sourceBagLocation to $storageDestination")
 
+    println(s"duplicating bag from $sourceBagLocation to $storageDestination")
+
     val dstBagLocation = sourceBagLocation.copy(
       storageNamespace = storageDestination.namespace,
       storagePrefix = storageDestination.rootPath
     )
 
-    for {
-      sourceBagItems <- listBagItems(sourceBagLocation)
-      _ <- duplicateBagItems(
-        sourceBagItems = sourceBagItems,
-        dstBagLocation = dstBagLocation
-      )
-    } yield dstBagLocation
-  }
-
-  private def listObjects(bagLocation: BagLocation): Future[ObjectListing] =
-    Future {
-      val absolutePathInStorage = bagLocation.completePath
-        .replaceAll("(.*[^/]+)/*", "$1/")
-
-      s3Client.listObjects(
-        bagLocation.storageNamespace,
-        absolutePathInStorage
-      )
-    }
-
-  private def getItemInPath(
-    summary: S3ObjectSummary,
-    prefix: String
-  ): String =
-    summary.getKey
-      .stripPrefix(prefix)
-
-  private def getObjectSummaries(
-    listing: ObjectListing,
-    bagLocation: BagLocation
-  ): Future[List[BagItemLocation]] = Future {
-    val prefix = s"${bagLocation.completePath}/"
-
-    listing.getObjectSummaries.asScala
-      .map(getItemInPath(_, prefix))
-      .map { path: String =>
-        BagItemLocation(
-          bagLocation = bagLocation,
-          bagItemPath = BagItemPath(path)
-        )
-      }
-      .toList
-  }
-
-  private def listBagItems(
-    location: BagLocation
-  ): Future[List[BagItemLocation]] = {
-    // TODO: limit size of the returned List
-    // use Marker to paginate(?)
-    // needs care if bag contents can change during copy.
-    debug(s"listing items in $location")
-
-    for {
-      listing <- listObjects(location)
-      summaries <- getObjectSummaries(listing, location)
-    } yield summaries
-  }
-
-  private def duplicateBagItems(
-    sourceBagItems: List[BagItemLocation],
-    dstBagLocation: BagLocation
-  ): Future[List[BagItemLocation]] = {
-    debug(s"duplicating bag items: $sourceBagItems")
-
-    Future.sequence(
-      sourceBagItems.map { srcBagItemLocation =>
-        val dstBagItemLocation = srcBagItemLocation.copy(
-          bagLocation = dstBagLocation
-        )
-
-        val future = s3Copier.copy(
-          src = srcBagItemLocation.objectLocation,
-          dst = dstBagItemLocation.objectLocation
-        )
-
-        future.map { _ =>
-          dstBagItemLocation
-        }
-      }
+    val future = s3PrefixCopier.copyObjects(
+      srcLocationPrefix = sourceBagLocation.objectLocation,
+      dstLocationPrefix = dstBagLocation.objectLocation
     )
+
+    future.map { _ => dstBagLocation }
   }
 }

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/BagStorage.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/BagStorage.scala
@@ -28,6 +28,8 @@ class BagStorage(s3Client: AmazonS3)(implicit ec: ExecutionContext)
       dstLocationPrefix = dstBagLocation.objectLocation
     )
 
-    future.map { _ => dstBagLocation }
+    future.map { _ =>
+      dstBagLocation
+    }
   }
 }

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/BagStorage.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/BagStorage.scala
@@ -18,8 +18,6 @@ class BagStorage(s3Client: AmazonS3)(implicit ec: ExecutionContext)
   ): Future[BagLocation] = {
     debug(s"duplicating bag from $sourceBagLocation to $storageDestination")
 
-    println(s"duplicating bag from $sourceBagLocation to $storageDestination")
-
     val dstBagLocation = sourceBagLocation.copy(
       storageNamespace = storageDestination.namespace,
       storagePrefix = storageDestination.rootPath

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3PrefixCopier.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3PrefixCopier.scala
@@ -9,7 +9,8 @@ import uk.ac.wellcome.storage.ObjectLocation
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 
-class S3PrefixCopier(s3Client: AmazonS3)(implicit ec: ExecutionContext) extends Logging {
+class S3PrefixCopier(s3Client: AmazonS3)(implicit ec: ExecutionContext)
+    extends Logging {
   val s3Copier = new S3Copier(s3Client)
 
   /** Copy all the objects from under ObjectLocation into another ObjectLocation,
@@ -38,11 +39,13 @@ class S3PrefixCopier(s3Client: AmazonS3)(implicit ec: ExecutionContext) extends 
       _ <- duplicateObjects(copyObjectPairs)
     } yield ()
 
-  private def listObjects(objectLocation: ObjectLocation): Future[ObjectListing] = {
-    val prefix = if (objectLocation.key.endsWith("/"))
-      objectLocation.key
-    else
-      objectLocation.key + "/"
+  private def listObjects(
+    objectLocation: ObjectLocation): Future[ObjectListing] = {
+    val prefix =
+      if (objectLocation.key.endsWith("/"))
+        objectLocation.key
+      else
+        objectLocation.key + "/"
 
     Future {
       s3Client.listObjects(objectLocation.namespace, prefix)
@@ -54,7 +57,9 @@ class S3PrefixCopier(s3Client: AmazonS3)(implicit ec: ExecutionContext) extends 
     objectLocation: ObjectLocation
   ): List[ObjectLocation] =
     listing.getObjectSummaries.asScala
-      .map { summary: S3ObjectSummary => summary.getKey }
+      .map { summary: S3ObjectSummary =>
+        summary.getKey
+      }
       .map { key: String =>
         ObjectLocation(
           namespace = objectLocation.namespace,
@@ -98,8 +103,9 @@ class S3PrefixCopier(s3Client: AmazonS3)(implicit ec: ExecutionContext) extends 
     copyObjectPairs: List[(ObjectLocation, ObjectLocation)]
   ): Future[List[CopyResult]] =
     Future.sequence(
-      copyObjectPairs.map { case (src: ObjectLocation, dst: ObjectLocation) =>
-        s3Copier.copy(src = src, dst = dst)
+      copyObjectPairs.map {
+        case (src: ObjectLocation, dst: ObjectLocation) =>
+          s3Copier.copy(src = src, dst = dst)
       }
     )
 }

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3PrefixCopier.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3PrefixCopier.scala
@@ -52,7 +52,7 @@ class S3PrefixCopier(s3Client: AmazonS3)(implicit ec: ExecutionContext) extends 
   private def getObjectLocations(
     listing: ObjectListing,
     objectLocation: ObjectLocation
-  ): Future[List[ObjectLocation]] = Future {
+  ): List[ObjectLocation] =
     listing.getObjectSummaries.asScala
       .map { summary: S3ObjectSummary => summary.getKey }
       .map { key: String =>
@@ -62,7 +62,6 @@ class S3PrefixCopier(s3Client: AmazonS3)(implicit ec: ExecutionContext) extends 
         )
       }
       .toList
-  }
 
   private def listObjectsUnderPrefix(
     locationPrefix: ObjectLocation
@@ -74,7 +73,7 @@ class S3PrefixCopier(s3Client: AmazonS3)(implicit ec: ExecutionContext) extends 
 
     for {
       listing <- listObjects(locationPrefix)
-      summaries <- getObjectLocations(listing, locationPrefix)
+      summaries = getObjectLocations(listing, locationPrefix)
     } yield summaries
   }
 

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3PrefixCopier.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3PrefixCopier.scala
@@ -1,0 +1,112 @@
+package uk.ac.wellcome.platform.archive.bagreplicator.storage
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.{ObjectListing, S3ObjectSummary}
+import grizzled.slf4j.Logging
+import uk.ac.wellcome.storage.ObjectLocation
+
+import scala.collection.JavaConverters._
+import scala.concurrent.{ExecutionContext, Future}
+
+class S3PrefixCopier(s3Client: AmazonS3)(implicit ec: ExecutionContext) extends Logging {
+  val s3Copier = new S3Copier(s3Client)
+
+  /** Copy all the objects from under ObjectLocation into another ObjectLocation,
+    * preserving the relative path from the source in the destination.
+    *
+    * e.g. if you copy s3://bucket/foo to s3://other_bucket/bar, this
+    * function would copy
+    *
+    *     s3://bucket/foo/0.txt       ~> s3://other_bucket/bar/0.txt
+    *     s3://bucket/foo/1.txt       ~> s3://other_bucket/bar/1.txt
+    *     s3://bucket/foo/2/20.txt    ~> s3://other_bucket/bar/2/20.txt
+    *     s3://bucket/foo/2/21.txt    ~> s3://other_bucket/bar/2/21.txt
+    *
+    */
+  def copyObjects(
+    srcLocationPrefix: ObjectLocation,
+    dstLocationPrefix: ObjectLocation
+  ): Future[Unit] =
+    for {
+      sourceObjects <- listObjectsUnderPrefix(srcLocationPrefix)
+      _ <- duplicateObjects(
+        sourceObjects = sourceObjects,
+        srcLocationPrefix = srcLocationPrefix,
+        dstLocationPrefix = dstLocationPrefix
+      )
+    } yield ()
+
+  private def listObjects(objectLocation: ObjectLocation): Future[ObjectListing] =
+    Future {
+      val prefix = objectLocation.key
+        .replaceAll("(.*[^/]+)/*", "$1/")
+
+      s3Client.listObjects(
+        objectLocation.namespace,
+        prefix
+      )
+    }
+
+  private def getItemInPath(
+    summary: S3ObjectSummary,
+    prefix: String
+  ): String =
+    summary.getKey
+      .stripPrefix(prefix)
+
+  private def getObjectLocations(
+    listing: ObjectListing,
+    objectLocation: ObjectLocation
+  ): Future[List[ObjectLocation]] = Future {
+    val prefix = s"${objectLocation.key}/"
+
+    listing.getObjectSummaries.asScala
+      .map { getItemInPath(_, prefix) }
+      .map { key: String =>
+        ObjectLocation(
+          namespace = objectLocation.namespace,
+          key = key
+        )
+      }
+      .toList
+  }
+
+  private def listObjectsUnderPrefix(
+    locationPrefix: ObjectLocation
+  ): Future[List[ObjectLocation]] = {
+    // TODO: limit size of the returned List
+    // use Marker to paginate(?)
+    // needs care if bag contents can change during copy.
+    debug(s"listing items in $locationPrefix")
+
+    for {
+      listing <- listObjects(locationPrefix)
+      summaries <- getObjectLocations(listing, locationPrefix)
+    } yield summaries
+  }
+
+  private def duplicateObjects(
+    sourceObjects: List[ObjectLocation],
+    srcLocationPrefix: ObjectLocation,
+    dstLocationPrefix: ObjectLocation
+  ): Future[List[ObjectLocation]] = {
+    debug(s"duplicating S3 objects: $sourceObjects")
+
+    Future.sequence(
+      sourceObjects.map { srcLocation =>
+        val relativeKey = srcLocation.key.replaceFirst(srcLocationPrefix.key, "")
+
+        val dstLocation = ObjectLocation(
+          namespace = dstLocationPrefix.namespace,
+          key = dstLocationPrefix.key + relativeKey
+        )
+
+        val future = s3Copier.copy(
+          src = srcLocation,
+          dst = dstLocation
+        )
+
+        future.map { _ => dstLocation }
+      }
+    )
+  }
+}

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/S3CopierFixtures.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/S3CopierFixtures.scala
@@ -1,0 +1,32 @@
+package uk.ac.wellcome.platform.archive.bagreplicator.fixtures
+
+import com.amazonaws.services.s3.model.PutObjectResult
+import org.scalatest.Assertion
+import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
+import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.fixtures.S3
+import uk.ac.wellcome.storage.fixtures.S3.Bucket
+
+trait S3CopierFixtures extends S3 with RandomThings {
+  def createObjectLocationWith(
+    bucket: Bucket = Bucket(randomAlphanumeric()),
+    key: String = randomAlphanumeric()
+  ): ObjectLocation =
+    ObjectLocation(
+      namespace = bucket.name,
+      key = key
+    )
+
+  def createObjectLocation: ObjectLocation = createObjectLocationWith()
+
+  def createObject(location: ObjectLocation): PutObjectResult =
+    s3Client.putObject(
+      location.namespace,
+      location.key,
+      randomAlphanumeric()
+    )
+
+  def assertEqualObjects(x: ObjectLocation,
+                                 y: ObjectLocation): Assertion =
+    getContentFromS3(x) shouldBe getContentFromS3(y)
+}

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/S3CopierFixtures.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/S3CopierFixtures.scala
@@ -26,7 +26,6 @@ trait S3CopierFixtures extends S3 with RandomThings {
       randomAlphanumeric()
     )
 
-  def assertEqualObjects(x: ObjectLocation,
-                                 y: ObjectLocation): Assertion =
+  def assertEqualObjects(x: ObjectLocation, y: ObjectLocation): Assertion =
     getContentFromS3(x) shouldBe getContentFromS3(y)
 }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/BagStorageTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/BagStorageTest.scala
@@ -1,10 +1,9 @@
-package uk.ac.wellcome.platform.archive.bagreplicator
+package uk.ac.wellcome.platform.archive.bagreplicator.storage
 
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.bagreplicator.config.ReplicatorDestinationConfig
 import uk.ac.wellcome.platform.archive.bagreplicator.fixtures.BagReplicatorFixtures
-import uk.ac.wellcome.platform.archive.bagreplicator.storage.BagStorage
 import uk.ac.wellcome.platform.archive.common.generators.BagInfoGenerators
 import uk.ac.wellcome.platform.archive.common.models.bagit.{
   BagLocation,

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3CopierTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3CopierTest.scala
@@ -1,11 +1,9 @@
 package uk.ac.wellcome.platform.archive.bagreplicator.storage
 
-import com.amazonaws.services.s3.model.{AmazonS3Exception, PutObjectResult}
+import com.amazonaws.services.s3.model.AmazonS3Exception
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{Assertion, FunSpec, Matchers}
-import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
-import uk.ac.wellcome.storage.ObjectLocation
-import uk.ac.wellcome.storage.fixtures.S3
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.platform.archive.bagreplicator.fixtures.S3CopierFixtures
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -14,8 +12,7 @@ class S3CopierTest
     extends FunSpec
     with Matchers
     with ScalaFutures
-    with RandomThings
-    with S3 {
+    with S3CopierFixtures {
 
   val s3Copier = new S3Copier(s3Client)
 
@@ -81,26 +78,4 @@ class S3CopierTest
       }
     }
   }
-
-  private def createObjectLocationWith(
-    bucket: Bucket = Bucket(randomAlphanumeric()),
-    key: String = randomAlphanumeric()
-  ): ObjectLocation =
-    ObjectLocation(
-      namespace = bucket.name,
-      key = key
-    )
-
-  private def createObjectLocation: ObjectLocation = createObjectLocationWith()
-
-  private def createObject(location: ObjectLocation): PutObjectResult =
-    s3Client.putObject(
-      location.namespace,
-      location.key,
-      randomAlphanumeric()
-    )
-
-  private def assertEqualObjects(x: ObjectLocation,
-                                 y: ObjectLocation): Assertion =
-    getContentFromS3(x) shouldBe getContentFromS3(y)
 }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3CopierTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3CopierTest.scala
@@ -27,7 +27,9 @@ class S3CopierTest
       val future = s3Copier.copy(src = src, dst = dst)
 
       whenReady(future) { _ =>
-        listKeysInBucket(bucket) should contain theSameElementsAs List(src.key, dst.key)
+        listKeysInBucket(bucket) should contain theSameElementsAs List(
+          src.key,
+          dst.key)
         assertEqualObjects(src, dst)
       }
     }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3PrefixCopierTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3PrefixCopierTest.scala
@@ -107,7 +107,7 @@ class S3PrefixCopierTest extends FunSpec with Matchers with ScalaFutures with S3
     }
   }
 
-  it("copies more objects than are returned in a single ListObject call") {
+  ignore("copies more objects than are returned in a single ListObject call") {
     withLocalS3Bucket { srcBucket =>
       withLocalS3Bucket { dstBucket =>
         val srcPrefix = createObjectLocationWith(srcBucket, key = "src/")

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3PrefixCopierTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3PrefixCopierTest.scala
@@ -9,7 +9,11 @@ import uk.ac.wellcome.storage.fixtures.S3.Bucket
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class S3PrefixCopierTest extends FunSpec with Matchers with ScalaFutures with S3CopierFixtures {
+class S3PrefixCopierTest
+    extends FunSpec
+    with Matchers
+    with ScalaFutures
+    with S3CopierFixtures {
   val s3PrefixCopier = new S3PrefixCopier(s3Client)
 
   it("returns a successful Future if there are no files in the prefix") {
@@ -69,10 +73,11 @@ class S3PrefixCopierTest extends FunSpec with Matchers with ScalaFutures with S3
         val future = s3PrefixCopier.copyObjects(srcPrefix, dstPrefix)
 
         whenReady(future) { _ =>
-            listKeysInBucket(dstBucket) shouldBe dstLocations.map { _.key }
+          listKeysInBucket(dstBucket) shouldBe dstLocations.map { _.key }
 
-          srcLocations.zip(dstLocations).map { case (src, dst) =>
-            assertEqualObjects(src, dst)
+          srcLocations.zip(dstLocations).map {
+            case (src, dst) =>
+              assertEqualObjects(src, dst)
           }
         }
       }
@@ -136,8 +141,9 @@ class S3PrefixCopierTest extends FunSpec with Matchers with ScalaFutures with S3
           actualKeys.size shouldBe expectedKeys.size
           actualKeys should contain theSameElementsAs expectedKeys
 
-          srcLocations.zip(dstLocations).map { case (src, dst) =>
-            assertEqualObjects(src, dst)
+          srcLocations.zip(dstLocations).map {
+            case (src, dst) =>
+              assertEqualObjects(src, dst)
           }
         }
       }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3PrefixCopierTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3PrefixCopierTest.scala
@@ -1,0 +1,109 @@
+package uk.ac.wellcome.platform.archive.bagreplicator.storage
+
+import com.amazonaws.services.s3.model.AmazonS3Exception
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.platform.archive.bagreplicator.fixtures.S3CopierFixtures
+import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.fixtures.S3.Bucket
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class S3PrefixCopierTest extends FunSpec with Matchers with ScalaFutures with S3CopierFixtures {
+  val s3PrefixCopier = new S3PrefixCopier(s3Client)
+
+  it("returns a successful Future if there are no files in the prefix") {
+    withLocalS3Bucket { bucket =>
+      val src = createObjectLocationWith(bucket, key = "src/")
+      val dst = createObjectLocationWith(bucket, key = "dst/")
+
+      val future = s3PrefixCopier.copyObjects(src, dst)
+
+      whenReady(future) { _ =>
+        listKeysInBucket(bucket) shouldBe empty
+      }
+    }
+  }
+
+  it("copies a single file under a prefix") {
+    withLocalS3Bucket { srcBucket =>
+      withLocalS3Bucket { dstBucket =>
+        val srcPrefix = createObjectLocationWith(srcBucket, key = "src/")
+
+        val src = srcPrefix.copy(key = srcPrefix.key + "foo.txt")
+        createObject(src)
+
+        val dstPrefix = createObjectLocationWith(dstBucket, key = "dst/")
+        val dst = dstPrefix.copy(key = dstPrefix.key + "foo.txt")
+
+        val future = s3PrefixCopier.copyObjects(srcPrefix, dstPrefix)
+
+        whenReady(future) { _ =>
+          listKeysInBucket(dstBucket) shouldBe List("dst/foo.txt")
+          assertEqualObjects(src, dst)
+        }
+      }
+    }
+  }
+
+  it("copies multiple files under a prefix") {
+    withLocalS3Bucket { srcBucket =>
+      withLocalS3Bucket { dstBucket =>
+        val srcPrefix = createObjectLocationWith(srcBucket, key = "src/")
+
+        val srcLocations = (1 to 5).map { i =>
+          val src = srcPrefix.copy(key = srcPrefix.key + s"$i.txt")
+          createObject(src)
+          src
+        }
+
+        val dstPrefix = createObjectLocationWith(dstBucket, key = "dst/")
+
+        val dstLocations = srcLocations.map { loc: ObjectLocation =>
+          loc.copy(
+            namespace = dstPrefix.namespace,
+            key = loc.key.replace("src/", "dst/")
+          )
+        }
+
+        val future = s3PrefixCopier.copyObjects(srcPrefix, dstPrefix)
+
+        whenReady(future) { _ =>
+            listKeysInBucket(dstBucket) shouldBe dstLocations.map { _.key }
+
+          srcLocations.zip(dstLocations).map { case (src, dst) =>
+            assertEqualObjects(src, dst)
+          }
+        }
+      }
+    }
+  }
+
+  it("returns a failed Future if the source bucket does not exist") {
+    val srcPrefix = createObjectLocation
+    val dstPrefix = createObjectLocation
+
+    val future = s3PrefixCopier.copyObjects(srcPrefix, dstPrefix)
+
+    whenReady(future.failed) { err =>
+      err shouldBe a[AmazonS3Exception]
+    }
+  }
+
+  it("returns a failed Future if the destination bucket does not exist") {
+    withLocalS3Bucket { bucket =>
+      val srcPrefix = createObjectLocationWith(bucket)
+
+      val src = srcPrefix.copy(key = srcPrefix.key + "/foo.txt")
+      createObject(src)
+
+      val dstPrefix = createObjectLocationWith(Bucket("no_such_bucket"))
+
+      val future = s3PrefixCopier.copyObjects(srcPrefix, dstPrefix)
+
+      whenReady(future.failed) { err =>
+        err shouldBe a[AmazonS3Exception]
+      }
+    }
+  }
+}


### PR DESCRIPTION
The BagStorage class in the replicator contained a lot of logic for copying objects around in S3, but most of it wasn’t BagLocation-specific.

This patch adds an intermediate class “S3PrefixCopier”, which does the actual work of copying around S3 directories, and BagStorage becomes a thin wrapper that calls that class.

There are new tests for the S3Copier code, which we can now access directly rather than through an intermediary.

Notably, this includes a test for the case where the bag contains more than 1000 objects – which currently fails, because you can’t get more than 1000 objects from a single ListObject call. I considered fixing that in this patch, but that will need more thought. Simply loading all the objects into memory will crash on a big bag; the alternative is something with Alpakka S3, but it's sufficiently fiddly that we should do that separately.