### PR TITLE
Copy the entire contents of a bag in the replicator, not just the first 1000 objects

### DIFF
--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/BagStorage.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/BagStorage.scala
@@ -10,7 +10,8 @@ import scala.concurrent.{ExecutionContext, Future}
 class BagStorage(s3Client: AmazonS3)(implicit ec: ExecutionContext)
     extends Logging {
 
-  val s3PrefixCopier = new S3PrefixCopier(s3Client)
+  val copier = new S3Copier(s3Client)
+  val s3PrefixCopier = new S3PrefixCopier(s3Client, copier = copier)
 
   def duplicateBag(
     sourceBagLocation: BagLocation,

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/ObjectCopier.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/ObjectCopier.scala
@@ -1,0 +1,7 @@
+package uk.ac.wellcome.platform.archive.bagreplicator.storage
+
+import uk.ac.wellcome.storage.ObjectLocation
+
+trait ObjectCopier {
+  def copy(src: ObjectLocation, dst: ObjectLocation): Unit
+}

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3Copier.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3Copier.scala
@@ -1,22 +1,18 @@
 package uk.ac.wellcome.platform.archive.bagreplicator.storage
 
 import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.transfer.model.CopyResult
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.storage.ObjectLocation
 
-class S3Copier(s3Client: AmazonS3) extends Logging {
+class S3Copier(s3Client: AmazonS3) extends Logging with ObjectCopier {
 
   import com.amazonaws.services.s3.transfer.TransferManagerBuilder
 
   private val transferManager = TransferManagerBuilder.standard
     .withS3Client(s3Client)
-    .build // Fixed thread pool
+    .build
 
-  def copy(
-    src: ObjectLocation,
-    dst: ObjectLocation
-  ): CopyResult = {
+  def copy(src: ObjectLocation, dst: ObjectLocation): Unit = {
     debug(s"Copying ${s3Uri(src)} -> ${s3Uri(dst)}")
 
     val copyTransfer = transferManager.copy(
@@ -27,6 +23,8 @@ class S3Copier(s3Client: AmazonS3) extends Logging {
     )
 
     copyTransfer.waitForCopyResult()
+
+    ()
   }
 
   private def s3Uri(objectLocation: ObjectLocation): String =

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3Copier.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3Copier.scala
@@ -5,8 +5,6 @@ import com.amazonaws.services.s3.transfer.model.CopyResult
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.storage.ObjectLocation
 
-import scala.concurrent.{ExecutionContext, Future}
-
 class S3Copier(s3Client: AmazonS3) extends Logging {
 
   import com.amazonaws.services.s3.transfer.TransferManagerBuilder
@@ -18,8 +16,7 @@ class S3Copier(s3Client: AmazonS3) extends Logging {
   def copy(
     src: ObjectLocation,
     dst: ObjectLocation
-  )(implicit
-    ec: ExecutionContext): Future[CopyResult] = Future {
+  ): CopyResult = {
     debug(s"Copying ${s3Uri(src)} -> ${s3Uri(dst)}")
 
     val copyTransfer = transferManager.copy(

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3PrefixCopier.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3PrefixCopier.scala
@@ -3,21 +3,14 @@ package uk.ac.wellcome.platform.archive.bagreplicator.storage
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.iterable.S3Objects
 import com.amazonaws.services.s3.model.S3ObjectSummary
-import com.amazonaws.services.s3.transfer.{TransferManager, TransferManagerBuilder}
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.storage.ObjectLocation
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 
-class S3PrefixCopier(s3Client: AmazonS3)(implicit ec: ExecutionContext)
+class S3PrefixCopier(s3Client: AmazonS3, copier: ObjectCopier)(implicit ec: ExecutionContext)
     extends Logging {
-
-  val transferManager: TransferManager = TransferManagerBuilder.standard
-    .withS3Client(s3Client)
-    .build
-
-  val s3Copier = new S3Copier(s3Client)
 
   /** Copy all the objects from under ObjectLocation into another ObjectLocation,
     * preserving the relative path from the source in the destination.
@@ -64,7 +57,7 @@ class S3PrefixCopier(s3Client: AmazonS3)(implicit ec: ExecutionContext)
         key = dstLocationPrefix.key + relativeKey
       )
 
-      s3Copier.copy(srcLocation, dstLocation)
+      copier.copy(srcLocation, dstLocation)
     }
   }
 }

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3PrefixCopier.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3PrefixCopier.scala
@@ -42,9 +42,7 @@ class S3PrefixCopier(s3Client: AmazonS3, copier: ObjectCopier)(
     // just use this simple version, and we can revisit it if it's not fast
     // enough in practice.
 
-    while (objects.hasNext) {
-      val summary = objects.next()
-
+    objects.foreach { summary: S3ObjectSummary =>
       val srcLocation = ObjectLocation(
         namespace = srcLocationPrefix.namespace,
         key = summary.getKey

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3PrefixCopier.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3PrefixCopier.scala
@@ -9,7 +9,8 @@ import uk.ac.wellcome.storage.ObjectLocation
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
 
-class S3PrefixCopier(s3Client: AmazonS3, copier: ObjectCopier)(implicit ec: ExecutionContext)
+class S3PrefixCopier(s3Client: AmazonS3, copier: ObjectCopier)(
+  implicit ec: ExecutionContext)
     extends Logging {
 
   /** Copy all the objects from under ObjectLocation into another ObjectLocation,

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3PrefixCopier.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3PrefixCopier.scala
@@ -1,8 +1,9 @@
 package uk.ac.wellcome.platform.archive.bagreplicator.storage
 
 import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.model.{ObjectListing, S3ObjectSummary}
-import com.amazonaws.services.s3.transfer.model.CopyResult
+import com.amazonaws.services.s3.iterable.S3Objects
+import com.amazonaws.services.s3.model.S3ObjectSummary
+import com.amazonaws.services.s3.transfer.{TransferManager, TransferManagerBuilder}
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.storage.ObjectLocation
 
@@ -11,6 +12,11 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class S3PrefixCopier(s3Client: AmazonS3)(implicit ec: ExecutionContext)
     extends Logging {
+
+  val transferManager: TransferManager = TransferManagerBuilder.standard
+    .withS3Client(s3Client)
+    .build
+
   val s3Copier = new S3Copier(s3Client)
 
   /** Copy all the objects from under ObjectLocation into another ObjectLocation,
@@ -28,66 +34,28 @@ class S3PrefixCopier(s3Client: AmazonS3)(implicit ec: ExecutionContext)
   def copyObjects(
     srcLocationPrefix: ObjectLocation,
     dstLocationPrefix: ObjectLocation
-  ): Future[Unit] =
-    for {
-      sourceObjects <- listObjectsUnderPrefix(srcLocationPrefix)
-      copyObjectPairs = getCopyObjectPairs(
-        sourceObjects = sourceObjects,
-        srcLocationPrefix = srcLocationPrefix,
-        dstLocationPrefix = dstLocationPrefix
+  ): Future[Unit] = Future {
+    val objects: Iterator[S3ObjectSummary] = S3Objects
+      .withPrefix(s3Client, srcLocationPrefix.namespace, srcLocationPrefix.key)
+      .iterator()
+      .asScala
+
+    // Implementation note: this means we're single-threaded within a single bag.
+    // That is, we're copying objects in a bag one at a time.
+    //
+    // We could rewrite this code to process objects in parallel, but it would
+    // make it more complicated and introduces more failure modes.  For now we'll
+    // just use this simple version, and we can revisit it if it's not fast
+    // enough in practice.
+
+    while (objects.hasNext) {
+      val summary = objects.next()
+
+      val srcLocation = ObjectLocation(
+        namespace = srcLocationPrefix.namespace,
+        key = summary.getKey
       )
-      _ <- duplicateObjects(copyObjectPairs)
-    } yield ()
 
-  private def listObjects(
-    objectLocation: ObjectLocation): Future[ObjectListing] = {
-    val prefix =
-      if (objectLocation.key.endsWith("/"))
-        objectLocation.key
-      else
-        objectLocation.key + "/"
-
-    Future {
-      s3Client.listObjects(objectLocation.namespace, prefix)
-    }
-  }
-
-  private def getObjectLocations(
-    listing: ObjectListing,
-    objectLocation: ObjectLocation
-  ): List[ObjectLocation] =
-    listing.getObjectSummaries.asScala
-      .map { summary: S3ObjectSummary =>
-        summary.getKey
-      }
-      .map { key: String =>
-        ObjectLocation(
-          namespace = objectLocation.namespace,
-          key = key
-        )
-      }
-      .toList
-
-  private def listObjectsUnderPrefix(
-    locationPrefix: ObjectLocation
-  ): Future[List[ObjectLocation]] = {
-    // TODO: limit size of the returned List
-    // use Marker to paginate(?)
-    // needs care if bag contents can change during copy.
-    debug(s"listing items in $locationPrefix")
-
-    for {
-      listing <- listObjects(locationPrefix)
-      summaries = getObjectLocations(listing, locationPrefix)
-    } yield summaries
-  }
-
-  private def getCopyObjectPairs(
-    sourceObjects: List[ObjectLocation],
-    srcLocationPrefix: ObjectLocation,
-    dstLocationPrefix: ObjectLocation
-  ): List[(ObjectLocation, ObjectLocation)] =
-    sourceObjects.map { srcLocation =>
       val relativeKey = srcLocation.key
         .stripPrefix(srcLocationPrefix.key)
 
@@ -96,16 +64,7 @@ class S3PrefixCopier(s3Client: AmazonS3)(implicit ec: ExecutionContext)
         key = dstLocationPrefix.key + relativeKey
       )
 
-      (srcLocation, dstLocation)
+      s3Copier.copy(srcLocation, dstLocation)
     }
-
-  private def duplicateObjects(
-    copyObjectPairs: List[(ObjectLocation, ObjectLocation)]
-  ): Future[List[CopyResult]] =
-    Future.sequence(
-      copyObjectPairs.map {
-        case (src: ObjectLocation, dst: ObjectLocation) =>
-          s3Copier.copy(src = src, dst = dst)
-      }
-    )
+  }
 }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3CopierTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3CopierTest.scala
@@ -5,10 +5,7 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.bagreplicator.fixtures.S3CopierFixtures
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
 
-class S3CopierTest
-    extends FunSpec
-    with Matchers
-    with S3CopierFixtures {
+class S3CopierTest extends FunSpec with Matchers with S3CopierFixtures {
 
   val s3Copier = new S3Copier(s3Client)
 

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3CopierTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3CopierTest.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.platform.archive.bagreplicator.storage
 
+import com.amazonaws.services.s3.model.AmazonS3Exception
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.bagreplicator.fixtures.S3CopierFixtures
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
@@ -52,11 +53,9 @@ class S3CopierTest
     val src = createObjectLocation
     val dst = createObjectLocation
 
-    s3Copier.copy(src, dst)
-
-//    whenReady(future.failed) { err =>
-//      err shouldBe a[AmazonS3Exception]
-//    }
+    intercept[AmazonS3Exception] {
+      s3Copier.copy(src, dst)
+    }
   }
 
   it("returns a failed Future if the destination bucket does not exist") {
@@ -64,11 +63,9 @@ class S3CopierTest
       val src = createObjectLocationWith(bucket)
       val dst = createObjectLocationWith(Bucket("no_such_bucket"))
 
-      s3Copier.copy(src, dst)
-
-//      whenReady(future.failed) { err =>
-//        err shouldBe a[AmazonS3Exception]
-//      }
+      intercept[AmazonS3Exception] {
+        s3Copier.copy(src, dst)
+      }
     }
   }
 }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3CopierTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3CopierTest.scala
@@ -1,17 +1,12 @@
 package uk.ac.wellcome.platform.archive.bagreplicator.storage
 
-import com.amazonaws.services.s3.model.AmazonS3Exception
-import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.bagreplicator.fixtures.S3CopierFixtures
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
 
-import scala.concurrent.ExecutionContext.Implicits.global
-
 class S3CopierTest
     extends FunSpec
     with Matchers
-    with ScalaFutures
     with S3CopierFixtures {
 
   val s3Copier = new S3Copier(s3Client)
@@ -24,14 +19,12 @@ class S3CopierTest
       createObject(src)
       listKeysInBucket(bucket) shouldBe List(src.key)
 
-      val future = s3Copier.copy(src = src, dst = dst)
+      s3Copier.copy(src = src, dst = dst)
 
-      whenReady(future) { _ =>
-        listKeysInBucket(bucket) should contain theSameElementsAs List(
-          src.key,
-          dst.key)
-        assertEqualObjects(src, dst)
-      }
+      listKeysInBucket(bucket) should contain theSameElementsAs List(
+        src.key,
+        dst.key)
+      assertEqualObjects(src, dst)
     }
   }
 
@@ -46,13 +39,11 @@ class S3CopierTest
         listKeysInBucket(srcBucket) shouldBe List(src.key)
         listKeysInBucket(dstBucket) shouldBe List()
 
-        val future = s3Copier.copy(src = src, dst = dst)
+        s3Copier.copy(src = src, dst = dst)
 
-        whenReady(future) { _ =>
-          listKeysInBucket(srcBucket) shouldBe List(src.key)
-          listKeysInBucket(dstBucket) shouldBe List(dst.key)
-          assertEqualObjects(src, dst)
-        }
+        listKeysInBucket(srcBucket) shouldBe List(src.key)
+        listKeysInBucket(dstBucket) shouldBe List(dst.key)
+        assertEqualObjects(src, dst)
       }
     }
   }
@@ -61,11 +52,11 @@ class S3CopierTest
     val src = createObjectLocation
     val dst = createObjectLocation
 
-    val future = s3Copier.copy(src, dst)
+    s3Copier.copy(src, dst)
 
-    whenReady(future.failed) { err =>
-      err shouldBe a[AmazonS3Exception]
-    }
+//    whenReady(future.failed) { err =>
+//      err shouldBe a[AmazonS3Exception]
+//    }
   }
 
   it("returns a failed Future if the destination bucket does not exist") {
@@ -73,11 +64,11 @@ class S3CopierTest
       val src = createObjectLocationWith(bucket)
       val dst = createObjectLocationWith(Bucket("no_such_bucket"))
 
-      val future = s3Copier.copy(src, dst)
+      s3Copier.copy(src, dst)
 
-      whenReady(future.failed) { err =>
-        err shouldBe a[AmazonS3Exception]
-      }
+//      whenReady(future.failed) { err =>
+//        err shouldBe a[AmazonS3Exception]
+//      }
     }
   }
 }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3PrefixCopierTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/S3PrefixCopierTest.scala
@@ -192,10 +192,13 @@ class S3PrefixCopierTest
   // A modified version of listKeysInBucket that can retrieve everything,
   // even if it takes multiple ListObject calls.
   override def listKeysInBucket(bucket: Bucket): List[String] =
-    S3Objects.inBucket(s3Client, bucket.name)
+    S3Objects
+      .inBucket(s3Client, bucket.name)
       .withBatchSize(1000)
       .iterator()
       .asScala
       .toList
-      .map { objectSummary: S3ObjectSummary => objectSummary.getKey }
+      .map { objectSummary: S3ObjectSummary =>
+        objectSummary.getKey
+      }
 }


### PR DESCRIPTION
I found a paginator in the V1 API, and so I wrote some super-simple code that blocks when copying every single object. Includes a test that it works for lots of objects, and that if an individual object fails, we fail the entire copy.

I’ve also added a new `ObjectCopier` trait, because making this abstract opens the door to copying from S3 to elsewhere later (e.g. Azure).

Resolves https://github.com/wellcometrust/platform/issues/3450