### PR TITLE
Scalaify ChecksumVerifier

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/models/bagit/ChecksumVerifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/models/bagit/ChecksumVerifier.scala
@@ -32,11 +32,11 @@ object ChecksumVerifier extends Logging {
     triedChecksum.toEither
   }
 
-
   private def checksumObject(
     objectLocation: ObjectLocation,
     digestAlgorithm: String
-  )(implicit s3Client: AmazonS3) = for {
+  )(implicit s3Client: AmazonS3) =
+    for {
       objectContent <- tryObjectContent(
         s3Client,
         objectLocation
@@ -48,7 +48,6 @@ object ChecksumVerifier extends Logging {
       )
 
     } yield checksum
-
 
   private def tryObjectContent(
     s3Client: AmazonS3,
@@ -81,9 +80,10 @@ object ChecksumVerifier extends Logging {
   private def getChecksum(checksumAlgorithm: String) = {
     checksumAlgorithms.get(checksumAlgorithm) match {
       case Some(algo) => Success(algo)
-      case None => Failure(
-        new RuntimeException(s"Unknown algorithm: $checksumAlgorithm")
-      )
+      case None =>
+        Failure(
+          new RuntimeException(s"Unknown algorithm: $checksumAlgorithm")
+        )
     }
   }
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/models/bagit/ChecksumVerifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/models/bagit/ChecksumVerifier.scala
@@ -16,8 +16,7 @@ object ChecksumVerifier extends Logging {
     objectLocation: ObjectLocation,
     bagItAlgorithm: String
   )(implicit
-      s3Client: AmazonS3
-  ): Option[String] = {
+    s3Client: AmazonS3): Option[String] = {
 
     for {
 
@@ -58,7 +57,8 @@ object ChecksumVerifier extends Logging {
           error("Failed to get checksum!", t)
           None
         }
-      }.get
+      }
+      .get
 
     stringOption
   }
@@ -68,9 +68,7 @@ object ChecksumVerifier extends Logging {
     objectLocation: ObjectLocation
   ): Try[S3ObjectInputStream] = Try {
     s3Client
-      .getObject(
-        objectLocation.namespace,
-        objectLocation.key)
+      .getObject(objectLocation.namespace, objectLocation.key)
       .getObjectContent
   }
 
@@ -96,7 +94,7 @@ object ChecksumVerifier extends Logging {
   private def getChecksum(checksumAlgorithm: String) = {
     val tryAlgorithm: Option[String] = checksumAlgorithms.get(checksumAlgorithm)
 
-    if(tryAlgorithm.isEmpty){
+    if (tryAlgorithm.isEmpty) {
       error(s"Unknown algorithm: $checksumAlgorithm ")
     }
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/models/bagit/ChecksumVerifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/models/bagit/ChecksumVerifier.scala
@@ -1,40 +1,104 @@
 package uk.ac.wellcome.platform.archive.common.models.bagit
 
 import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.S3ObjectInputStream
+import grizzled.slf4j.Logging
 import org.apache.commons.codec.binary.Hex
 import org.apache.commons.codec.digest.DigestUtils._
 import org.apache.commons.codec.digest.MessageDigestAlgorithms
 import uk.ac.wellcome.storage.ObjectLocation
 
-object ChecksumVerifier {
-  @throws(classOf[IllegalArgumentException])
-  def checksum(objectLocation: ObjectLocation, bagItAlgorithm: String)(
-    implicit s3Client: AmazonS3): String = {
-    checksumAlgorithms.get(bagItAlgorithm) match {
-      case Some(digestAlgorithm) =>
-        checksumObject(objectLocation, digestAlgorithm)
-      case None =>
-        throw new IllegalArgumentException(
-          f"unknown algorithm '$bagItAlgorithm'")
-    }
+import scala.util.Try
+
+object ChecksumVerifier extends Logging {
+
+  def checksum(
+    objectLocation: ObjectLocation,
+    bagItAlgorithm: String
+  )(implicit
+      s3Client: AmazonS3
+  ): Option[String] = {
+
+    for {
+
+      digestAlgorithm <- getChecksum(
+        bagItAlgorithm
+      )
+
+      checksum <- checksumObject(
+        objectLocation,
+        digestAlgorithm
+      )
+
+    } yield checksum
   }
 
   private def checksumObject(
     objectLocation: ObjectLocation,
-    digestAlgorithm: String)(implicit s3Client: AmazonS3): String = {
-    // TODO: handle exceptions thrown in stream construction and proper stream closure
-    val objectStream = s3Client
-      .getObject(objectLocation.namespace, objectLocation.key)
-      .getObjectContent
-    try {
-      Hex.encodeHexString(
-        updateDigest(getDigest(digestAlgorithm), objectStream).digest)
-    } finally {
-      objectStream.close()
-    }
+    digestAlgorithm: String
+  )(implicit s3Client: AmazonS3): Option[String] = {
+
+    val checksumResult: Try[String] = for {
+      objectContent <- tryObjectContent(
+        s3Client,
+        objectLocation
+      )
+
+      checksum <- tryChecksum(
+        objectContent,
+        digestAlgorithm
+      )
+
+    } yield checksum
+
+    val stringOption: Option[String] = checksumResult
+      .map(Some(_))
+      .recover {
+        case t: Throwable => {
+          error("Failed to get checksum!", t)
+          None
+        }
+      }.get
+
+    stringOption
   }
 
-  // Normalised BagIt checksum algorithms to MessageDigestAlgorithms
+  private def tryObjectContent(
+    s3Client: AmazonS3,
+    objectLocation: ObjectLocation
+  ): Try[S3ObjectInputStream] = Try {
+    s3Client
+      .getObject(
+        objectLocation.namespace,
+        objectLocation.key)
+      .getObjectContent
+  }
+
+  private def tryChecksum(
+    objectStream: S3ObjectInputStream,
+    digestAlgorithm: String
+  ): Try[String] = Try {
+    Hex.encodeHexString(
+      updateDigest(
+        getDigest(digestAlgorithm),
+        objectStream
+      ).digest
+    )
+  }
+
+  private def getChecksum(checksumAlgorithm: String) = {
+    val tryAlgorithm: Option[String] = checksumAlgorithms.get(checksumAlgorithm)
+
+    if(tryAlgorithm.isEmpty){
+      error(s"Unknown algorithm: $checksumAlgorithm ")
+    }
+
+    tryAlgorithm
+  }
+
+  // Normalised BagIt checksum algorithms
+  // to MessageDigestAlgorithms
   private val checksumAlgorithms = Map(
-    "sha256" -> MessageDigestAlgorithms.SHA_256)
+    "sha256" -> MessageDigestAlgorithms.SHA_256
+  )
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/models/bagit/ChecksumVerifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/models/bagit/ChecksumVerifier.scala
@@ -44,7 +44,7 @@ object ChecksumVerifier extends Logging {
         objectLocation
       )
 
-      checksum <- tryChecksum(
+      checksum: String <- tryChecksum(
         objectContent,
         digestAlgorithm
       )
@@ -77,13 +77,20 @@ object ChecksumVerifier extends Logging {
   private def tryChecksum(
     objectStream: S3ObjectInputStream,
     digestAlgorithm: String
-  ): Try[String] = Try {
-    Hex.encodeHexString(
-      updateDigest(
-        getDigest(digestAlgorithm),
-        objectStream
-      ).digest
-    )
+  ): Try[String] = {
+    val triedChecksum = Try {
+      Hex.encodeHexString(
+        updateDigest(
+          getDigest(digestAlgorithm),
+          objectStream
+        ).digest
+      )
+    }
+
+    // We are done with the stream here so close it.
+    objectStream.close()
+
+    triedChecksum
   }
 
   private def getChecksum(checksumAlgorithm: String) = {

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/models/bagit/ChecksumVerifierTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/models/bagit/ChecksumVerifierTest.scala
@@ -32,7 +32,7 @@ class ChecksumVerifierTest extends FunSpec with Matchers with S3 {
     }
   }
 
-  it("returns None for an unknown algorithm") {
+  it("returns Left for an unknown algorithm") {
     val actualChecksumEither = ChecksumVerifier.checksum(
       ObjectLocation("bucket", "key"),
       bagItAlgorithm = "unknown"
@@ -43,7 +43,7 @@ class ChecksumVerifierTest extends FunSpec with Matchers with S3 {
     actualChecksumEither.left.get shouldBe a[RuntimeException]
   }
 
-  it("returns None if the bucket cannot be found") {
+  it("returns Left if the bucket cannot be found") {
     val actualChecksumEither = ChecksumVerifier.checksum(
       ObjectLocation("bucket", "not-there"),
       bagItAlgorithm = "sha256"
@@ -54,7 +54,7 @@ class ChecksumVerifierTest extends FunSpec with Matchers with S3 {
     actualChecksumEither.left.get shouldBe a[AmazonS3Exception]
   }
 
-  it("returns None if the object cannot be found") {
+  it("returns Left if the object cannot be found") {
     withLocalS3Bucket { bucket =>
       val actualChecksumEither = ChecksumVerifier.checksum(
         ObjectLocation(bucket.name, "not-there"),

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/models/bagit/ChecksumVerifierTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/models/bagit/ChecksumVerifierTest.scala
@@ -30,9 +30,9 @@ class ChecksumVerifierTest extends FunSpec with Matchers with S3 {
 
   it("returns None for an unknown algorithm") {
     val actualChecksum = ChecksumVerifier.checksum(
-        ObjectLocation("bucket", "key"),
-        bagItAlgorithm = "unknown"
-      )
+      ObjectLocation("bucket", "key"),
+      bagItAlgorithm = "unknown"
+    )
 
     val expectedChecksum = None
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/models/bagit/ChecksumVerifierTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/models/bagit/ChecksumVerifierTest.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.archive.common.models.bagit
 
 import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.model.AmazonS3Exception
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.fixtures.S3
@@ -13,38 +12,54 @@ class ChecksumVerifierTest extends FunSpec with Matchers with S3 {
     withLocalS3Bucket { bucket =>
       val content = "text"
       val key = "key"
+
       s3Client.putObject(bucket.name, key, content)
-      val contentChecksum =
+
+      val expectedChecksum = Some(
         "982d9e3eb996f559e633f4d194def3761d909f5a3b647d1a851fead67c32c9d1"
+      )
 
-      ChecksumVerifier.checksum(ObjectLocation(bucket.name, key), "sha256") shouldBe contentChecksum
+      val actualChecksum = ChecksumVerifier.checksum(
+        ObjectLocation(bucket.name, key),
+        bagItAlgorithm = "sha256"
+      )
+
+      actualChecksum shouldBe expectedChecksum
     }
   }
 
-  it("fails for an unknown algorithm") {
-    val thrown = intercept[IllegalArgumentException] {
-      ChecksumVerifier.checksum(ObjectLocation("bucket", "key"), "unknown")
-    }
-    thrown.getMessage shouldBe "unknown algorithm 'unknown'"
+  it("returns None for an unknown algorithm") {
+    val actualChecksum = ChecksumVerifier.checksum(
+        ObjectLocation("bucket", "key"),
+        bagItAlgorithm = "unknown"
+      )
+
+    val expectedChecksum = None
+
+    actualChecksum shouldBe expectedChecksum
   }
 
-  it("fails if the bucket cannot be found") {
-    val thrown = intercept[AmazonS3Exception] {
-      ChecksumVerifier.checksum(ObjectLocation("bucket", "not-there"), "sha256")
-    }
-    thrown.getMessage should startWith("The specified bucket does not exist.")
+  it("returns None if the bucket cannot be found") {
+    val actualChecksum = ChecksumVerifier.checksum(
+      ObjectLocation("bucket", "not-there"),
+      bagItAlgorithm = "sha256"
+    )
+
+    val expectedChecksum = None
+
+    actualChecksum shouldBe expectedChecksum
   }
 
-  it("fails if the object cannot be found") {
+  it("returns None if the object cannot be found") {
     withLocalS3Bucket { bucket =>
-      val thrown = intercept[AmazonS3Exception] {
-        ChecksumVerifier.checksum(
-          ObjectLocation(bucket.name, "not-there"),
-          "sha256")
-      }
-      thrown.getMessage should startWith("The specified key does not exist.")
+      val actualChecksum = ChecksumVerifier.checksum(
+        ObjectLocation(bucket.name, "not-there"),
+        bagItAlgorithm = "sha256"
+      )
+
+      val expectedChecksum = None
+
+      actualChecksum shouldBe expectedChecksum
     }
   }
-
-  //  TODO: it("fails if the object get/stream fails") {
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/models/bagit/ChecksumVerifierTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/models/bagit/ChecksumVerifierTest.scala
@@ -19,13 +19,12 @@ class ChecksumVerifierTest extends FunSpec with Matchers with S3 {
       val expectedChecksum =
         "982d9e3eb996f559e633f4d194def3761d909f5a3b647d1a851fead67c32c9d1"
 
-
       val actualChecksumEither = ChecksumVerifier.checksum(
         ObjectLocation(bucket.name, key),
         bagItAlgorithm = "sha256"
       )
 
-      actualChecksumEither shouldBe a [Right[_,_]]
+      actualChecksumEither shouldBe a[Right[_, _]]
       val actualChecksum = actualChecksumEither.right.get
 
       actualChecksum shouldBe expectedChecksum
@@ -38,7 +37,7 @@ class ChecksumVerifierTest extends FunSpec with Matchers with S3 {
       bagItAlgorithm = "unknown"
     )
 
-    actualChecksumEither shouldBe a[Left[_,_]]
+    actualChecksumEither shouldBe a[Left[_, _]]
 
     actualChecksumEither.left.get shouldBe a[RuntimeException]
   }
@@ -49,7 +48,7 @@ class ChecksumVerifierTest extends FunSpec with Matchers with S3 {
       bagItAlgorithm = "sha256"
     )
 
-    actualChecksumEither shouldBe a[Left[_,_]]
+    actualChecksumEither shouldBe a[Left[_, _]]
 
     actualChecksumEither.left.get shouldBe a[AmazonS3Exception]
   }
@@ -61,7 +60,7 @@ class ChecksumVerifierTest extends FunSpec with Matchers with S3 {
         bagItAlgorithm = "sha256"
       )
 
-      actualChecksumEither shouldBe a[Left[_,_]]
+      actualChecksumEither shouldBe a[Left[_, _]]
 
       actualChecksumEither.left.get shouldBe a[AmazonS3Exception]
     }


### PR DESCRIPTION
Log errors instead of throwing exceptions, return an option when there is nothing to do.

If there are no exceptions we can predictably close the stream when done.