### PR TITLE
Fix directory handling in unpacker

### DIFF
--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
@@ -18,9 +18,9 @@ import scala.concurrent.{ExecutionContext, Future}
 class Unpacker(implicit s3Client: AmazonS3, ec: ExecutionContext) {
 
   def unpack(
-              srcLocation: ObjectLocation,
-              dstLocation: ObjectLocation
-            ): Future[OperationResult[UnpackSummary]] = {
+    srcLocation: ObjectLocation,
+    dstLocation: ObjectLocation
+  ): Future[OperationResult[UnpackSummary]] = {
 
     val unpackSummary =
       UnpackSummary(startTime = Instant.now)
@@ -31,7 +31,6 @@ class Unpacker(implicit s3Client: AmazonS3, ec: ExecutionContext) {
         (summary: UnpackSummary,
          inputStream: InputStream,
          archiveEntry: ArchiveEntry) =>
-
           if (!archiveEntry.isDirectory) {
             val archiveEntrySize = putObject(
               inputStream,
@@ -54,10 +53,10 @@ class Unpacker(implicit s3Client: AmazonS3, ec: ExecutionContext) {
   }
 
   private def putObject(
-                         inputStream: InputStream,
-                         archiveEntry: ArchiveEntry,
-                         destination: ObjectLocation
-                       ) = {
+    inputStream: InputStream,
+    archiveEntry: ArchiveEntry,
+    destination: ObjectLocation
+  ) = {
 
     val metadata = new ObjectMetadata()
     val archiveEntrySize = archiveEntry.getSize

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
@@ -78,6 +78,7 @@ class Unpacker(implicit s3Client: AmazonS3, ec: ExecutionContext) {
             destination.key,
             archiveEntry.getName
           )
+          .normalize()
           .toString,
         inputStream,
         metadata

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/CompressFixture.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/CompressFixture.scala
@@ -95,10 +95,13 @@ trait CompressFixture extends RandomThings with S3 with Logging {
     (file, randomFiles, entries)
   }
 
-  def relativeToTmpDir(file: File) =
-    (new File(tmpDir).toURI)
+  def relativeToTmpDir(file: File) = {
+    val path = (new File(tmpDir).toURI)
       .relativize(file.toURI)
       .getPath
+
+    s"./$path"
+  }
 
   class Archive(
     archiverName: String,

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTest.scala
@@ -74,9 +74,11 @@ class UnpackerTest
             testArchive.containedFiles.map { file =>
               val fis = new FileInputStream(file)
               val content = IOUtils.toByteArray(fis)
-              val name = Paths.get(relativeToTmpDir(file))
-                .normalize().toString
-              
+              val name = Paths
+                .get(relativeToTmpDir(file))
+                .normalize()
+                .toString
+
               val actualFile = actualFileMap.get(name)
 
               actualFile shouldBe defined

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTest.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.platform.archive.bagunpacker.services
 
 import java.io.FileInputStream
+import java.nio.file.Paths
 
 import org.apache.commons.io.IOUtils
 import org.scalatest.concurrent.ScalaFutures
@@ -73,8 +74,9 @@ class UnpackerTest
             testArchive.containedFiles.map { file =>
               val fis = new FileInputStream(file)
               val content = IOUtils.toByteArray(fis)
-              val name = relativeToTmpDir(file)
-
+              val name = Paths.get(relativeToTmpDir(file))
+                .normalize().toString
+              
               val actualFile = actualFileMap.get(name)
 
               actualFile shouldBe defined


### PR DESCRIPTION
The unpacker should ignore "./" at the beginning of entry paths and not attempt to create directories in S3.