### PR TITLE
Use hashed data structures to improve bagger performance

### DIFF
--- a/bagger/src/bagger.py
+++ b/bagger/src/bagger.py
@@ -41,7 +41,7 @@ def bag_from_identifier(identifier, skip_file_download):
     root = tree.getroot()
     title = mets.get_title(root)
 
-    logging.info("-> started bagging {0}: {1}".format(b_number, title))
+    logging.info("-> started bagging %s: %s", b_number, title)
     logging.debug(
         "We will transform xml that involves Preservica, and the tessella namespace"
     )
@@ -55,8 +55,8 @@ def bag_from_identifier(identifier, skip_file_download):
     struct_type = struct_div.get("TYPE")
     struct_label = struct_div.get("LABEL")
 
-    logging.debug("Found structDiv with TYPE " + struct_type)
-    logging.debug("LABEL: " + struct_label)
+    logging.debug("Found structDiv with TYPE %s", struct_type)
+    logging.debug("LABEL: %s", struct_label)
 
     root_mets_file = os.path.join(bag_details["directory"], "{0}.xml".format(b_number))
 
@@ -78,7 +78,7 @@ def bag_from_identifier(identifier, skip_file_download):
             assert int(order) > 0, "ORDER {0} <= 0".format(order)  # can it be 0?
             assert len(div) == 1, "one and only one child element"
             file_pointer_href = mets.get_file_pointer_link(div)
-            logging.debug("link to manifestation file: " + file_pointer_href)
+            logging.debug("link to manifestation file: %s", file_pointer_href)
             manifestation_relative_paths.append((file_pointer_href, order))
 
         # TODO - we have stored the order, we could validate that the manifestation files match this order
@@ -89,18 +89,18 @@ def bag_from_identifier(identifier, skip_file_download):
         # then go through the linked files _0001 etc
         for rel_path in manifestation_relative_paths:
             full_path = bag_details["mets_partial_path"] + rel_path[0]
-            logging.debug("loading manifestation " + full_path)
-            logging.debug("ORDER: {0}".format(rel_path[1]))
+            logging.debug("loading manifestation %s", full_path)
+            logging.debug("ORDER: %s", rel_path[1])
             mf_tree = load_xml(full_path)
             mf_root = mf_tree.getroot()
             manif_struct_div = mets.get_logical_struct_div(mf_root)
             link_to_anchor = mets.get_file_pointer_link(manif_struct_div)
-            logging.debug("{0} should be link back to anchor".format(link_to_anchor))
+            logging.debug("%s should be link back to anchor", link_to_anchor)
             process_manifestation(mf_root, bag_details, skip_file_download, id_map)
             # not os separator, this is in the METS; always /
             parts = rel_path[0].split("/")
             manifestation_file = os.path.join(bag_details["directory"], *parts)
-            logging.debug("writing manifestation to bag: " + manifestation_file)
+            logging.debug("writing manifestation to bag: %s", manifestation_file)
             mf_tree.write(manifestation_file, encoding="utf-8", xml_declaration=True)
             aws.save_mets_to_side(b_number, manifestation_file)
 

--- a/bagger/src/files.py
+++ b/bagger/src/files.py
@@ -159,7 +159,9 @@ def process_assets(root, bag_details, assets, skip_file_download):
             bucket_key = origin_info["bucket_key"]
             logging.debug(
                 "Downloading object from bucket %s/%s to %s",
-                bucket_name, bucket_key, destination
+                bucket_name,
+                bucket_key,
+                destination,
             )
             try:
                 source_bucket.download_file(bucket_key, destination)
@@ -169,7 +171,8 @@ def process_assets(root, bag_details, assets, skip_file_download):
                 if ce.response["Error"]["Code"] == "NoSuchKey" and alt_key is not None:
                     logging.debug(
                         "key %s not found, trying alternate key: %s",
-                        bucket_key, alt_key
+                        bucket_key,
+                        alt_key,
                     )
                     source_bucket.download_file(alt_key, destination)
                     asset_downloaded = True

