### PR TITLE
Add code for locating the root of a bag in an S3 location

### DIFF
--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/bag/ArchiveJobCreator.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/bag/ArchiveJobCreator.scala
@@ -41,11 +41,16 @@ object ArchiveJobCreator {
             val bagRootPathInZip =
               ZippedBagFile.bagPathFromBagInfoPath(bagInfoPath)
             val tagManifestLocation = BagItemPath(
-              config.bagItConfig.tagManifestFileName,
-              bagRootPathInZip)
+              itemPath = config.bagItConfig.tagManifestFileName,
+              maybeBagRootPath = bagRootPathInZip
+            )
             val bagManifestLocations = config.bagItConfig.digestNames
-              .map((itemPath: String) =>
-                BagItemPath(itemPath, bagRootPathInZip))
+              .map { itemPath: String =>
+                BagItemPath(
+                  itemPath = itemPath,
+                  maybeBagRootPath = bagRootPathInZip
+                )
+              }
 
             ArchiveJob(
               externalIdentifier = externalIdentifier,

--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/bag/ZippedBagFile.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/bag/ZippedBagFile.scala
@@ -3,20 +3,16 @@ package uk.ac.wellcome.platform.archive.archivist.bag
 import java.util.zip.ZipFile
 
 import uk.ac.wellcome.platform.archive.common.bagit.BagInfoLocator
-import uk.ac.wellcome.platform.archive.common.models.bagit.BagIt
 
 import scala.collection.JavaConverters._
 import scala.util.Try
 
 object ZippedBagFile {
-  private val endsWithBagInfoFilenameRegexp = (BagIt.BagInfoFilename + "$").r
-
-  def bagPathFromBagInfoPath(bagInfo: String): Option[String] = {
-    endsWithBagInfoFilenameRegexp replaceFirstIn (bagInfo, "") match {
+  def bagPathFromBagInfoPath(bagInfo: String): Option[String] =
+    BagInfoLocator.bagPathFrom(bagInfoPath = bagInfo) match {
       case ""        => None
       case s: String => Some(s)
     }
-  }
 
   def locateBagInfo(zipFile: ZipFile): Try[String] = {
     val entries =

--- a/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/bag/ZippedBagFile.scala
+++ b/archivist/src/main/scala/uk/ac/wellcome/platform/archive/archivist/bag/ZippedBagFile.scala
@@ -1,8 +1,8 @@
 package uk.ac.wellcome.platform.archive.archivist.bag
 
-import java.io.FileNotFoundException
 import java.util.zip.ZipFile
 
+import uk.ac.wellcome.platform.archive.common.bagit.BagInfoLocator
 import uk.ac.wellcome.platform.archive.common.models.bagit.BagIt
 
 import scala.collection.JavaConverters._
@@ -18,28 +18,14 @@ object ZippedBagFile {
     }
   }
 
-  def locateBagInfo(zipFile: ZipFile): Try[String] = Try {
-    val entries = zipFile
-      .entries()
-      .asScala
-      .toList
+  def locateBagInfo(zipFile: ZipFile): Try[String] = {
+    val entries =
+      zipFile
+        .entries()
+        .asScala
+        .filterNot { _.isDirectory }
+        .map { _.getName }
 
-    entries
-      .filter { e =>
-        e.getName
-          .split("/")
-          .last == BagIt.BagInfoFilename && !e.isDirectory
-      }
-      .map(_.getName)
-      .toList match {
-      case Seq(bagInfo) =>
-        bagInfo
-      case Seq() =>
-        throw new FileNotFoundException(
-          s"'${BagIt.BagInfoFilename}' not found.")
-      case matchingBagInfoFiles: Seq[_] =>
-        throw new IllegalArgumentException(
-          s"Expected only one '${BagIt.BagInfoFilename}' found $matchingBagInfoFiles.")
-    }
+    BagInfoLocator.locateBagInfo(entries)
   }
 }

--- a/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/ArchivistFeatureTest.scala
+++ b/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/ArchivistFeatureTest.scala
@@ -427,14 +427,14 @@ class ArchivistFeatureTest
                   assertTopicReceivesFailedProgress(
                     requestId = invalidRequest1.id,
                     expectedDescription =
-                      "Failed to identify bag in zip file, 'bag-info.txt' not found.",
+                      "Failed to identify bag in zip file, No bag-info.txt file found!",
                     progressTopic = progressTopic
                   )
 
                   assertTopicReceivesFailedProgress(
                     requestId = invalidRequest2.id,
                     expectedDescription =
-                      "Failed to identify bag in zip file, 'bag-info.txt' not found.",
+                      "Failed to identify bag in zip file, No bag-info.txt file found!",
                     progressTopic = progressTopic
                   )
                 }

--- a/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/bag/ZippedBagFileTest.scala
+++ b/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/bag/ZippedBagFileTest.scala
@@ -49,7 +49,7 @@ class ZippedBagFileTest
           .failure
           .exception
           .getMessage shouldBe
-          "Expected only one 'bag-info.txt' found List(bag-info.txt, bag/bag-info.txt)."
+          "Multiple bag-info.txt files found, only wanted one: bag-info.txt, bag/bag-info.txt"
       }
     }
   }

