### PR TITLE
Move all the Akka stuff into the archivist

### DIFF
--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/Archivist.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/Archivist.scala
@@ -11,10 +11,9 @@ import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSConfig}
 import uk.ac.wellcome.platform.archive.archivist.flow._
+import uk.ac.wellcome.platform.archive.archivist.messaging.MessageStream
 import uk.ac.wellcome.platform.archive.archivist.models.BagUploaderConfig
 import uk.ac.wellcome.platform.archive.common.config.models.Parallelism
-import uk.ac.wellcome.platform.archive.common.flows.SupervisedMaterializer
-import uk.ac.wellcome.platform.archive.common.messaging.MessageStream
 import uk.ac.wellcome.typesafe.Runnable
 
 import scala.concurrent.Future

--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/ConvertibleToInputStream.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/ConvertibleToInputStream.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common
+package uk.ac.wellcome.platform.archive.archivist
 
 import java.io.InputStream
 

--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/Main.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/Main.scala
@@ -5,8 +5,10 @@ import com.typesafe.config.Config
 import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.messaging.typesafe.SNSBuilder
 import uk.ac.wellcome.platform.archive.archivist.builders.TransferManagerBuilder
-import uk.ac.wellcome.platform.archive.archivist.config.BagUploaderConfigBuilder
-import uk.ac.wellcome.platform.archive.common.config.builders.MessagingBuilder
+import uk.ac.wellcome.platform.archive.archivist.config.{
+  BagUploaderConfigBuilder,
+  MessagingBuilder
+}
 import uk.ac.wellcome.storage.typesafe.S3Builder
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder

--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/config/MessagingBuilder.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/config/MessagingBuilder.scala
@@ -1,10 +1,10 @@
-package uk.ac.wellcome.platform.archive.common.config.builders
+package uk.ac.wellcome.platform.archive.archivist.config
 
 import akka.actor.ActorSystem
 import com.typesafe.config.Config
 import uk.ac.wellcome.messaging.typesafe.SQSBuilder
 import uk.ac.wellcome.monitoring.typesafe.MetricsSenderBuilder