--- a/bagger/src/files.py
+++ b/bagger/src/files.py
@@ -64,7 +64,7 @@ def process_alto(root, bag_details, alto, skip_file_download):
     alto_file_group = root.find("./mets:fileSec/mets:fileGrp[@USE='ALTO']", namespaces)
 
     if alto_file_group is None:
-        logging.debug("No ALTO for " + b_number)
+        logging.debug("No ALTO for %s", b_number)
         return
 
     source_bucket = None
@@ -112,7 +112,7 @@ def get_flattened_destination(file_element, keys, folder, bag_details):
     keys.add(file_name)  # let this raise error if duplicate
     desired_relative_location = "{0}/{1}".format(folder, file_name)
     locator.set(expand("xlink", "href"), desired_relative_location)
-    logging.debug("updated path in METS to " + desired_relative_location)
+    logging.debug("updated path in METS to %s", desired_relative_location)
     # the local temp assembly area
     destination = os.path.join(bag_details["directory"], folder, file_name)
     bag_assembly.ensure_directory(destination)
@@ -120,7 +120,7 @@ def get_flattened_destination(file_element, keys, folder, bag_details):
 
 
 def process_assets(root, bag_details, assets, skip_file_download):
-    logging.debug("Collecting assets for " + bag_details["b_number"])
+    logging.debug("Collecting assets for %s", bag_details["b_number"])
 
     chunk_size = 1024 * 1024
 
@@ -139,15 +139,15 @@ def process_assets(root, bag_details, assets, skip_file_download):
         checksum = file_element.get("CHECKSUM")
         file_element.attrib.pop("CHECKSUM")  # don't need it now
         pres_uuid = tech_md["uuid"]
-        logging.debug("Need to determine where to get {0} from.".format(pres_uuid))
+        logging.debug("Need to determine where to get %s from.", pres_uuid)
 
         if skip_file_download:
-            logging.debug("Skipping processing file {0}".format(pres_uuid))
+            logging.debug("Skipping processing file %s", pres_uuid)
             continue
 
         image_info = dlcs.get_image(pres_uuid)
         origin = image_info.get("origin", None)
-        logging.debug("DLCS reports origin " + str(origin))
+        logging.debug("DLCS reports origin %s", origin)
         # if the origin is wellcomelibrary.org, the object is LIKELY to be in the DLCS's
         # storage bucket. So we should try that first, then fall back to the wellcomelibrary
         # origin (using the creds) if for whatever reason it isn't in the DLCS bucket.
@@ -158,9 +158,8 @@ def process_assets(root, bag_details, assets, skip_file_download):
             source_bucket = aws.get_s3().Bucket(bucket_name)
             bucket_key = origin_info["bucket_key"]
             logging.debug(
-                "Downloading object from bucket {0}/{1} to {2}".format(
-                    bucket_name, bucket_key, destination
-                )
+                "Downloading object from bucket %s/%s to %s",
+                bucket_name, bucket_key, destination
             )
             try:
                 source_bucket.download_file(bucket_key, destination)
@@ -169,9 +168,8 @@ def process_assets(root, bag_details, assets, skip_file_download):
                 alt_key = origin_info["alt_key"]
                 if ce.response["Error"]["Code"] == "NoSuchKey" and alt_key is not None:
                     logging.debug(
-                        "key {0} not found, trying alternate key: {1}".format(
-                            bucket_key, alt_key
-                        )
+                        "key %s not found, trying alternate key: %s",
+                        bucket_key, alt_key
                     )
                     source_bucket.download_file(alt_key, destination)
                     asset_downloaded = True
@@ -199,5 +197,5 @@ def process_assets(root, bag_details, assets, skip_file_download):
         message = "Unable to find asset {0}".format(pres_uuid)
         assert asset_downloaded, message
 
-        logging.debug("TODO: doing checksums on " + destination)
-        logging.debug("validate " + checksum)
+        logging.debug("TODO: doing checksums on %s", destination)
+        logging.debug("validate %s", checksum)

--- a/bagger/src/local_bag_all.py
+++ b/bagger/src/local_bag_all.py
@@ -37,7 +37,7 @@ def main():
         start = time.time()
         counter = 0
         for b_number in bnumber_generator(filter):
