### PR TITLE
If there are too many objects for the bag replicator, explode

### DIFF
--- a/bag_replicator/docker-compose.yml
+++ b/bag_replicator/docker-compose.yml
@@ -8,6 +8,8 @@ sns:
   ports:
     - "9292:9292"
 s3:
-  image: scality/s3server:mem-latest
+  image: zenko/cloudserver
+  environment:
+    - "S3BACKEND=mem"
   ports:
     - "33333:8000"

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3PrefixCopier.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3PrefixCopier.scala
@@ -48,7 +48,8 @@ class S3PrefixCopier(s3Client: AmazonS3)(implicit ec: ExecutionContext)
         objectLocation.key + "/"
 
     Future {
-      val listObjectsResult = s3Client.listObjectsV2(objectLocation.namespace, prefix)
+      val listObjectsResult =
+        s3Client.listObjectsV2(objectLocation.namespace, prefix)
 
       // @@AWLC We should remove this when we have a fix in place for
       // https://github.com/wellcometrust/platform/issues/3450, but for now it's
@@ -57,7 +58,7 @@ class S3PrefixCopier(s3Client: AmazonS3)(implicit ec: ExecutionContext)
       if (listObjectsResult.isTruncated)
         throw new RuntimeException(
           "ListObjectsV2 result truncated! The replicator couldn't copy everything. " +
-          "See https://github.com/wellcometrust/platform/issues/3450"
+            "See https://github.com/wellcometrust/platform/issues/3450"
         )
 
       listObjectsResult

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/S3CopierFixtures.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/S3CopierFixtures.scala
@@ -19,11 +19,11 @@ trait S3CopierFixtures extends S3 with RandomThings {
 
   def createObjectLocation: ObjectLocation = createObjectLocationWith()
 
-  def createObject(location: ObjectLocation): PutObjectResult =
+  def createObject(location: ObjectLocation, content: String = randomAlphanumeric()): PutObjectResult =
     s3Client.putObject(
       location.namespace,
       location.key,
-      randomAlphanumeric()
+      content
     )
 
   def assertEqualObjects(x: ObjectLocation, y: ObjectLocation): Assertion =

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/S3CopierFixtures.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/S3CopierFixtures.scala
@@ -19,7 +19,8 @@ trait S3CopierFixtures extends S3 with RandomThings {
 
   def createObjectLocation: ObjectLocation = createObjectLocationWith()
 
-  def createObject(location: ObjectLocation, content: String = randomAlphanumeric()): PutObjectResult =
+  def createObject(location: ObjectLocation,
+                   content: String = randomAlphanumeric()): PutObjectResult =
     s3Client.putObject(
       location.namespace,
       location.key,

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3PrefixCopierTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3PrefixCopierTest.scala
@@ -113,7 +113,8 @@ class S3PrefixCopierTest
     }
   }
 
-  it("explodes if you try to copy more objects than are returned in a single ListObject call") {
+  it(
+    "explodes if you try to copy more objects than are returned in a single ListObject call") {
     withLocalS3Bucket { srcBucket =>
       withLocalS3Bucket { dstBucket =>
         val srcPrefix = createObjectLocationWith(srcBucket, key = "src/")
@@ -121,7 +122,7 @@ class S3PrefixCopierTest
         // You can get up to 1000 objects in a single S3 ListObject call.
         (1 to 1002).map { i =>
           val src = srcPrefix.copy(key = srcPrefix.key + s"$i.txt")
-          createObject(src, content="")
+          createObject(src, content = "")
           src
         }
 
@@ -144,7 +145,7 @@ class S3PrefixCopierTest
         // You can get up to 1000 objects in a single S3 ListObject call.
         val srcLocations = (1 to 1002).map { i =>
           val src = srcPrefix.copy(key = srcPrefix.key + s"$i.txt")
-          createObject(src, content="")
+          createObject(src, content = "")
           src
         }
 


### PR DESCRIPTION
For https://github.com/wellcometrust/platform/issues/3450

We don’t have an immediate fix, and we don’t want to rush into it (because Akka!).

This patch will just cause the bag replicator to fail the replication if it finds there are >1000 objects in the bucket, so it will be very visible to us and we can't forget it. We'll also get a better idea of the scale of the problem (does this affect 1 bag? 10? 1000?).

Note: I've switched us to using ListObjectsV2, because I couldn't get `isTruncated` working with the legacy API. The old S3 Docker image we were using didn't support that, so I bumped us to a new version.