-import uk.ac.wellcome.platform.archive.common.messaging.MessageStream
+import uk.ac.wellcome.platform.archive.archivist.messaging.MessageStream
 
 object MessagingBuilder {
   def buildMessageStream[T, R](config: Config)(

--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/error/FileDownloadingError.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/error/FileDownloadingError.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.errors
+package uk.ac.wellcome.platform.archive.archivist.error
 
 import uk.ac.wellcome.platform.archive.common.models.IngestBagRequest
 import uk.ac.wellcome.platform.archive.common.models.error.ArchiveError

--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveAndNotifyNextFlow.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveAndNotifyNextFlow.scala
@@ -1,4 +1,5 @@
 package uk.ac.wellcome.platform.archive.archivist.flow
+
 import akka.NotUsed
 import akka.stream.scaladsl.Flow
 import com.amazonaws.services.s3.AmazonS3
@@ -6,7 +7,6 @@ import com.amazonaws.services.sns.AmazonSNS
 import uk.ac.wellcome.messaging.sns.SNSConfig
 import uk.ac.wellcome.platform.archive.archivist.models.TypeAliases.BagDownload
 import uk.ac.wellcome.platform.archive.archivist.models.BagUploaderConfig
-import uk.ac.wellcome.platform.archive.common.flows.FoldEitherFlow
 import uk.ac.wellcome.platform.archive.common.models.BagRequest
 import uk.ac.wellcome.platform.archive.common.models.error.ArchiveError
 

--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveJobDigestItemsFlow.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveJobDigestItemsFlow.scala
@@ -11,10 +11,6 @@ import uk.ac.wellcome.platform.archive.archivist.models.{
   ArchiveJob,
   DigestItemJob
 }
-import uk.ac.wellcome.platform.archive.common.flows.{
-  FoldEitherFlow,
-  OnErrorFlow
-}
 import uk.ac.wellcome.platform.archive.common.models.error.ArchiveError
 import uk.ac.wellcome.platform.archive.common.models.{
   BagRequest,

--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveJobFlow.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveJobFlow.scala
@@ -6,10 +6,6 @@ import com.amazonaws.services.s3.AmazonS3
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.archivist.models.ArchiveJob
 import uk.ac.wellcome.platform.archive.archivist.models.TypeAliases.ArchiveCompletion
-import uk.ac.wellcome.platform.archive.common.flows.{
-  FoldEitherFlow,
-  OnErrorFlow
-}
 import uk.ac.wellcome.platform.archive.common.models.error.ArchiveError
 import uk.ac.wellcome.platform.archive.common.models.{
   BagRequest,

--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveTagManifestFlow.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveTagManifestFlow.scala
@@ -10,7 +10,6 @@ import uk.ac.wellcome.platform.archive.archivist.models.errors.{
   ArchiveItemJobError,
   ArchiveJobError
 }
-import uk.ac.wellcome.platform.archive.common.flows.FoldEitherFlow
 import uk.ac.wellcome.platform.archive.common.models.error.ArchiveError
 
 /** This flow extracts a tag manifest from a ZIP file, and uploads it to S3

--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveZipFileFlow.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveZipFileFlow.scala
@@ -11,6 +11,7 @@ import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.SNSConfig
 import uk.ac.wellcome.platform.archive.archivist.bag.ArchiveJobCreator
+import uk.ac.wellcome.platform.archive.archivist.messaging.SnsPublishFlow
 import uk.ac.wellcome.platform.archive.archivist.models.{
   BagUploaderConfig,
   FileDownloadComplete
@@ -20,7 +21,6 @@ import uk.ac.wellcome.platform.archive.archivist.models.TypeAliases.{
   BagDownload
 }
 import uk.ac.wellcome.platform.archive.archivist.models.errors.ArchiveJobError
-import uk.ac.wellcome.platform.archive.common.messaging.SnsPublishFlow
 import uk.ac.wellcome.platform.archive.common.models.error.ArchiveError
 import uk.ac.wellcome.platform.archive.common.models.{
   BagRequest,

--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/DigestItemJobFlow.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/DigestItemJobFlow.scala
@@ -5,10 +5,6 @@ import akka.stream.scaladsl.Flow
 import com.amazonaws.services.s3.AmazonS3
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.archivist.models.DigestItemJob
-import uk.ac.wellcome.platform.archive.common.flows.{
-  FoldEitherFlow,
-  OnErrorFlow
-}
 import uk.ac.wellcome.platform.archive.common.models.error.ArchiveError
 
 object DigestItemJobFlow extends Logging {

--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/DiscardLeftFlow.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/DiscardLeftFlow.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.flows
+package uk.ac.wellcome.platform.archive.archivist.flow
 
 import akka.NotUsed
 import akka.stream.scaladsl.Flow

--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/DownloadAndVerifyDigestItemFlow.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/DownloadAndVerifyDigestItemFlow.scala
@@ -16,7 +16,7 @@ import scala.util.{Failure, Success}
 
 object DownloadAndVerifyDigestItemFlow extends Logging {
 
-  import uk.ac.wellcome.platform.archive.common.ConvertibleToInputStream._
+  import uk.ac.wellcome.platform.archive.archivist.ConvertibleToInputStream._
 
   def apply(parallelism: Int)(implicit s3Client: AmazonS3)
     : Flow[DigestItemJob,

--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/EitherFanOut.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/EitherFanOut.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.flows
+package uk.ac.wellcome.platform.archive.archivist.flow
 
 import akka.stream.FanOutShape2
 import akka.stream.scaladsl.{Broadcast, Flow, GraphDSL}

--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/EitherFlow.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/EitherFlow.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.flows
+package uk.ac.wellcome.platform.archive.archivist.flow
 
 import akka.NotUsed
 import akka.stream.FlowShape

--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/FoldEitherFlow.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/FoldEitherFlow.scala
@@ -1,4 +1,5 @@
-package uk.ac.wellcome.platform.archive.common.flows
+package uk.ac.wellcome.platform.archive.archivist.flow
+
 import akka.NotUsed
 import akka.stream.FlowShape
 import akka.stream.scaladsl.{Broadcast, Flow, GraphDSL, Merge}

--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/LogLeftFlow.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/LogLeftFlow.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.flows
+package uk.ac.wellcome.platform.archive.archivist.flow
 
 import akka.NotUsed
 import akka.stream.scaladsl.Flow

--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/NextNotifierFlow.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/NextNotifierFlow.scala
@@ -6,7 +6,7 @@ import com.amazonaws.services.sns.AmazonSNS
 import com.amazonaws.services.sns.model.PublishResult
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.SNSConfig
-import uk.ac.wellcome.platform.archive.common.messaging.SnsPublishFlow
+import uk.ac.wellcome.platform.archive.archivist.messaging.SnsPublishFlow
 import uk.ac.wellcome.platform.archive.common.models.BagRequest
 
 object NextNotifierFlow {

--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/NotificationMessageFlow.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/NotificationMessageFlow.scala
@@ -5,11 +5,11 @@ import akka.stream.scaladsl.{Flow, Source}
 import com.amazonaws.services.sns.AmazonSNS
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.{NotificationMessage, SNSConfig}
-import uk.ac.wellcome.platform.archive.common.config.models.Parallelism
-import uk.ac.wellcome.platform.archive.common.messaging.{
+import uk.ac.wellcome.platform.archive.archivist.messaging.{
   NotificationParsingFlow,
   SnsPublishFlow
 }
+import uk.ac.wellcome.platform.archive.common.config.models.Parallelism
 import uk.ac.wellcome.platform.archive.common.models.IngestBagRequest
 import uk.ac.wellcome.platform.archive.common.progress.models.{
   ProgressEvent,

--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/OnErrorFlow.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/OnErrorFlow.scala
@@ -1,4 +1,5 @@
-package uk.ac.wellcome.platform.archive.common.flows
+package uk.ac.wellcome.platform.archive.archivist.flow
+
 import akka.stream.scaladsl.Flow
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.common.models.error.ArchiveError

--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/ProcessLogDiscardFlow.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/ProcessLogDiscardFlow.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.flows
+package uk.ac.wellcome.platform.archive.archivist.flow
 
 import akka.NotUsed
 import akka.stream.scaladsl.Flow

--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/SupervisedMaterializer.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/SupervisedMaterializer.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.flows
+package uk.ac.wellcome.platform.archive.archivist.flow
 
 import akka.actor.ActorSystem
 import akka.stream.{ActorMaterializer, ActorMaterializerSettings, Supervision}

--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/UploadDigestItemFlow.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/UploadDigestItemFlow.scala
@@ -8,10 +8,6 @@ import com.amazonaws.services.s3.AmazonS3
 import uk.ac.wellcome.platform.archive.archivist.models.DigestItemJob
 import uk.ac.wellcome.platform.archive.archivist.models.errors.FileNotFoundError
 import uk.ac.wellcome.platform.archive.archivist.zipfile.ZipFileReader
-import uk.ac.wellcome.platform.archive.common.flows.{
-  FoldEitherFlow,
-  OnErrorFlow
-}
 import uk.ac.wellcome.platform.archive.common.models.error.ArchiveError
 
 /** This flow extracts an item from a ZIP file, uploads it to S3 and validates

--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/UploadItemFlow.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/UploadItemFlow.scala
@@ -8,10 +8,6 @@ import com.amazonaws.services.s3.AmazonS3
 import uk.ac.wellcome.platform.archive.archivist.models.ArchiveItemJob
 import uk.ac.wellcome.platform.archive.archivist.models.errors.FileNotFoundError
 import uk.ac.wellcome.platform.archive.archivist.zipfile.ZipFileReader
-import uk.ac.wellcome.platform.archive.common.flows.{
-  FoldEitherFlow,
-  OnErrorFlow
-}
 import uk.ac.wellcome.platform.archive.common.models.error.ArchiveError
 
 /** This flow extracts an item from a ZIP file, uploads it to S3 and calculates the checksum

--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/ZipFileDownloadFlow.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/flow/ZipFileDownloadFlow.scala
@@ -6,11 +6,11 @@ import com.amazonaws.services.s3.transfer.TransferManager
 import com.amazonaws.services.sns.AmazonSNS
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.SNSConfig
+import uk.ac.wellcome.platform.archive.archivist.error.FileDownloadingError
+import uk.ac.wellcome.platform.archive.archivist.messaging.SnsPublishFlow
 import uk.ac.wellcome.platform.archive.archivist.models.FileDownloadComplete
 import uk.ac.wellcome.platform.archive.archivist.models.TypeAliases._
 import uk.ac.wellcome.platform.archive.common.config.models.Parallelism
-import uk.ac.wellcome.platform.archive.common.errors.FileDownloadingError
-import uk.ac.wellcome.platform.archive.common.messaging.SnsPublishFlow
 import uk.ac.wellcome.platform.archive.common.models.IngestBagRequest
 import uk.ac.wellcome.platform.archive.common.progress.models._
 

--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/messaging/MessageStream.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/messaging/MessageStream.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.messaging
+package uk.ac.wellcome.platform.archive.archivist.messaging
 
 import akka.NotUsed
 import akka.actor.ActorSystem

--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/messaging/NotificationParsingFlow.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/messaging/NotificationParsingFlow.scala
@@ -1,11 +1,11 @@
-package uk.ac.wellcome.platform.archive.common.messaging
+package uk.ac.wellcome.platform.archive.archivist.messaging
 
 import akka.NotUsed
 import akka.stream.scaladsl.Flow
 import io.circe.Decoder
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.NotificationMessage
-import uk.ac.wellcome.platform.archive.common.flows.ProcessLogDiscardFlow
+import uk.ac.wellcome.platform.archive.archivist.flow.ProcessLogDiscardFlow
 
 /** Parses a NotificationMessage as an instance of type T, and only
   * emits the successfully parsed results.

--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/messaging/SnsPublishFlow.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/messaging/SnsPublishFlow.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.messaging
+package uk.ac.wellcome.platform.archive.archivist.messaging
 
 import akka.NotUsed
 import akka.stream.ActorAttributes
@@ -9,7 +9,7 @@ import grizzled.slf4j.Logging
 import io.circe.Encoder
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.SNSConfig
-import uk.ac.wellcome.platform.archive.common.flows.ProcessLogDiscardFlow
+import uk.ac.wellcome.platform.archive.archivist.flow.ProcessLogDiscardFlow
 
 import scala.util.Try
 

--- a/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/ConvertibleToInputStreamTest.scala
+++ b/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/ConvertibleToInputStreamTest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common
+package uk.ac.wellcome.platform.archive.archivist
 
 import org.scalatest.FunSpec
 import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings

--- a/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/fixtures/ArchiveMessaging.scala
+++ b/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/fixtures/ArchiveMessaging.scala
@@ -1,10 +1,10 @@
-package uk.ac.wellcome.platform.archive.common.fixtures
+package uk.ac.wellcome.platform.archive.archivist.fixtures
 
 import akka.actor.ActorSystem
+import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
-import uk.ac.wellcome.platform.archive.common.messaging.MessageStream
-import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.platform.archive.archivist.messaging.MessageStream
 
 trait ArchiveMessaging extends SQS {
   def withArchiveMessageStream[I, O, R](queue: Queue)(

--- a/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/fixtures/ArchivistFixtures.scala
+++ b/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/fixtures/ArchivistFixtures.scala
@@ -13,7 +13,6 @@ import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.platform.archive.archivist.Archivist
 import uk.ac.wellcome.platform.archive.archivist.generators.BagUploaderConfigGenerators
 import uk.ac.wellcome.platform.archive.common.fixtures.{
-  ArchiveMessaging,
   FileEntry,
   ZipBagItFixture
 }

--- a/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/DiscardLeftFlowTest.scala
+++ b/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/DiscardLeftFlowTest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.flows
+package uk.ac.wellcome.platform.archive.archivist.flow
 
 import akka.stream.scaladsl.{Sink, Source}
 import org.scalatest.concurrent.ScalaFutures

--- a/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/EitherFanOutTest.scala
+++ b/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/EitherFanOutTest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.flows
+package uk.ac.wellcome.platform.archive.archivist.flow
 
 import akka.stream.FlowShape
 import akka.stream.scaladsl.{Flow, GraphDSL, Sink, Source}

--- a/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/LogLeftFlowTest.scala
+++ b/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/LogLeftFlowTest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.flows
+package uk.ac.wellcome.platform.archive.archivist.flow
 
 import akka.stream.scaladsl.{Sink, Source}
 import org.scalatest.{FunSpec, Matchers}

--- a/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/NotificationParsingFlowTest.scala
+++ b/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/NotificationParsingFlowTest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.flows
+package uk.ac.wellcome.platform.archive.archivist.flow
 
 import akka.stream.scaladsl.{Sink, Source}
 import org.scalatest.{FunSpec, Matchers}
@@ -6,7 +6,7 @@ import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.NotificationMessage
-import uk.ac.wellcome.platform.archive.common.messaging.NotificationParsingFlow
+import uk.ac.wellcome.platform.archive.archivist.messaging.NotificationParsingFlow
 
 class NotificationParsingFlowTest
     extends FunSpec

--- a/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/SNSPublishFlowTest.scala
+++ b/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/SNSPublishFlowTest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.flows
+package uk.ac.wellcome.platform.archive.archivist.flow
 
 import akka.stream.scaladsl.{Sink, Source}
 import com.amazonaws.services.sns.model.PublishResult
@@ -9,7 +9,7 @@ import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SNS
 import uk.ac.wellcome.messaging.fixtures.SNS.Topic
-import uk.ac.wellcome.platform.archive.common.messaging.SnsPublishFlow
+import uk.ac.wellcome.platform.archive.archivist.messaging.SnsPublishFlow
 
 class SNSPublishFlowTest
     extends FunSpec

--- a/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ZipFileDownloadFlowTest.scala
+++ b/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ZipFileDownloadFlowTest.scala
@@ -15,13 +15,13 @@ import uk.ac.wellcome.platform.archive.archivist.fixtures.ArchivistFixtures
 import uk.ac.wellcome.platform.archive.archivist.models.FileDownloadComplete
 import uk.ac.wellcome.platform.archive.archivist.models.TypeAliases.BagDownload
 import uk.ac.wellcome.platform.archive.common.config.models.Parallelism
-import uk.ac.wellcome.platform.archive.common.errors.FileDownloadingError
 import uk.ac.wellcome.platform.archive.common.generators.IngestBagRequestGenerators
 import uk.ac.wellcome.platform.archive.common.models.IngestBagRequest
 import uk.ac.wellcome.platform.archive.common.progress.ProgressUpdateAssertions
 import uk.ac.wellcome.platform.archive.common.progress.models.Progress
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.platform.archive.archivist.error.FileDownloadingError
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable

--- a/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/messaging/MessageStreamTest.scala
+++ b/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/messaging/MessageStreamTest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.messaging
+package uk.ac.wellcome.platform.archive.archivist.messaging
 
 import java.util.concurrent.ConcurrentLinkedQueue
 
@@ -14,7 +14,7 @@ import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.Messaging
 import uk.ac.wellcome.messaging.fixtures.SQS.{Queue, QueuePair}
-import uk.ac.wellcome.platform.archive.common.fixtures.ArchiveMessaging
+import uk.ac.wellcome.platform.archive.archivist.fixtures.ArchiveMessaging
 
 class MessageStreamTest
     extends FunSpec

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
@@ -10,7 +10,6 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.Messaging
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.platform.archive.common.fixtures.{
-  ArchiveMessaging,
   BagLocationFixtures,
   RandomThings
 }
@@ -26,8 +25,7 @@ trait BagReplicatorFixtures
     with RandomThings
     with Messaging
     with Akka
-    with BagLocationFixtures
-    with ArchiveMessaging {
+    with BagLocationFixtures {
 
   def withBagNotification[R](
     queue: Queue,

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/BagUnpackerFixtures.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/BagUnpackerFixtures.scala
@@ -12,7 +12,6 @@ import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.platform.archive.bagunpacker.BagUnpacker
 import uk.ac.wellcome.platform.archive.bagunpacker.config.BagUnpackerConfig
 import uk.ac.wellcome.platform.archive.common.fixtures.{
-  ArchiveMessaging,
   BagLocationFixtures,
   RandomThings
 }
@@ -30,8 +29,7 @@ trait BagUnpackerFixtures
     with RandomThings
     with Messaging
     with Akka
-    with BagLocationFixtures
-    with ArchiveMessaging {
+    with BagLocationFixtures {
 
   def withBagNotification[R](
     queue: Queue,

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.archive.bagverifier
 
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.platform.archive.bagreplicator.fixtures.BagVerifierFixtures
+import uk.ac.wellcome.platform.archive.bagverifier.fixtures.BagVerifierFixtures
 import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
 import uk.ac.wellcome.platform.archive.common.progress.ProgressUpdateAssertions
 import uk.ac.wellcome.json.JsonUtil._

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.bagreplicator.fixtures
+package uk.ac.wellcome.platform.archive.bagverifier.fixtures
 
 import java.util.UUID
 
@@ -12,7 +12,6 @@ import uk.ac.wellcome.messaging.sns.NotificationMessage
 import uk.ac.wellcome.platform.archive.bagverifier.BagVerifier
 import uk.ac.wellcome.platform.archive.bagverifier.config.BagVerifierConfig
 import uk.ac.wellcome.platform.archive.common.fixtures.{
-  ArchiveMessaging,
   BagLocationFixtures,
   RandomThings
 }
@@ -25,8 +24,7 @@ trait BagVerifierFixtures
     with RandomThings
     with Messaging
     with Akka
-    with BagLocationFixtures
-    with ArchiveMessaging {
+    with BagLocationFixtures {
 
   def withBagNotification[R](
     queue: Queue,

--- a/common/docker-compose.yml
+++ b/common/docker-compose.yml
@@ -1,12 +1,3 @@
-sns:
-  image: wellcome/fake-sns
-  ports:
-    - "9292:9292"
-sqs:
-  image: s12v/elasticmq
-  ports:
-    - "9324:9324"
-    - "4789:9324"
 s3:
   image: scality/s3server:mem-latest
   ports:


### PR DESCRIPTION
After #60, there's no reason to keep it in the common lib. When we ditch the archivist, we can now delete all this code in one fell swoop.