-            logging.debug("processing " + b_number)
+            logging.debug("processing %s", b_number)
             message = {"identifier": b_number, "do_not_bag": skip}
             result = bagger_processor.process_bagging_message(message)
             error = result.get("error", None)

--- a/bagger/src/local_enqueue.py
+++ b/bagger/src/local_enqueue.py
@@ -46,7 +46,7 @@ def main():
 
         for b_number in bnumber_generator(to_process):
             counter = counter + 1
-            logging.debug("processing " + b_number)
+            logging.debug("processing %s", b_number)
             message = {
                 "identifier": b_number,
                 "bagger_batch_id": batch_id,

--- a/bagger/src/mappings.py
+++ b/bagger/src/mappings.py
@@ -38,13 +38,13 @@ SIGNIFICANT_PROPERTIES = {
 
 # Do not transform any of these file properties.
 # If a file property is encountered that isn't in either list, an error will be raised.
-IGNORED_PROPERTIES = [
+IGNORED_PROPERTIES = set([
     "Creation Date",
     "Number of Images",
     "Bits Per Sample",
     "Samples Per Pixel",
-]
+])
 
-IGNORED_TECHMD_FILENAMES = ["thumbs.db"]
+IGNORED_TECHMD_FILENAMES = set(["thumbs.db"])
 
 CHECKSUM_ALGORITHMS = {"2": "SHA-1"}

--- a/bagger/src/mappings.py
+++ b/bagger/src/mappings.py
@@ -38,12 +38,9 @@ SIGNIFICANT_PROPERTIES = {
 
 # Do not transform any of these file properties.
 # If a file property is encountered that isn't in either list, an error will be raised.
-IGNORED_PROPERTIES = set([
-    "Creation Date",
-    "Number of Images",
-    "Bits Per Sample",
-    "Samples Per Pixel",
-])
+IGNORED_PROPERTIES = set(
+    ["Creation Date", "Number of Images", "Bits Per Sample", "Samples Per Pixel"]
+)
 
 IGNORED_TECHMD_FILENAMES = set(["thumbs.db"])
 

--- a/bagger/src/mets.py
+++ b/bagger/src/mets.py
@@ -4,9 +4,13 @@ import mappings
 
 # Borrowed from Dds.Dashboard, LogicalStructDiv impl
 
-collection_types = ["MultipleManifestation", "Periodical", "PeriodicalVolume"]
+collection_types = set([
+    "MultipleManifestation",
+    "Periodical",
+    "PeriodicalVolume",
+])
 
-manifestation_types = [
+manifestation_types = set([
     "Monograph",
     "Archive",
     "Artwork",
@@ -19,7 +23,7 @@ manifestation_types = [
     "MultipleVolumeMultipleCopy",
     "Audio",
     "Map",
-]
+])
 
 
 def is_collection(struct_type):
@@ -95,7 +99,7 @@ the AMD to start at _0001
     amd_sec.remove(amd_sec[0])
 
     counter = 1
-    ignore = ["RIGHTS", "DIGIPROV"]
+    ignore = set(["RIGHTS", "DIGIPROV"])
     for tech_md in amd_sec:
         old_id = tech_md.get("ID")
         if old_id in ignore:

--- a/bagger/src/mets.py
+++ b/bagger/src/mets.py
@@ -60,7 +60,7 @@ def get_file_pointer_link(struct_div):
         link = link + ".xml"
         struct_div[0].set(xlink_href, link)
 
-    logging.debug("obtained link from pointer: " + link)
+    logging.debug("obtained link from pointer: %s", link)
     return link
 
 
@@ -166,16 +166,16 @@ def get_physical_file_maps(root):
 
     tech_file_infos = {}
     amds = root.find("./mets:amdSec[@ID='AMD']", namespaces)
-    logging.debug("{0} tech mds to process".format(len(amds)))
+    logging.debug("%d tech mds to process", len(amds))
     for tech_md in amds:
         adm_id = tech_md.get("ID")
         premis_object = tech_md.find(".//premis:object", namespaces)
         if premis_object is None:
-            logging.debug("No premis:object element for " + adm_id)
+            logging.debug("No premis:object element for %s", adm_id)
 
         else:
             adm_id = tech_md.get("ID")
-            logging.debug("adding " + adm_id + " to map")
+            logging.debug("adding %s to map")
             uuid_el = premis_object.find(
                 "./premis:objectIdentifier[premis:objectIdentifierType='uuid']",
                 namespaces,

--- a/bagger/src/mets.py
+++ b/bagger/src/mets.py
@@ -4,26 +4,24 @@ import mappings
 
 # Borrowed from Dds.Dashboard, LogicalStructDiv impl
 
-collection_types = set([
-    "MultipleManifestation",
-    "Periodical",
-    "PeriodicalVolume",
-])
+collection_types = set(["MultipleManifestation", "Periodical", "PeriodicalVolume"])
 
-manifestation_types = set([
-    "Monograph",
-    "Archive",
-    "Artwork",
-    "Manuscript",
-    "PeriodicalIssue",
-    "Video",
-    "Transcript",
-    "MultipleVolume",
-    "MultipleCopy",
-    "MultipleVolumeMultipleCopy",
-    "Audio",
-    "Map",
-])
+manifestation_types = set(
+    [
+        "Monograph",
+        "Archive",
+        "Artwork",
+        "Manuscript",
+        "PeriodicalIssue",
+        "Video",
+        "Transcript",
+        "MultipleVolume",
+        "MultipleCopy",
+        "MultipleVolumeMultipleCopy",
+        "Audio",
+        "Map",
+    ]
+)
 
 
 def is_collection(struct_type):

--- a/bagger/src/tech_md.py
+++ b/bagger/src/tech_md.py
@@ -53,7 +53,7 @@ def remodel_file_technical_metadata(root, id_map):
                 add_premis_significant_prop(premis_file, premis_name, value)
             except KeyError:
                 if name in mappings.IGNORED_PROPERTIES:
-                    logging.debug("Ignoring property name {0}".format(name))
+                    logging.debug("Ignoring property name %s", name)
                 else:
                     message = "Unknown file property: {0}".format(name)
                     raise ValueError(message)

--- a/bagger/src/tech_md.py
+++ b/bagger/src/tech_md.py
@@ -42,20 +42,21 @@ def remodel_file_technical_metadata(root, id_map):
         id_map[uuid] = file_name
 
         file_properties = tessella_file.findall("tessella:FileProperty", namespaces)
-        to_copy = mappings.SIGNIFICANT_PROPERTIES.keys()
         for file_property in file_properties:
             name = file_property.find(
                 "tessella:FilePropertyName", namespaces
             ).text.strip()
-            if name in to_copy:
-                value = file_property.find("tessella:Value", namespaces).text.strip()
+
+            try:
                 premis_name = mappings.SIGNIFICANT_PROPERTIES[name]
+                value = file_property.find("tessella:Value", namespaces).text.strip()
                 add_premis_significant_prop(premis_file, premis_name, value)
-            elif name in mappings.IGNORED_PROPERTIES:
-                logging.debug("Ignoring property name {0}".format(name))
-            else:
-                message = "Unknown file property: {0}".format(name)
-                raise ValueError(message)
+            except KeyError:
+                if name in mappings.IGNORED_PROPERTIES:
+                    logging.debug("Ignoring property name {0}".format(name))
+                else:
+                    message = "Unknown file property: {0}".format(name)
+                    raise ValueError(message)
 
         characteristics = make_child(premis_file, "premis", "objectCharacteristics")
         composition_level = make_child(characteristics, "premis", "compositionLevel")


### PR DESCRIPTION
In Python, there's a big penalty for doing lookups in lists:

- `x in list(foo)` is O(n) in the length of the list
- `x in set(foo)` or `x in dict(foo)` is O(1)

By converting a couple of internal data structures to sets/dicts, we should make the bagger go a bit faster. How much faster? No idea, this is just picking some really low-hanging fruit.

(But for comparison, changing the data structures took the time to compute the destinations of ~400k Miro records from ~90 minutes to ~3 minutes, so it might help!)