--- a/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveZipFileFlowTest.scala
+++ b/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveZipFileFlowTest.scala
@@ -162,7 +162,7 @@ class ArchiveZipFileFlowTest
 
               whenReady(verification) { result =>
                 result shouldBe List(Left(
-                  BagNotFoundError("'bag-info.txt' not found.", ingestContext)))
+                  BagNotFoundError("No bag-info.txt file found!", ingestContext)))
 
                 assertTopicReceivesProgressStatusUpdate(
                   ingestContext.id,

--- a/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveZipFileFlowTest.scala
+++ b/archivist/src/test/scala/uk/ac/wellcome/platform/archive/archivist/flow/ArchiveZipFileFlowTest.scala
@@ -161,8 +161,10 @@ class ArchiveZipFileFlowTest
                   Sink.seq)
 
               whenReady(verification) { result =>
-                result shouldBe List(Left(
-                  BagNotFoundError("No bag-info.txt file found!", ingestContext)))
+                result shouldBe List(
+                  Left(BagNotFoundError(
+                    "No bag-info.txt file found!",
+                    ingestContext)))
 
                 assertTopicReceivesProgressStatusUpdate(
                   ingestContext.id,

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/BagInfoLocator.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/BagInfoLocator.scala
@@ -9,6 +9,9 @@ import scala.util.Try
   * by the presence of a "/bag-info.txt" file.
   */
 object BagInfoLocator {
+  private val bagInfoFilename = "bag-info.txt"
+  private val endsWithBagInfoFilenameRegexp = (bagInfoFilename + "$").r
+
   def locateBagInfo(filenames: Iterator[String]): Try[String] = Try {
     val matching =
       filenames
@@ -16,16 +19,19 @@ object BagInfoLocator {
           f
             .split("/")
             .last
-            .endsWith("bag-info.txt")
+            .endsWith(bagInfoFilename)
         }
         .toSeq
 
     matching match {
       case Seq(filename) => filename
-      case Seq() => throw new FileNotFoundException("No bag-info.txt file found!")
+      case Seq() => throw new FileNotFoundException(s"No $bagInfoFilename file found!")
       case _ => throw new IllegalArgumentException(
-        s"Multiple bag-info.txt files found, only wanted one: ${matching.mkString(", ")}"
+        s"Multiple $bagInfoFilename files found, only wanted one: ${matching.mkString(", ")}"
       )
     }
   }
+
+  def bagPathFrom(bagInfoPath: String): String =
+    endsWithBagInfoFilenameRegexp.replaceFirstIn(bagInfoPath, "")
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/BagInfoLocator.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/BagInfoLocator.scala
@@ -1,0 +1,31 @@
+package uk.ac.wellcome.platform.archive.common.bagit
+
+import java.io.FileNotFoundException
+
+import scala.util.Try
+
+/** Sometimes we get told "there's a bag at this location" but it's not at
+  * the root.  We need to find the root of the bag, which we can detect
+  * by the presence of a "/bag-info.txt" file.
+  */
+object BagInfoLocator {
+  def locateBagInfo(filenames: Iterator[String]): Try[String] = Try {
+    val matching =
+      filenames
+        .filter { f: String =>
+          f
+            .split("/")
+            .last
+            .endsWith("bag-info.txt")
+        }
+        .toSeq
+
+    matching match {
+      case Seq(filename) => filename
+      case Seq() => throw new FileNotFoundException("No bag-info.txt file found!")
+      case _ => throw new IllegalArgumentException(
+        s"Multiple bag-info.txt files found, only wanted one: ${matching.mkString(", ")}"
+      )
+    }
+  }
+}

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/BagInfoLocator.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/BagInfoLocator.scala
@@ -14,21 +14,20 @@ object BagInfoLocator {
 
   def locateBagInfo(filenames: Iterator[String]): Try[String] = Try {
     val matching =
-      filenames
-        .filter { f: String =>
-          f
-            .split("/")
-            .last
-            .endsWith(bagInfoFilename)
-        }
-        .toSeq
+      filenames.filter { f: String =>
+        f.split("/")
+          .last
+          .endsWith(bagInfoFilename)
+      }.toSeq
 
     matching match {
       case Seq(filename) => filename
-      case Seq() => throw new FileNotFoundException(s"No $bagInfoFilename file found!")
-      case _ => throw new IllegalArgumentException(
-        s"Multiple $bagInfoFilename files found, only wanted one: ${matching.mkString(", ")}"
-      )
+      case Seq() =>
+        throw new FileNotFoundException(s"No $bagInfoFilename file found!")
+      case _ =>
+        throw new IllegalArgumentException(
+          s"Multiple $bagInfoFilename files found, only wanted one: ${matching.mkString(", ")}"
+        )
     }
   }
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/S3BagFile.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/S3BagFile.scala
@@ -1,0 +1,26 @@
+package uk.ac.wellcome.platform.archive.common.bagit
+
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.iterable.S3Objects
+import uk.ac.wellcome.storage.ObjectLocation
+
+import scala.collection.JavaConverters._
+import scala.util.Try
+
+class S3BagFile(s3Client: AmazonS3, batchSize: Int = 1000) {
+  def locateBagInfo(objectLocation: ObjectLocation): Try[String] = {
+    val keys =
+      S3Objects
+        .withPrefix(
+          s3Client,
+          objectLocation.namespace,
+          objectLocation.key
+        )
+        .withBatchSize(batchSize)
+        .iterator()
+        .asScala
+        .map { _.getKey }
+
+    BagInfoLocator.locateBagInfo(keys)
+  }
+}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/BagInfoLocatorTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/BagInfoLocatorTest.scala
@@ -9,12 +9,15 @@ import scala.util.Success
 class BagInfoLocatorTest extends FunSpec with Matchers {
   describe("locateBagInfo") {
     it("detects a bag-info.txt file") {
-      val filenames = Seq("/foo/README.txt", "/foo/data", "/foo/bag-info.txt").toIterator
-      BagInfoLocator.locateBagInfo(filenames) shouldBe Success("/foo/bag-info.txt")
+      val filenames =
+        Seq("/foo/README.txt", "/foo/data", "/foo/bag-info.txt").toIterator
+      BagInfoLocator.locateBagInfo(filenames) shouldBe Success(
+        "/foo/bag-info.txt")
     }
 
     it("detects a bag-info.txt file without a leading slash") {
-      val filenames = Seq("/foo/README.txt", "/foo/data", "bag-info.txt").toIterator
+      val filenames =
+        Seq("/foo/README.txt", "/foo/data", "bag-info.txt").toIterator
       BagInfoLocator.locateBagInfo(filenames) shouldBe Success("bag-info.txt")
     }
 
@@ -33,7 +36,8 @@ class BagInfoLocatorTest extends FunSpec with Matchers {
       val result = BagInfoLocator.locateBagInfo(filenames.toIterator)
       result.isFailure shouldBe true
       result.failed.get shouldBe a[IllegalArgumentException]
-      result.failed.get.getMessage shouldBe s"Multiple bag-info.txt files found, only wanted one: ${filenames.mkString(", ")}"
+      result.failed.get.getMessage shouldBe s"Multiple bag-info.txt files found, only wanted one: ${filenames
+        .mkString(", ")}"
     }
   }
 
@@ -48,7 +52,8 @@ class BagInfoLocatorTest extends FunSpec with Matchers {
       }
 
       it("ignores bag-info.txt not at the end") {
-        BagInfoLocator.bagPathFrom(bagInfoPath = "bag-info.txt/bag/bag-info.txt") shouldBe "bag-info.txt/bag/"
+        BagInfoLocator.bagPathFrom(
+          bagInfoPath = "bag-info.txt/bag/bag-info.txt") shouldBe "bag-info.txt/bag/"
       }
 
       it("preserves preceding slashes") {

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/BagInfoLocatorTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/BagInfoLocatorTest.scala
@@ -7,31 +7,57 @@ import org.scalatest.{FunSpec, Matchers}
 import scala.util.Success
 
 class BagInfoLocatorTest extends FunSpec with Matchers {
-  it("detects a bag-info.txt file") {
-    val filenames = Seq("/foo/README.txt", "/foo/data", "/foo/bag-info.txt").toIterator
-    BagInfoLocator.locateBagInfo(filenames) shouldBe Success("/foo/bag-info.txt")
+  describe("locateBagInfo") {
+    it("detects a bag-info.txt file") {
+      val filenames = Seq("/foo/README.txt", "/foo/data", "/foo/bag-info.txt").toIterator
+      BagInfoLocator.locateBagInfo(filenames) shouldBe Success("/foo/bag-info.txt")
+    }
+
+    it("detects a bag-info.txt file without a leading slash") {
+      val filenames = Seq("/foo/README.txt", "/foo/data", "bag-info.txt").toIterator
+      BagInfoLocator.locateBagInfo(filenames) shouldBe Success("bag-info.txt")
+    }
+
+    it("throws an exception if it can't find a bag-info.txt file") {
+      val filenames = Seq("/foo/README.txt", "/foo/data").toIterator
+
+      val result = BagInfoLocator.locateBagInfo(filenames)
+      result.isFailure shouldBe true
+      result.failed.get shouldBe a[FileNotFoundException]
+      result.failed.get.getMessage shouldBe "No bag-info.txt file found!"
+    }
+
+    it("throws an exception if it finds multiple bag-info.txt files") {
+      val filenames = Seq("/foo/bag-info.txt", "/bar/bag-info.txt")
+
+      val result = BagInfoLocator.locateBagInfo(filenames.toIterator)
+      result.isFailure shouldBe true
+      result.failed.get shouldBe a[IllegalArgumentException]
+      result.failed.get.getMessage shouldBe s"Multiple bag-info.txt files found, only wanted one: ${filenames.mkString(", ")}"
+    }
   }
 
-  it("detects a bag-info.txt file without a leading slash") {
-    val filenames = Seq("/foo/README.txt", "/foo/data", "bag-info.txt").toIterator
-    BagInfoLocator.locateBagInfo(filenames) shouldBe Success("bag-info.txt")
-  }
+  describe("bagPathFrom") {
+    describe("bagPathFromBagInfoPath") {
+      it("returns an empty string if there is no enclosing bag directory") {
+        BagInfoLocator.bagPathFrom(bagInfoPath = "bag-info.txt") shouldBe ""
+      }
 
-  it("throws an exception if it can't find a bag-info.txt file") {
-    val filenames = Seq("/foo/README.txt", "/foo/data").toIterator
+      it("finds the bag path when in a parent directory") {
+        BagInfoLocator.bagPathFrom(bagInfoPath = "bag/bag-info.txt") shouldBe "bag/"
+      }
 
-    val result = BagInfoLocator.locateBagInfo(filenames)
-    result.isFailure shouldBe true
-    result.failed.get shouldBe a[FileNotFoundException]
-    result.failed.get.getMessage shouldBe "No bag-info.txt file found!"
-  }
+      it("ignores bag-info.txt not at the end") {
+        BagInfoLocator.bagPathFrom(bagInfoPath = "bag-info.txt/bag/bag-info.txt") shouldBe "bag-info.txt/bag/"
+      }
 
-  it("throws an exception if it finds multiple bag-info.txt files") {
-    val filenames = Seq("/foo/bag-info.txt", "/bar/bag-info.txt")
+      it("preserves preceding slashes") {
+        BagInfoLocator.bagPathFrom(bagInfoPath = "/bag/bag-info.txt") shouldBe "/bag/"
+      }
 
-    val result = BagInfoLocator.locateBagInfo(filenames.toIterator)
-    result.isFailure shouldBe true
-    result.failed.get shouldBe a[IllegalArgumentException]
-    result.failed.get.getMessage shouldBe s"Multiple bag-info.txt files found, only wanted one: ${filenames.mkString(", ")}"
+      it("preserves preceding slashes even if bag-info.txt is at the root") {
+        BagInfoLocator.bagPathFrom(bagInfoPath = "/bag-info.txt") shouldBe "/"
+      }
+    }
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/BagInfoLocatorTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/BagInfoLocatorTest.scala
@@ -1,0 +1,37 @@
+package uk.ac.wellcome.platform.archive.common.bagit
+
+import java.io.FileNotFoundException
+
+import org.scalatest.{FunSpec, Matchers}
+
+import scala.util.Success
+
+class BagInfoLocatorTest extends FunSpec with Matchers {
+  it("detects a bag-info.txt file") {
+    val filenames = Seq("/foo/README.txt", "/foo/data", "/foo/bag-info.txt").toIterator
+    BagInfoLocator.locateBagInfo(filenames) shouldBe Success("/foo/bag-info.txt")
+  }
+
+  it("detects a bag-info.txt file without a leading slash") {
+    val filenames = Seq("/foo/README.txt", "/foo/data", "bag-info.txt").toIterator
+    BagInfoLocator.locateBagInfo(filenames) shouldBe Success("bag-info.txt")
+  }
+
+  it("throws an exception if it can't find a bag-info.txt file") {
+    val filenames = Seq("/foo/README.txt", "/foo/data").toIterator
+
+    val result = BagInfoLocator.locateBagInfo(filenames)
+    result.isFailure shouldBe true
+    result.failed.get shouldBe a[FileNotFoundException]
+    result.failed.get.getMessage shouldBe "No bag-info.txt file found!"
+  }
+
+  it("throws an exception if it finds multiple bag-info.txt files") {
+    val filenames = Seq("/foo/bag-info.txt", "/bar/bag-info.txt")
+
+    val result = BagInfoLocator.locateBagInfo(filenames.toIterator)
+    result.isFailure shouldBe true
+    result.failed.get shouldBe a[IllegalArgumentException]
+    result.failed.get.getMessage shouldBe s"Multiple bag-info.txt files found, only wanted one: ${filenames.mkString(", ")}"
+  }
+}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/S3BagFileTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/S3BagFileTest.scala
@@ -1,0 +1,84 @@
+package uk.ac.wellcome.platform.archive.common.bagit
+
+import com.amazonaws.services.s3.model.PutObjectResult
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
+import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.fixtures.S3
+import uk.ac.wellcome.storage.fixtures.S3.Bucket
+
+import scala.util.Success
+
+class S3BagFileTest extends FunSpec with Matchers with RandomThings with S3 {
+  val s3BagFile = new S3BagFile(s3Client = s3Client, batchSize = 10)
+
+  it("detects a bag-info.txt in an S3 bucket") {
+    withLocalS3Bucket { bucket =>
+      putObject(bucket)
+      putObject(bucket)
+      putObject(bucket, key = "/foo/bag-info.txt")
+
+      s3BagFile.locateBagInfo(
+        objectLocation = ObjectLocation(
+          namespace = bucket.name,
+          key = "/"
+        )
+      ) shouldBe Success("/foo/bag-info.txt")
+
+      s3BagFile.locateBagInfo(
+        objectLocation = ObjectLocation(
+          namespace = bucket.name,
+          key = "/foo"
+        )
+      ) shouldBe Success("/foo/bag-info.txt")
+    }
+  }
+
+  it("ignores a bag-info.txt in a different prefix") {
+    withLocalS3Bucket { bucket =>
+      putObject(bucket)
+      putObject(bucket)
+      putObject(bucket, key = "/foo/bag-info.txt")
+      putObject(bucket, key = "/bar/bag-info.txt")
+
+      s3BagFile.locateBagInfo(
+        objectLocation = ObjectLocation(
+          namespace = bucket.name,
+          key = "/bar"
+        )
+      ) shouldBe Success("/bar/bag-info.txt")
+    }
+  }
+
+  it("errors if it cannot find a bag-info.txt") {
+    withLocalS3Bucket { bucket =>
+      putObject(bucket)
+      putObject(bucket)
+      putObject(bucket, key = "/foo/bag-info.txt")
+
+      s3BagFile.locateBagInfo(
+        objectLocation = ObjectLocation(
+          namespace = bucket.name,
+          key = "/bar"
+        )
+      ).isFailure shouldBe true
+    }
+  }
+  
+  it("looks through the entire bag, even if it's bigger than the batch size") {
+    withLocalS3Bucket { bucket =>
+      (1 to 20).foreach { _ => putObject(bucket) }
+      putObject(bucket, key = "/foo/bag-info.txt")
+
+      s3BagFile.locateBagInfo(
+        objectLocation = ObjectLocation(
+          namespace = bucket.name,
+          key = "/"
+        )
+      ) shouldBe Success("/foo/bag-info.txt")
+    }
+  }
+
+  private def putObject(bucket: Bucket, key: String = randomAlphanumeric()): PutObjectResult =
+    s3Client.putObject(bucket.name, key, randomAlphanumeric())
+}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/S3BagFileTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/S3BagFileTest.scala
@@ -56,18 +56,22 @@ class S3BagFileTest extends FunSpec with Matchers with RandomThings with S3 {
       putObject(bucket)
       putObject(bucket, key = "/foo/bag-info.txt")
 
-      s3BagFile.locateBagInfo(
-        objectLocation = ObjectLocation(
-          namespace = bucket.name,
-          key = "/bar"
+      s3BagFile
+        .locateBagInfo(
+          objectLocation = ObjectLocation(
+            namespace = bucket.name,
+            key = "/bar"
+          )
         )
-      ).isFailure shouldBe true
+        .isFailure shouldBe true
     }
   }
-  
+
   it("looks through the entire bag, even if it's bigger than the batch size") {
     withLocalS3Bucket { bucket =>
-      (1 to 20).foreach { _ => putObject(bucket) }
+      (1 to 20).foreach { _ =>
+        putObject(bucket)
+      }
       putObject(bucket, key = "/foo/bag-info.txt")
 
       s3BagFile.locateBagInfo(
@@ -79,6 +83,7 @@ class S3BagFileTest extends FunSpec with Matchers with RandomThings with S3 {
     }
   }
 
-  private def putObject(bucket: Bucket, key: String = randomAlphanumeric()): PutObjectResult =
+  private def putObject(bucket: Bucket,
+                        key: String = randomAlphanumeric()): PutObjectResult =
     s3Client.putObject(bucket.name, key, randomAlphanumeric())
 }


### PR DESCRIPTION
This patch puts the code for detecting the bag-info.txt in a list of filenames in a pure, in-memory class, and then we can call it for either ZIP files in the archivist or S3 objects more generally.