### PR TITLE
Optional storage prefix

### DIFF
--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/bag/ArchiveJobCreator.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/bag/ArchiveJobCreator.scala
@@ -53,7 +53,7 @@ object ArchiveJobCreator extends Logging {
               maybeBagRootPathInZip = bagRootPathInZip,
               bagUploadLocation = BagLocation(
                 storageNamespace = config.uploadConfig.uploadNamespace,
-                storagePrefix = config.uploadConfig.uploadPrefix,
+                storagePrefix = Some(config.uploadConfig.uploadPrefix),
                 storageSpace = ingestBagRequest.storageSpace,
                 bagPath = BagPath(externalIdentifier.toString)
               ),

--- a/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/ArchivistFeatureTest.scala
+++ b/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/ArchivistFeatureTest.scala
@@ -48,7 +48,7 @@ class ArchivistFeatureTest
                   archiveRequestId = request.id,
                   srcBagLocation = BagLocation(
                     storageNamespace = storageBucket.name,
-                    storagePrefix = "archive",
+                    storagePrefix = Some("archive"),
                     storageSpace = request.storageSpace,
                     bagPath = BagPath(bagInfo.externalIdentifier.toString)
                   )
@@ -161,7 +161,7 @@ class ArchivistFeatureTest
                         archiveRequestId = validRequest1.id,
                         srcBagLocation = BagLocation(
                           storageNamespace = storageBucket.name,
-                          storagePrefix = "archive",
+                          storagePrefix = Some("archive"),
                           storageSpace = validRequest1.storageSpace,
                           bagPath =
                             BagPath(bagInfo1.externalIdentifier.toString)
@@ -171,7 +171,7 @@ class ArchivistFeatureTest
                         archiveRequestId = validRequest2.id,
                         srcBagLocation = BagLocation(
                           storageNamespace = storageBucket.name,
-                          storagePrefix = "archive",
+                          storagePrefix = Some("archive"),
                           storageSpace = validRequest2.storageSpace,
                           bagPath =
                             BagPath(bagInfo2.externalIdentifier.toString)
@@ -252,7 +252,7 @@ class ArchivistFeatureTest
                     archiveRequestId = validRequest1.id,
                     srcBagLocation = BagLocation(
                       storageNamespace = storageBucket.name,
-                      storagePrefix = "archive",
+                      storagePrefix = Some("archive"),
                       storageSpace = validRequest1.storageSpace,
                       bagPath = BagPath(bagInfo1.externalIdentifier.toString)
                     )
@@ -261,7 +261,7 @@ class ArchivistFeatureTest
                     archiveRequestId = validRequest2.id,
                     srcBagLocation = BagLocation(
                       storageNamespace = storageBucket.name,
-                      storagePrefix = "archive",
+                      storagePrefix = Some("archive"),
                       storageSpace = validRequest2.storageSpace,
                       bagPath = BagPath(bagInfo2.externalIdentifier.toString)
                     )
@@ -327,7 +327,7 @@ class ArchivistFeatureTest
                             archiveRequestId = validRequest1.id,
                             srcBagLocation = BagLocation(
                               storageNamespace = storageBucket.name,
-                              storagePrefix = "archive",
+                              storagePrefix = Some("archive"),
                               storageSpace = validRequest1.storageSpace,
                               bagPath =
                                 BagPath(bagInfo1.externalIdentifier.toString)
@@ -337,7 +337,7 @@ class ArchivistFeatureTest
                             archiveRequestId = validRequest2.id,
                             srcBagLocation = BagLocation(
                               storageNamespace = storageBucket.name,
-                              storagePrefix = "archive",
+                              storagePrefix = Some("archive"),
                               storageSpace = validRequest2.storageSpace,
                               bagPath =
                                 BagPath(bagInfo2.externalIdentifier.toString)
@@ -404,7 +404,7 @@ class ArchivistFeatureTest
                         archiveRequestId = validRequest1.id,
                         srcBagLocation = BagLocation(
                           storageNamespace = storageBucket.name,
-                          storagePrefix = "archive",
+                          storagePrefix = Some("archive"),
                           storageSpace = validRequest1.storageSpace,
                           bagPath =
                             BagPath(bagInfo1.externalIdentifier.toString)
@@ -414,7 +414,7 @@ class ArchivistFeatureTest
                         archiveRequestId = validRequest2.id,
                         srcBagLocation = BagLocation(
                           storageNamespace = storageBucket.name,
-                          storagePrefix = "archive",
+                          storagePrefix = Some("archive"),
                           storageSpace = validRequest2.storageSpace,
                           bagPath =
                             BagPath(bagInfo2.externalIdentifier.toString)

--- a/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/bag/ArchiveJobCreatorTest.scala
+++ b/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/bag/ArchiveJobCreatorTest.scala
@@ -47,7 +47,7 @@ class ArchiveJobCreatorTest
           actualZipFile.size() shouldBe new ZipFile(file).size()
           bagLocation shouldBe BagLocation(
             storageNamespace = bucketName,
-            storagePrefix = "archive",
+            storagePrefix = Some("archive"),
             storageSpace = ingestRequest.storageSpace,
             bagPath = BagPath(bagIdentifier.toString)
           )

--- a/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveZipFileFlowTest.scala
+++ b/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveZipFileFlowTest.scala
@@ -79,7 +79,7 @@ class ArchiveZipFileFlowTest
                   archiveRequestId = ingestContext.id,
                   srcBagLocation = BagLocation(
                     storageNamespace = storageBucket.name,
-                    storagePrefix = "archive",
+                    storagePrefix = Some("archive"),
                     storageSpace = ingestContext.storageSpace,
                     bagPath = BagPath(bagInfo.externalIdentifier.toString)
                   )
@@ -215,7 +215,7 @@ class ArchiveZipFileFlowTest
                           .asInstanceOf[ArchiveJob]
                           .bagUploadLocation shouldBe BagLocation(
                           storageNamespace = storageBucket.name,
-                          storagePrefix = "archive",
+                          storagePrefix = Some("archive"),
                           storageSpace = ingestContext.storageSpace,
                           bagPath = BagPath(bagInfo.externalIdentifier.toString)
                         )

--- a/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/generators/ArchiveJobGenerators.scala
+++ b/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/generators/ArchiveJobGenerators.scala
@@ -69,7 +69,7 @@ trait ArchiveJobGenerators
   ): ArchiveJob = {
     val bagLocation = BagLocation(
       storageNamespace = bucket.name,
-      storagePrefix = "archive",
+      storagePrefix = Some("archive"),
       storageSpace = createStorageSpace,
       bagPath = BagPath(bagIdentifier.toString)
     )

--- a/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/models/UploadLocationBuilderTest.scala
+++ b/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/models/UploadLocationBuilderTest.scala
@@ -25,7 +25,7 @@ class UploadLocationBuilderTest
 
   val bagUploadLocation = BagLocation(
     uploadNamespace,
-    uploadStoragePrefix,
+    Some(uploadStoragePrefix),
     StorageSpace(uploadSpace),
     BagPath(bagIdentifier))
 

--- a/bag_replicator/src/main/resources/application.conf
+++ b/bag_replicator/src/main/resources/application.conf
@@ -2,5 +2,4 @@ aws.sqs.queue.url=${?queue_url}
 aws.progress.sns.topic.arn=${?progress_topic_arn}
 aws.outgoing.sns.topic.arn=${?outgoing_topic_arn}
 bag-replicator.storage.destination.bucket=${?destination_bucket_name}
-bag-replicator.storage.destination.rootpath="storage"
 metrics.namespace=bag-replicator

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/config/BagReplicatorConfig.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/config/BagReplicatorConfig.scala
@@ -16,8 +16,7 @@ object BagReplicatorConfig {
       destination = ReplicatorDestinationConfig(
         namespace =
           config.required[String]("bag-replicator.storage.destination.bucket"),
-        rootPath =
-          config.get("bag-replicator.storage.destination.rootpath")
+        rootPath = config.get("bag-replicator.storage.destination.rootpath")
       )
     )
   }

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/config/BagReplicatorConfig.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/config/BagReplicatorConfig.scala
@@ -17,7 +17,7 @@ object BagReplicatorConfig {
         namespace =
           config.required[String]("bag-replicator.storage.destination.bucket"),
         rootPath =
-          config.required[String]("bag-replicator.storage.destination.rootpath")
+          config.get("bag-replicator.storage.destination.rootpath")
       )
     )
   }

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/config/ReplicatorDestinationConfig.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/config/ReplicatorDestinationConfig.scala
@@ -1,4 +1,5 @@
 package uk.ac.wellcome.platform.archive.bagreplicator.config
 
 // Specifies the S3 bucket and root path for objects copied by the replicator.
-case class ReplicatorDestinationConfig(namespace: String, rootPath: Option[String])
+case class ReplicatorDestinationConfig(namespace: String,
+                                       rootPath: Option[String])

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/config/ReplicatorDestinationConfig.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/config/ReplicatorDestinationConfig.scala
@@ -1,4 +1,4 @@
 package uk.ac.wellcome.platform.archive.bagreplicator.config
 
 // Specifies the S3 bucket and root path for objects copied by the replicator.
-case class ReplicatorDestinationConfig(namespace: String, rootPath: String)
+case class ReplicatorDestinationConfig(namespace: String, rootPath: Option[String])

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
@@ -30,7 +30,7 @@ class BagReplicatorFeatureTest
           eventually {
             val dstBagLocation = srcBagLocation.copy(
               storageNamespace = destinationBucket.name,
-              storagePrefix = dstRootPath
+              storagePrefix = Some(dstRootPath)
             )
 
             verifyBagCopied(srcBagLocation, dstBagLocation)

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
@@ -66,7 +66,7 @@ trait BagReplicatorFixtures
             messageStream = messageStream,
             bagReplicatorConfig = BagReplicatorConfig(
               parallelism = 10,
-              ReplicatorDestinationConfig(dstBucket.name, dstRootPath)),
+              ReplicatorDestinationConfig(dstBucket.name, Some(dstRootPath))),
             progressSnsConfig = createSNSConfigWith(progressTopic),
             outgoingSnsConfig = createSNSConfigWith(outgoingTopic)
           )

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/BagStorageTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/storage/BagStorageTest.scala
@@ -28,7 +28,7 @@ class BagStorageTest
       withBag(bucket) { srcBagLocation =>
         val destinationConfig = ReplicatorDestinationConfig(
           namespace = bucket.name,
-          rootPath = randomAlphanumeric()
+          rootPath = Some(randomAlphanumeric())
         )
 
         val result: Future[BagLocation] = bagStorage.duplicateBag(
@@ -52,7 +52,7 @@ class BagStorageTest
         withBag(sourceBucket) { srcBagLocation =>
           val destinationConfig = ReplicatorDestinationConfig(
             namespace = destinationBucket.name,
-            rootPath = randomAlphanumeric()
+            rootPath = Some(randomAlphanumeric())
           )
 
           val result: Future[BagLocation] =
@@ -88,7 +88,7 @@ class BagStorageTest
             withBag(sourceBucket, bagInfo = bagInfo2) { _ =>
               val destinationConfig = ReplicatorDestinationConfig(
                 namespace = destinationBucket.name,
-                rootPath = randomAlphanumeric()
+                rootPath = Some(randomAlphanumeric())
               )
 
               val result: Future[BagLocation] =

--- a/bags/src/test/scala/uk/ac/wellcome/platform/archive/bags/async/RegistrarFeatureTest.scala
+++ b/bags/src/test/scala/uk/ac/wellcome/platform/archive/bags/async/RegistrarFeatureTest.scala
@@ -108,13 +108,13 @@ class RegistrarFeatureTest
 
         val srcBagLocation = BagLocation(
           storageNamespace = storageBucket.name,
-          storagePrefix = "archive",
+          storagePrefix = Some("archive"),
           storageSpace = bagId.space,
           bagPath = randomBagPath
         )
 
         val dstBagLocation = srcBagLocation.copy(
-          storagePrefix = "access"
+          storagePrefix = Some("access")
         )
 
         sendNotificationToSQS(

--- a/bags/src/test/scala/uk/ac/wellcome/platform/archive/bags/async/factories/StorageManifestFactoryTest.scala
+++ b/bags/src/test/scala/uk/ac/wellcome/platform/archive/bags/async/factories/StorageManifestFactoryTest.scala
@@ -72,7 +72,7 @@ class StorageManifestFactoryTest
       withLocalS3Bucket { bucket =>
         val bagLocation = bagit.BagLocation(
           storageNamespace = bucket.name,
-          storagePrefix = "archive",
+          storagePrefix = Some("archive"),
           storageSpace = createStorageSpace,
           bagPath = randomBagPath
         )

--- a/bags/src/test/scala/uk/ac/wellcome/platform/archive/bags/async/fixtures/RegistrarFixtures.scala
+++ b/bags/src/test/scala/uk/ac/wellcome/platform/archive/bags/async/fixtures/RegistrarFixtures.scala
@@ -48,7 +48,7 @@ trait RegistrarFixtures
       bagInfo = bagInfo,
       storageSpace = storageSpace,
       storagePrefix = "archive") { srcBagLocation =>
-      val dstBagLocation = srcBagLocation.copy(storagePrefix = "access")
+      val dstBagLocation = srcBagLocation.copy(storagePrefix = Some("access"))
       val replicationResult = ReplicationResult(
         archiveRequestId = archiveRequestId,
         srcBagLocation = srcBagLocation,

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/models/bagit/BagLocation.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/models/bagit/BagLocation.scala
@@ -1,5 +1,7 @@
 package uk.ac.wellcome.platform.archive.common.models.bagit
 
+import java.nio.file.Paths
+
 import uk.ac.wellcome.platform.archive.common.models.StorageSpace
 import uk.ac.wellcome.storage.ObjectLocation
 
@@ -13,11 +15,11 @@ import uk.ac.wellcome.storage.ObjectLocation
   */
 case class BagLocation(
   storageNamespace: String,
-  storagePrefix: String,
+  storagePrefix: Option[String],
   storageSpace: StorageSpace,
   bagPath: BagPath
 ) {
-  def completePath = s"$storagePrefix/$storageSpace/$bagPath"
+  def completePath = Paths.get(storagePrefix.getOrElse(""), storageSpace.toString, bagPath.toString).toString
 
   def objectLocation: ObjectLocation =
     ObjectLocation(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/models/bagit/BagLocation.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/models/bagit/BagLocation.scala
@@ -19,7 +19,10 @@ case class BagLocation(
   storageSpace: StorageSpace,
   bagPath: BagPath
 ) {
-  def completePath = Paths.get(storagePrefix.getOrElse(""), storageSpace.toString, bagPath.toString).toString
+  def completePath =
+    Paths
+      .get(storagePrefix.getOrElse(""), storageSpace.toString, bagPath.toString)
+      .toString
 
   def objectLocation: ObjectLocation =
     ObjectLocation(

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagLocationFixtures.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagLocationFixtures.scala
@@ -44,7 +44,7 @@ trait BagLocationFixtures
 
     val bagLocation = BagLocation(
       storageNamespace = bucket.name,
-      storagePrefix = storagePrefix,
+      storagePrefix = Some(storagePrefix),
       storageSpace = storageSpace,
       bagPath = BagPath(bagIdentifier.toString)
     )

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/models/bagit/BagLocationTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/models/bagit/BagLocationTest.scala
@@ -12,7 +12,9 @@ class BagLocationTest extends FunSpec with Matchers {
       storageSpace = StorageSpace("digitised"),
       bagPath = BagPath("a/bag")
     )
-    bagLocation.objectLocation shouldBe ObjectLocation("bucket", "storage/digitised/a/bag")
+    bagLocation.objectLocation shouldBe ObjectLocation(
+      "bucket",
+      "storage/digitised/a/bag")
   }
 
   it("creates a bagLocation with blank prefix") {
@@ -22,7 +24,9 @@ class BagLocationTest extends FunSpec with Matchers {
       storageSpace = StorageSpace("digitised"),
       bagPath = BagPath("a/bag")
     )
-    bagLocation.objectLocation shouldBe ObjectLocation("bucket", "digitised/a/bag")
+    bagLocation.objectLocation shouldBe ObjectLocation(
+      "bucket",
+      "digitised/a/bag")
   }
 
   it("creates a bagLocation with no prefix") {
@@ -32,6 +36,8 @@ class BagLocationTest extends FunSpec with Matchers {
       storageSpace = StorageSpace("digitised"),
       bagPath = BagPath("a/bag")
     )
-    bagLocation.objectLocation shouldBe ObjectLocation("bucket", "digitised/a/bag")
+    bagLocation.objectLocation shouldBe ObjectLocation(
+      "bucket",
+      "digitised/a/bag")
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/models/bagit/BagLocationTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/models/bagit/BagLocationTest.scala
@@ -1,0 +1,37 @@
+package uk.ac.wellcome.platform.archive.common.models.bagit
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.platform.archive.common.models.StorageSpace
+import uk.ac.wellcome.storage.ObjectLocation
+
+class BagLocationTest extends FunSpec with Matchers {
+  it("creates a bagLocation") {
+    val bagLocation = BagLocation(
+      storageNamespace = "bucket",
+      storagePrefix = Some("storage"),
+      storageSpace = StorageSpace("digitised"),
+      bagPath = BagPath("a/bag")
+    )
+    bagLocation.objectLocation shouldBe ObjectLocation("bucket", "storage/digitised/a/bag")
+  }
+
+  it("creates a bagLocation with blank prefix") {
+    val bagLocation = BagLocation(
+      storageNamespace = "bucket",
+      storagePrefix = Some(""),
+      storageSpace = StorageSpace("digitised"),
+      bagPath = BagPath("a/bag")
+    )
+    bagLocation.objectLocation shouldBe ObjectLocation("bucket", "digitised/a/bag")
+  }
+
+  it("creates a bagLocation with no prefix") {
+    val bagLocation = BagLocation(
+      storageNamespace = "bucket",
+      storagePrefix = None,
+      storageSpace = StorageSpace("digitised"),
+      bagPath = BagPath("a/bag")
+    )
+    bagLocation.objectLocation shouldBe ObjectLocation("bucket", "digitised/a/bag")
+  }
+}


### PR DESCRIPTION
Make the storagePrefix optional in BagLocation, so that it can match DLCS for access copies.