### PR TITLE
Split out a StorageManifestService in the bags app

### DIFF
--- a/bags/src/main/scala/uk/ac/wellcome/platform/archive/bags/async/services/StorageManifestService.scala
+++ b/bags/src/main/scala/uk/ac/wellcome/platform/archive/bags/async/services/StorageManifestService.scala
@@ -52,7 +52,9 @@ class StorageManifestService(s3Client: AmazonS3)(implicit ec: ExecutionContext) 
         archiveLocations = List(
           StorageLocation(
             provider = InfrequentAccessStorageProvider,
-            location = bagManifestUpdate.archiveBagLocation.objectLocation)),
+            location = bagManifestUpdate.archiveBagLocation.objectLocation
+          )
+        ),
         createdDate = Instant.now()
       )
     }

--- a/bags/src/main/scala/uk/ac/wellcome/platform/archive/bags/async/services/StorageManifestService.scala
+++ b/bags/src/main/scala/uk/ac/wellcome/platform/archive/bags/async/services/StorageManifestService.scala
@@ -11,10 +11,10 @@ import uk.ac.wellcome.platform.archive.common.models.bagit.{BagDigestFile, BagIn
 import uk.ac.wellcome.platform.archive.common.progress.models.{InfrequentAccessStorageProvider, StorageLocation}
 import uk.ac.wellcome.storage.ObjectLocation
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
-class StorageManifestService(s3Client: AmazonS3) {
+class StorageManifestService(s3Client: AmazonS3)(implicit ec: ExecutionContext) {
 
   val algorithm = "sha256"
   val checksumAlgorithm = ChecksumAlgorithm(algorithm)
@@ -84,6 +84,7 @@ class StorageManifestService(s3Client: AmazonS3) {
         lines.map { line =>
           BagDigestFileCreator.create(
             line = line,
+            bagRootPathInZip = None,
             manifestName = filename
           )
         }

--- a/bags/src/main/scala/uk/ac/wellcome/platform/archive/bags/async/services/StorageManifestService.scala
+++ b/bags/src/main/scala/uk/ac/wellcome/platform/archive/bags/async/services/StorageManifestService.scala
@@ -1,0 +1,109 @@
+package uk.ac.wellcome.platform.archive.bags.async.services
+
+import java.io.InputStream
+import java.time.Instant
+
+import com.amazonaws.services.s3.AmazonS3
+import uk.ac.wellcome.platform.archive.bags.async.models.BagManifestUpdate
+import uk.ac.wellcome.platform.archive.bags.common.models.{ChecksumAlgorithm, FileManifest, StorageManifest}
+import uk.ac.wellcome.platform.archive.common.bag.{BagDigestFileCreator, BagInfoParser}
+import uk.ac.wellcome.platform.archive.common.models.bagit.{BagDigestFile, BagInfo, BagIt}
+import uk.ac.wellcome.platform.archive.common.progress.models.{InfrequentAccessStorageProvider, StorageLocation}
+import uk.ac.wellcome.storage.ObjectLocation
+
+import scala.concurrent.Future
+import scala.util.{Failure, Success, Try}
+
+class StorageManifestService(s3Client: AmazonS3) {
+
+  val algorithm = "sha256"
+  val checksumAlgorithm = ChecksumAlgorithm(algorithm)
+
+  def createManifest(bagManifestUpdate: BagManifestUpdate): Future[Either[Throwable, StorageManifest]] = {
+    val future: Future[StorageManifest] = for {
+      bagInfoInputStream <- downloadFile(
+        bagManifestUpdate = bagManifestUpdate,
+        filename = BagIt.BagInfoFilename
+      )
+      bagInfo <- Future.fromTry {
+        parseBagInfo(
+          bagManifestUpdate = bagManifestUpdate,
+          bagInfoInputStream = bagInfoInputStream
+        )
+      }
+      manifestTuples <- getBagItems(
+        bagManifestUpdate = bagManifestUpdate,
+        filename = s"manifest-$algorithm.txt"
+      )
+      tagManifestTuples <- getBagItems(
+        bagManifestUpdate = bagManifestUpdate,
+        filename = s"tagmanifest-$algorithm.txt"
+      )
+    } yield {
+      StorageManifest(
+        space = bagManifestUpdate.archiveBagLocation.storageSpace,
+        info = bagInfo,
+        manifest = FileManifest(checksumAlgorithm, manifestTuples),
+        tagManifest = FileManifest(checksumAlgorithm, tagManifestTuples),
+        accessLocation = StorageLocation(
+          provider = InfrequentAccessStorageProvider,
+          location = bagManifestUpdate.accessBagLocation.objectLocation
+        ),
+        archiveLocations = List(
+          StorageLocation(
+            provider = InfrequentAccessStorageProvider,
+            location = bagManifestUpdate.archiveBagLocation.objectLocation)),
+        createdDate = Instant.now()
+      )
+    }
+
+    future
+      .map { manifest => Right(manifest) }
+      .recover { case err: Throwable => Left(err) }
+  }
+
+  private def parseBagInfo(bagManifestUpdate: BagManifestUpdate, bagInfoInputStream: InputStream): Try[BagInfo] =
+    BagInfoParser.parseBagInfo(bagManifestUpdate, inputStream = bagInfoInputStream) match {
+      case Right(bagInfo) => Success(bagInfo)
+      case Left(err) => Failure(throw new RuntimeException(err.toString))
+    }
+
+  private def getBagItems(bagManifestUpdate: BagManifestUpdate,
+                          filename: String)
+  : Future[List[BagDigestFile]] =
+    for {
+      inputStream <- downloadFile(bagManifestUpdate = bagManifestUpdate, filename = filename)
+      lines: List[String] =
+        scala.io.Source
+          .fromInputStream(inputStream)
+          .mkString
+          .split("\n")
+          .filter { _.nonEmpty }
+          .toList
+      tryBagDigestFiles: List[Try[BagDigestFile]] =
+        lines.map { line =>
+          BagDigestFileCreator.create(
+            line = line,
+            manifestName = filename
+          )
+        }
+      bagDigestFiles: List[BagDigestFile] <- Future.sequence {
+        tryBagDigestFiles.map { Future.fromTry }
+      }
+    } yield bagDigestFiles
+
+  private def downloadFile(bagManifestUpdate: BagManifestUpdate,
+                           filename: String): Future[InputStream] = {
+    val bagLocation = bagManifestUpdate.archiveBagLocation
+    val location = ObjectLocation(
+      namespace = bagLocation.storageNamespace,
+      key = List(bagLocation.completePath, filename).mkString("/")
+    )
+
+    Future {
+      s3Client
+        .getObject(location.namespace, location.key)
+        .getObjectContent
+    }
+  }
+}

--- a/bags/src/test/scala/uk/ac/wellcome/platform/archive/bags/async/services/StorageManifestServiceTest.scala
+++ b/bags/src/test/scala/uk/ac/wellcome/platform/archive/bags/async/services/StorageManifestServiceTest.scala
@@ -5,15 +5,27 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.bags.async.generators.BagManifestUpdateGenerators
 import uk.ac.wellcome.platform.archive.bags.common.models.ChecksumAlgorithm
-import uk.ac.wellcome.platform.archive.common.fixtures.{BagLocationFixtures, FileEntry}
+import uk.ac.wellcome.platform.archive.common.fixtures.{
+  BagLocationFixtures,
+  FileEntry
+}
 import uk.ac.wellcome.platform.archive.common.models.bagit
 import uk.ac.wellcome.platform.archive.common.models.bagit.BagLocation
-import uk.ac.wellcome.platform.archive.common.progress.models.{InfrequentAccessStorageProvider, StorageLocation}
+import uk.ac.wellcome.platform.archive.common.progress.models.{
+  InfrequentAccessStorageProvider,
+  StorageLocation
+}
 import uk.ac.wellcome.storage.fixtures.S3
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
-class StorageManifestServiceTest extends FunSpec with Matchers with ScalaFutures with BagLocationFixtures with BagManifestUpdateGenerators with S3 {
+class StorageManifestServiceTest
+    extends FunSpec
+    with Matchers
+    with ScalaFutures
+    with BagLocationFixtures
+    with BagManifestUpdateGenerators
+    with S3 {
 
   val service = new StorageManifestService(s3Client)
 
@@ -38,10 +50,12 @@ class StorageManifestServiceTest extends FunSpec with Matchers with ScalaFutures
                 storageManifest.space shouldBe archiveBagLocation.storageSpace
                 storageManifest.info shouldBe bagInfo
 
-                storageManifest.manifest.checksumAlgorithm shouldBe ChecksumAlgorithm("sha256")
+                storageManifest.manifest.checksumAlgorithm shouldBe ChecksumAlgorithm(
+                  "sha256")
                 storageManifest.manifest.files should have size 1
 
-                storageManifest.tagManifest.checksumAlgorithm shouldBe ChecksumAlgorithm("sha256")
+                storageManifest.tagManifest.checksumAlgorithm shouldBe ChecksumAlgorithm(
+                  "sha256")
                 storageManifest.tagManifest.files should have size 3
                 val actualFiles =
                   storageManifest.tagManifest.files

--- a/bags/src/test/scala/uk/ac/wellcome/platform/archive/bags/async/services/StorageManifestServiceTest.scala
+++ b/bags/src/test/scala/uk/ac/wellcome/platform/archive/bags/async/services/StorageManifestServiceTest.scala
@@ -1,0 +1,144 @@
+package uk.ac.wellcome.platform.archive.bags.async.services
+
+import com.amazonaws.services.s3.model.AmazonS3Exception
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.platform.archive.bags.async.generators.BagManifestUpdateGenerators
+import uk.ac.wellcome.platform.archive.bags.common.models.ChecksumAlgorithm
+import uk.ac.wellcome.platform.archive.common.fixtures.{BagLocationFixtures, FileEntry}
+import uk.ac.wellcome.platform.archive.common.models.bagit
+import uk.ac.wellcome.platform.archive.common.progress.models.{InfrequentAccessStorageProvider, StorageLocation}
+import uk.ac.wellcome.storage.fixtures.S3
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class StorageManifestServiceTest extends FunSpec with Matchers with ScalaFutures with BagLocationFixtures with BagManifestUpdateGenerators with S3 {
+
+  val service = new StorageManifestService(s3Client)
+
+  it("returns a StorageManifest if reading a bag location succeeds") {
+    withLocalS3Bucket { bucket =>
+      val bagInfo = createBagInfo
+      withBag(bucket, bagInfo = bagInfo, storagePrefix = "archive") {
+        archiveBagLocation =>
+          withBag(bucket, bagInfo = bagInfo, storagePrefix = "access") {
+            accessBagLocation =>
+              val bagManifestUpdate = createBagManifestUpdateWith(
+                archiveBagLocation = archiveBagLocation,
+                accessBagLocation = accessBagLocation
+              )
+
+              val future = service.createManifest(bagManifestUpdate)
+
+              whenReady(future) { result =>
+                result.isRight shouldBe true
+                val storageManifest = result.right.get
+
+                storageManifest.space shouldBe archiveBagLocation.storageSpace
+                storageManifest.info shouldBe bagInfo
+
+                storageManifest.manifest.checksumAlgorithm shouldBe ChecksumAlgorithm("sha256")
+                storageManifest.manifest.files should have size 1
+
+                storageManifest.tagManifest.checksumAlgorithm shouldBe ChecksumAlgorithm("sha256")
+                storageManifest.tagManifest.files should have size 3
+                val actualFiles =
+                  storageManifest.tagManifest.files
+                    .map { _.path.toString }
+                val expectedFiles = List(
+                  "manifest-sha256.txt",
+                  "bag-info.txt",
+                  "bagit.txt"
+                )
+                actualFiles should contain theSameElementsAs expectedFiles
+
+                storageManifest.accessLocation shouldBe StorageLocation(
+                  provider = InfrequentAccessStorageProvider,
+                  location = accessBagLocation.objectLocation
+                )
+                storageManifest.archiveLocations shouldBe List(
+                  StorageLocation(
+                    provider = InfrequentAccessStorageProvider,
+                    location = archiveBagLocation.objectLocation
+                  )
+                )
+              }
+          }
+      }
+    }
+  }
+
+  describe("returns a Left upon error") {
+    it("if no files are at the BagLocation") {
+      withLocalS3Bucket { bucket =>
+        val bagLocation = bagit.BagLocation(
+          storageNamespace = bucket.name,
+          storagePrefix = Some("archive"),
+          storageSpace = createStorageSpace,
+          bagPath = randomBagPath
+        )
+        val bagManifestUpdate = createBagManifestUpdateWith(
+          archiveBagLocation = bagLocation,
+          accessBagLocation = bagLocation
+        )
+
+        val future = service.createManifest(bagManifestUpdate)
+
+        whenReady(future) { result =>
+          result.isLeft shouldBe true
+          val err = result.left.get
+          err shouldBe a[AmazonS3Exception]
+          err.getMessage should startWith("The specified key does not exist.")
+        }
+      }
+    }
+
+    it("if the BagLocation has an invalid manifest") {
+      withLocalS3Bucket { bucket =>
+        withBag(
+          bucket,
+          createDataManifest =
+            _ => Some(FileEntry("manifest-sha256.txt", "bleeergh!"))) {
+          bagLocation =>
+            val bagManifestUpdate = createBagManifestUpdateWith(
+              archiveBagLocation = bagLocation,
+              accessBagLocation = bagLocation
+            )
+
+            val future = service.createManifest(bagManifestUpdate)
+
+            whenReady(future) { result =>
+              result.isLeft shouldBe true
+              val err = result.left.get
+              err shouldBe a[RuntimeException]
+              err.getMessage shouldBe "Line <<bleeergh!>> is incorrectly formatted!"
+            }
+        }
+      }
+    }
+
+    it("if the BagLocation has an invalid tagmanifest") {
+      withLocalS3Bucket { bucket =>
+        withBag(
+          bucket,
+          createTagManifest =
+            _ => Some(FileEntry("tagmanifest-sha256.txt", "blaaargh!"))) {
+          bagLocation =>
+            val bagManifestUpdate = createBagManifestUpdateWith(
+              archiveBagLocation = bagLocation,
+              accessBagLocation = bagLocation
+            )
+
+            val future = service.createManifest(bagManifestUpdate)
+
+            whenReady(future) { result =>
+              result.isLeft shouldBe true
+              val err = result.left.get
+              err shouldBe a[RuntimeException]
+              err.getMessage shouldBe "Line <<blaaargh!>> is incorrectly formatted!"
+            }
+        }
+      }
+    }
+  }
+}

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bag/BagDigestFileCreator.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bag/BagDigestFileCreator.scala
@@ -1,15 +1,14 @@
 package uk.ac.wellcome.platform.archive.common.bag
 
-import uk.ac.wellcome.platform.archive.common.models.bagit.{
-  BagDigestFile,
-  BagItemPath
-}
-import uk.ac.wellcome.platform.archive.common.models.error.{
-  ArchiveError,
-  InvalidBagManifestError
-}
+import uk.ac.wellcome.platform.archive.common.models.bagit.{BagDigestFile, BagItemPath}
+import uk.ac.wellcome.platform.archive.common.models.error.{ArchiveError, InvalidBagManifestError}
+
+import scala.util.{Failure, Success, Try}
+import scala.util.matching.Regex
 
 object BagDigestFileCreator {
+
+  val checksumLineRegex: Regex = """(.+?)\s+(.+)""".r
 
   /** Within a manifest, each entry in the bag is a single line, containing
     * a checksum and the location.  For example:
@@ -22,22 +21,27 @@ object BagDigestFileCreator {
     * location, or returns an error if the line is incorrectly formatted.
     *
     */
-  def create[T](
-    line: String,
-    job: T,
-    bagRootPathInZip: Option[String] = None,
-    manifestName: String): Either[ArchiveError[T], BagDigestFile] = {
-    val checksumLineRegex = """(.+?)\s+(.+)""".r
-
+  def create(line: String,
+             bagRootPathInZip: Option[String] = None,
+             manifestName: String): Try[BagDigestFile] =
     line match {
       case checksumLineRegex(checksum, itemPath) =>
-        Right(
+        Success(
           BagDigestFile(
             checksum = checksum.trim,
             path = BagItemPath(bagRootPathInZip, itemPath.trim)
           )
         )
-      case _ => Left(InvalidBagManifestError(job, manifestName, line))
+      case _ => Failure(new RuntimeException(s"Line <<$line>> is incorrectly formatted!"))
     }
-  }
+
+  def create[T](
+    line: String,
+    job: T,
+    bagRootPathInZip: Option[String] = None,
+    manifestName: String): Either[ArchiveError[T], BagDigestFile] =
+    create(line, bagRootPathInZip, manifestName) match {
+      case Success(bagDigestFile) => Right(bagDigestFile)
+      case Failure(_) => Left(InvalidBagManifestError(job, manifestName, line))
+    }
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bag/BagDigestFileCreator.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bag/BagDigestFileCreator.scala
@@ -22,7 +22,7 @@ object BagDigestFileCreator {
     *
     */
   def create(line: String,
-             bagRootPathInZip: Option[String] = None,
+             bagRootPathInZip: Option[String],
              manifestName: String): Try[BagDigestFile] =
     line match {
       case checksumLineRegex(checksum, itemPath) =>

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bag/BagDigestFileCreator.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bag/BagDigestFileCreator.scala
@@ -1,7 +1,13 @@
 package uk.ac.wellcome.platform.archive.common.bag
 
-import uk.ac.wellcome.platform.archive.common.models.bagit.{BagDigestFile, BagItemPath}
-import uk.ac.wellcome.platform.archive.common.models.error.{ArchiveError, InvalidBagManifestError}
+import uk.ac.wellcome.platform.archive.common.models.bagit.{
+  BagDigestFile,
+  BagItemPath
+}
+import uk.ac.wellcome.platform.archive.common.models.error.{
+  ArchiveError,
+  InvalidBagManifestError
+}
 
 import scala.util.{Failure, Success, Try}
 import scala.util.matching.Regex
@@ -32,16 +38,17 @@ object BagDigestFileCreator {
             path = BagItemPath(bagRootPathInZip, itemPath.trim)
           )
         )
-      case _ => Failure(new RuntimeException(s"Line <<$line>> is incorrectly formatted!"))
+      case _ =>
+        Failure(
+          new RuntimeException(s"Line <<$line>> is incorrectly formatted!"))
     }
 
-  def create[T](
-    line: String,
-    job: T,
-    bagRootPathInZip: Option[String] = None,
-    manifestName: String): Either[ArchiveError[T], BagDigestFile] =
+  def create[T](line: String,
+                job: T,
+                bagRootPathInZip: Option[String] = None,
+                manifestName: String): Either[ArchiveError[T], BagDigestFile] =
     create(line, bagRootPathInZip, manifestName) match {
       case Success(bagDigestFile) => Right(bagDigestFile)
-      case Failure(_) => Left(InvalidBagManifestError(job, manifestName, line))
+      case Failure(_)             => Left(InvalidBagManifestError(job, manifestName, line))
     }
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bag/BagInfoParser.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bag/BagInfoParser.scala
@@ -67,11 +67,11 @@ object BagInfoParser {
     validated.toEither.leftMap(list => InvalidBagInfo(t, list.toList))
   }
 
-  private def extractExternalIdentifier(bagInfoLines: Array[String]): Option[String] =
+  private def extractExternalIdentifier(bagInfoLines: Array[String]) =
     extractRequiredValue(bagInfoLines, BagInfoKeys.externalIdentifier)
       .map(ExternalIdentifier.apply)
 
-  private def extractPayloadOxum(bagInfoLines: Array[String]): Option[String] =
+  private def extractPayloadOxum(bagInfoLines: Array[String]) =
     bagInfoLines
       .collectFirst {
         case payloadOxumRegex(bytes, numberOfFiles) =>
@@ -79,41 +79,40 @@ object BagInfoParser {
       }
       .toValidNel(BagInfoKeys.payloadOxum)
 
-  private def extractBaggingDate(bagInfoLines: Array[String]): Validated[NonEmptyList[String], LocalDate] =
+  private def extractBaggingDate(bagInfoLines: Array[String]) =
     extractRequiredValue(bagInfoLines, BagInfoKeys.baggingDate).andThen(
       dateString =>
         Try(LocalDate.parse(dateString)).toEither
           .leftMap(_ => BagInfoKeys.baggingDate)
           .toValidatedNel)
 
-  private def extractSourceOrganisation(bagInfoLines: Array[String]): ValidatedNel[Nothing, Option[SourceOrganisation]] = {
+  private def extractSourceOrganisation(bagInfoLines: Array[String]) =
     extractOptionalValue(bagInfoLines, BagInfoKeys.sourceOrganisation)
       .map(SourceOrganisation)
       .validNel
-  }
 
-  private def extractExternalDescription(bagInfoLines: Array[String]): ValidatedNel[Nothing, Option[ExternalDescription]] =
+  private def extractExternalDescription(bagInfoLines: Array[String]) =
     extractOptionalValue(bagInfoLines, BagInfoKeys.externalDescription)
       .map(ExternalDescription)
       .validNel
 
-  private def extractInternalSenderIdentifier(bagInfoLines: Array[String]): ValidatedNel[Nothing, Option[InternalSenderIdentifier]] =
+  private def extractInternalSenderIdentifier(bagInfoLines: Array[String]) =
     extractOptionalValue(bagInfoLines, BagInfoKeys.internalSenderIdentifier)
       .map(InternalSenderIdentifier)
       .validNel
 
-  private def extractInternalSenderDescription(bagInfoLines: Array[String]): ValidatedNel[Nothing, Option[InternalSenderDescription]] =
+  private def extractInternalSenderDescription(bagInfoLines: Array[String]) =
     extractOptionalValue(bagInfoLines, BagInfoKeys.internalSenderDescription)
       .map(InternalSenderDescription)
       .validNel
 
   private def extractRequiredValue(bagInfoLines: Array[String],
-                                   bagInfoKey: String): ValidatedNel[String, String] =
+                                   bagInfoKey: String) =
     extractOptionalValue(bagInfoLines, bagInfoKey)
       .toValidNel(bagInfoKey)
 
   private def extractOptionalValue(bagInfoLines: Array[String],
-                                   bagInfoKey: String): Option[String] =
+                                   bagInfoKey: String) =
     bagInfoLines
       .collectFirst {
         case bagInfoFieldRegex(key, value) if key == bagInfoKey =>

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bag/BagInfoParser.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bag/BagInfoParser.scala
@@ -67,12 +67,11 @@ object BagInfoParser {
     validated.toEither.leftMap(list => InvalidBagInfo(t, list.toList))
   }
 
-  private def extractExternalIdentifier(bagInfoLines: Array[String]) = {
+  private def extractExternalIdentifier(bagInfoLines: Array[String]): Option[String] =
     extractRequiredValue(bagInfoLines, BagInfoKeys.externalIdentifier)
       .map(ExternalIdentifier.apply)
-  }
 
-  private def extractPayloadOxum(bagInfoLines: Array[String]) = {
+  private def extractPayloadOxum(bagInfoLines: Array[String]): Option[String] =
     bagInfoLines
       .collectFirst {
         case payloadOxumRegex(bytes, numberOfFiles) =>
@@ -80,49 +79,44 @@ object BagInfoParser {
       }
       .toValidNel(BagInfoKeys.payloadOxum)
 
-  }
-
-  private def extractBaggingDate(bagInfoLines: Array[String]) = {
+  private def extractBaggingDate(bagInfoLines: Array[String]): Validated[NonEmptyList[String], LocalDate] =
     extractRequiredValue(bagInfoLines, BagInfoKeys.baggingDate).andThen(
       dateString =>
         Try(LocalDate.parse(dateString)).toEither
           .leftMap(_ => BagInfoKeys.baggingDate)
           .toValidatedNel)
-  }
 
-  private def extractSourceOrganisation(bagInfoLines: Array[String]) = {
+  private def extractSourceOrganisation(bagInfoLines: Array[String]): ValidatedNel[Nothing, Option[SourceOrganisation]] = {
     extractOptionalValue(bagInfoLines, BagInfoKeys.sourceOrganisation)
       .map(SourceOrganisation)
       .validNel
   }
 
-  private def extractExternalDescription(bagInfoLines: Array[String]) =
+  private def extractExternalDescription(bagInfoLines: Array[String]): ValidatedNel[Nothing, Option[ExternalDescription]] =
     extractOptionalValue(bagInfoLines, BagInfoKeys.externalDescription)
       .map(ExternalDescription)
       .validNel
 
-  private def extractInternalSenderIdentifier(bagInfoLines: Array[String]) =
+  private def extractInternalSenderIdentifier(bagInfoLines: Array[String]): ValidatedNel[Nothing, Option[InternalSenderIdentifier]] =
     extractOptionalValue(bagInfoLines, BagInfoKeys.internalSenderIdentifier)
       .map(InternalSenderIdentifier)
       .validNel
 
-  private def extractInternalSenderDescription(bagInfoLines: Array[String]) =
+  private def extractInternalSenderDescription(bagInfoLines: Array[String]): ValidatedNel[Nothing, Option[InternalSenderDescription]] =
     extractOptionalValue(bagInfoLines, BagInfoKeys.internalSenderDescription)
       .map(InternalSenderDescription)
       .validNel
 
   private def extractRequiredValue(bagInfoLines: Array[String],
-                                   bagInfoKey: String) = {
+                                   bagInfoKey: String): ValidatedNel[String, String] =
     extractOptionalValue(bagInfoLines, bagInfoKey)
       .toValidNel(bagInfoKey)
-  }
 
   private def extractOptionalValue(bagInfoLines: Array[String],
-                                   bagInfoKey: String) = {
+                                   bagInfoKey: String): Option[String] =
     bagInfoLines
       .collectFirst {
         case bagInfoFieldRegex(key, value) if key == bagInfoKey =>
           value
       }
-  }
 }


### PR DESCRIPTION
A first bit of refactoring for making the Bags app Akka-free.

@kenoir – I think this contains the majority of model changes, and can be merged separately. The rest of the app needs more work, and I messed up the first go, but this bit is a neat standalone bit we can get in now.