### PR TITLE
Treat AMD mismatch and missing ALTOs as warnings, and continue

### DIFF
--- a/bagger/src/aws.py
+++ b/bagger/src/aws.py
@@ -61,6 +61,12 @@ def log_processing_error(message):
     obj.put(Body=json.dumps(message, indent=4))
 
 
+def log_warning(message):
+    s3_path = "__warnings/{0}.json".format(message["identifier"])
+    obj = get_s3().Object(settings.DROP_BUCKET_NAME_ERRORS, s3_path)
+    obj.put(Body=json.dumps(message, indent=4))
+
+
 def send_bag_instruction(message):
     sqs = get_boto_session().resource("sqs")
     queue = None

--- a/bagger/src/aws.py
+++ b/bagger/src/aws.py
@@ -42,6 +42,7 @@ def save_mets_to_side(b_number, local_tmp_file):
     client.upload_file(local_tmp_file, settings.DROP_BUCKET_NAME_METS_ONLY, key)
 
 
+# This is used to drive the accelelrated DLCS migration
 def save_id_map(b_number, id_map):
     s3_path = "_idmaps/{0}.json".format(b_number)
     obj = get_s3().Object(settings.DROP_BUCKET_NAME_METS_ONLY, s3_path)

--- a/bagger/src/aws.py
+++ b/bagger/src/aws.py
@@ -61,8 +61,8 @@ def log_processing_error(message):
     obj.put(Body=json.dumps(message, indent=4))
 
 
-def log_warning(message):
-    s3_path = "__warnings/{0}.json".format(message["identifier"])
+def log_warning(key_part, message):
+    s3_path = "__warnings/{0}/{1}.json".format(key_part, message["identifier"])
     obj = get_s3().Object(settings.DROP_BUCKET_NAME_ERRORS, s3_path)
     obj.put(Body=json.dumps(message, indent=4))
 

--- a/bagger/src/aws.py
+++ b/bagger/src/aws.py
@@ -42,7 +42,7 @@ def save_mets_to_side(b_number, local_tmp_file):
     client.upload_file(local_tmp_file, settings.DROP_BUCKET_NAME_METS_ONLY, key)
 
 
-# This is used to drive the accelelrated DLCS migration
+# This is used to drive the accelerated DLCS migration
 def save_id_map(b_number, id_map):
     s3_path = "_idmaps/{0}.json".format(b_number)
     obj = get_s3().Object(settings.DROP_BUCKET_NAME_METS_ONLY, s3_path)

--- a/bagger/src/bagger.py
+++ b/bagger/src/bagger.py
@@ -135,11 +135,11 @@ def bag_from_identifier(identifier, skip_file_download):
 
 
 def process_manifestation(root, bag_details, skip_file_download, id_map):
-    mets.remove_deliverable_unit(root)
+    tech_md_files = mets.restructure_tech_md(root)
     tech_md.remodel_file_technical_metadata(root, id_map)
     mets.remodel_file_section(root)
     assets, alto = mets.get_physical_file_maps(root)
-    files.process_assets(root, bag_details, assets, skip_file_download)
+    files.process_assets(root, bag_details, assets, tech_md_files, skip_file_download)
     files.process_alto(root, bag_details, alto, skip_file_download)
 
 

--- a/bagger/src/files.py
+++ b/bagger/src/files.py
@@ -112,8 +112,10 @@ def process_alto(root, bag_details, alto, skip_file_download):
         if missing_count > 0:
             message = {
                 "identifier": b_number,
-                "summary": "{0} has {1} missing ALTO files.".format(b_number, missing_count),
-                "data": missing_altos
+                "summary": "{0} has {1} missing ALTO files.".format(
+                    b_number, missing_count
+                ),
+                "data": missing_altos,
             }
             aws.log_warning("missing_altos", message)
 
@@ -164,7 +166,9 @@ def process_assets(root, bag_details, assets, tech_md_files, skip_file_download)
         checksum = file_element.get("CHECKSUM")
         file_element.attrib.pop("CHECKSUM")  # don't need it now
         preservica_uuid = tech_md_for_structmap_asset["uuid"]
-        logging.debug("Need to determine where to get {0} from.".format(preservica_uuid))
+        logging.debug(
+            "Need to determine where to get {0} from.".format(preservica_uuid)
+        )
 
         if skip_file_download:
             logging.debug("Skipping processing file {0}".format(preservica_uuid))
@@ -181,11 +185,10 @@ def process_assets(root, bag_details, assets, tech_md_files, skip_file_download)
             # it's definitely an error that needs attention
             raise RuntimeError(fetch_attempt["message"])
 
-
     # Now see if there are files we didn't collect in that set of downloads
     # These are files mentioned in tech_md but not in the structmap
     # These are not considered errors, but they definitely need attention
-    # TODO - see how many errors we get this way and decide whether a missing 
+    # TODO - see how many errors we get this way and decide whether a missing
     # techMd-only file (can't obtain from anywhere) is still an error
 
     tech_md_mismatch_warnings = []
@@ -204,23 +207,27 @@ def process_assets(root, bag_details, assets, tech_md_files, skip_file_download)
             bag_assembly.ensure_directory(destination)
             fetch_attempt = try_to_download_asset(preservica_uuid, destination)
             if fetch_attempt["succeeded"]:
-                logging.debug("successfully fetched {0} - {1}".format(preservica_uuid, filename))
+                logging.debug(
+                    "successfully fetched {0} - {1}".format(preservica_uuid, filename)
+                )
             else:
-                missing_from_preservica.append({
-                    "preservica_uuid": preservica_uuid,
-                    "filename": filename
-                })
-                logging.debug("Unable to fetch {0} - {1}".format(preservica_uuid, filename))
+                missing_from_preservica.append(
+                    {"preservica_uuid": preservica_uuid, "filename": filename}
+                )
+                logging.debug(
+                    "Unable to fetch {0} - {1}".format(preservica_uuid, filename)
+                )
 
-    
     mismatch_count = len(tech_md_mismatch_warnings)
     if mismatch_count > 0:
         b_number = bag_details["b_number"]
         message = {
             "identifier": b_number,
-            "summary": "{0} has {1} AMD/techMD mismatches.".format(b_number, mismatch_count),
-            "data": tech_md_mismatch_warnings
-        }      
+            "summary": "{0} has {1} AMD/techMD mismatches.".format(
+                b_number, mismatch_count
+            ),
+            "data": tech_md_mismatch_warnings,
+        }
         if len(missing_from_preservica) > 0:
             message["missing_from_preservica"] = missing_from_preservica
 
@@ -269,13 +276,11 @@ def try_to_download_asset(preservica_uuid, destination):
 
     # TODO: this message could give a more detailed error report
     if asset_downloaded:
-        return {
-            "succeeded": True
-        }
+        return {"succeeded": True}
     else:
         return {
             "succeeded": False,
-            "message": "Unable to find asset {0}".format(preservica_uuid)
+            "message": "Unable to find asset {0}".format(preservica_uuid),
         }
 
 
@@ -283,13 +288,15 @@ def fetch_from_wlorg(web_url, destination, retry_attempts):
     # This will probably fail, if the DLCS hasn't got it.
     # But it is the only way of getting restricted files out.
     user, password = settings.DDS_API_KEY, settings.DDS_API_SECRET
-    message = "Try to fetch this from Preservica directly, via DDS, at {0}".format(web_url)
+    message = "Try to fetch this from Preservica directly, via DDS, at {0}".format(
+        web_url
+    )
     logging.debug(message)
     chunk_size = 1024 * 1024
     for _ in range(retry_attempts):
         try:
             # This is horribly slow, why?
-            logging.info(message) # remove me!
+            logging.info(message)  # remove me!
             resp = requests.get(web_url, auth=(user, password), stream=True)
             if resp.status_code == 200:
                 with open(destination, "wb") as f:
@@ -297,8 +304,10 @@ def fetch_from_wlorg(web_url, destination, retry_attempts):
                         f.write(chunk)
                 return True
             else:
-                logging.debug("Recieved HTTP {0} for {1}".format(resp.status_code, web_url))
-                return False           
+                logging.debug(
+                    "Recieved HTTP {0} for {1}".format(resp.status_code, web_url)
+                )
+                return False
         except Exception as err:
             pass
     raise err

--- a/bagger/src/files.py
+++ b/bagger/src/files.py
@@ -10,7 +10,6 @@ import settings
 import bag_assembly
 import dlcs
 import storage
-import aws
 from xml_help import expand, namespaces
 
 # keep track of these to ensure no collisions in Multiple Manifestations
@@ -293,6 +292,7 @@ def fetch_from_wlorg(web_url, destination, retry_attempts):
     )
     logging.debug(message)
     chunk_size = 1024 * 1024
+    download_err = None
     for _ in range(retry_attempts):
         try:
             # This is horribly slow, why?
@@ -309,5 +309,6 @@ def fetch_from_wlorg(web_url, destination, retry_attempts):
                 )
                 return False
         except Exception as err:
+            download_err = err
             pass
-    raise err
+    raise download_err

--- a/bagger/src/files.py
+++ b/bagger/src/files.py
@@ -195,7 +195,7 @@ def process_assets(root, bag_details, assets, tech_md_files, skip_file_download)
         if preservica_uuid not in structmap_uuids_downloaded:
             # double sanity check - we should have picked this up in the techMd restructure
             assert tech_md_file.get("warning", None) is not None
-            logging.info(tech_md_file["warning"])
+            logging.debug(tech_md_file["warning"])
             tech_md_mismatch_warnings.append(tech_md_file["warning"])
             # we've recorded the warning, now try to get the file
             folder = "objects"
@@ -204,13 +204,13 @@ def process_assets(root, bag_details, assets, tech_md_files, skip_file_download)
             bag_assembly.ensure_directory(destination)
             fetch_attempt = try_to_download_asset(preservica_uuid, destination)
             if fetch_attempt["succeeded"]:
-                logging.info("successfully fetched {0} - {1}".format(preservica_uuid, filename))
+                logging.debug("successfully fetched {0} - {1}".format(preservica_uuid, filename))
             else:
                 missing_from_preservica.append({
                     "preservica_uuid": preservica_uuid,
                     "filename": filename
                 })
-                logging.info("Unable to fetch {0} - {1}".format(preservica_uuid, filename))
+                logging.debug("Unable to fetch {0} - {1}".format(preservica_uuid, filename))
 
     
     mismatch_count = len(tech_md_mismatch_warnings)

--- a/bagger/src/mets.py
+++ b/bagger/src/mets.py
@@ -116,16 +116,18 @@ the AMD to start at _0001
         phys_file = None
         if len(refs) == 1:
             phys_file = refs[0]
-        tech_md_files.append({
-            "old_id": old_id,
-            "new_id": new_id,
-            "filename": tech_md_filename,
-            "preservica_id": tech_md_preservica_id,
-            "refs_count": len(refs),
-            "tech_md": tech_md,
-            "phys_file": phys_file,
-            "warning": None
-        })
+        tech_md_files.append(
+            {
+                "old_id": old_id,
+                "new_id": new_id,
+                "filename": tech_md_filename,
+                "preservica_id": tech_md_preservica_id,
+                "refs_count": len(refs),
+                "tech_md": tech_md,
+                "phys_file": phys_file,
+                "warning": None,
+            }
+        )
         counter = counter + 1
 
     # Now go through tech_md_files, providing new renumbered IDs
@@ -134,11 +136,13 @@ the AMD to start at _0001
         if tech_md_file.get("phys_file", None) is not None:
             tech_md_file["phys_file"].set("ADMID", tech_md_file["new_id"])
         else:
-            tech_md_file["warning"] = "Expected 1 AMD ref for {0} (old) {1} (new), got {2}, filename: {3}".format(
+            tech_md_file[
+                "warning"
+            ] = "Expected 1 AMD ref for {0} (old) {1} (new), got {2}, filename: {3}".format(
                 tech_md_file["old_id"],
                 tech_md_file["new_id"],
                 tech_md_file["refs_count"],
-                tech_md_file["filename"]
+                tech_md_file["filename"],
             )
 
     return tech_md_files
@@ -166,9 +170,7 @@ def get_tech_md_preservica_id(tech_md):
     id_els = tech_md.findall(
         "./mets:mdWrap/mets:xmlData/tessella:File/tessella:ID", namespaces
     )
-    assert len(id_els) == 1, "More than one ID in {0}".format(
-        tech_md.get("ID")
-    )
+    assert len(id_els) == 1, "More than one ID in {0}".format(tech_md.get("ID"))
     return id_els[0].text
 
 

--- a/bagger/src/mets.py
+++ b/bagger/src/mets.py
@@ -107,6 +107,7 @@ the AMD to start at _0001
         refs = root.findall(".//mets:div[@ADMID='{0}']".format(old_id), namespaces)
         tech_md_filename = get_tech_md_filename(tech_md)
         if len(refs) == 0 and is_ignorable_file(tech_md_filename):
+            logging.debug("ignoring file {0}".format(tech_md_filename))
             amd_sec.remove(tech_md)
             continue
 
@@ -122,29 +123,25 @@ the AMD to start at _0001
             "preservica_id": tech_md_preservica_id,
             "refs_count": len(refs),
             "tech_md": tech_md,
-            "phys_file": phys_file
+            "phys_file": phys_file,
+            "warning": None
         })
         counter = counter + 1
 
     # Now go through tech_md_files, providing new renumbered IDs
-    tech_md_map = {}
     for tech_md_file in tech_md_files:
-        tech_md_map[tech_md_file["new_id"]] = tech_md_file
         tech_md_file["tech_md"].set("ID", tech_md_file["new_id"])
         if tech_md_file.get("phys_file", None) is not None:
             tech_md_file["phys_file"].set("ADMID", tech_md_file["new_id"])
         else:
-            warnings = tech_md_map.get("__warnings", [])
-            message = "Expected 1 AMD ref for {0} (old) {1} (new), got {2}, filename: {3}".format(
+            tech_md_file["warning"] = "Expected 1 AMD ref for {0} (old) {1} (new), got {2}, filename: {3}".format(
                 tech_md_file["old_id"],
                 tech_md_file["new_id"],
                 tech_md_file["refs_count"],
                 tech_md_file["filename"]
             )
-            warnings.append(message)
-            tech_md_map["__warnings"] = warnings
 
-    return tech_md_map
+    return tech_md_files
     # if len(refs) != 1:
     #     message = "Expected 1 AMD ref for {0}, got {1}, filename: {2}".format(
     #         old_id, len(refs), tech_md_filename

--- a/bagger/src/storage.py
+++ b/bagger/src/storage.py
@@ -1,7 +1,7 @@
 import settings
 
 
-def analyse_origin(origin, pres_uuid):
+def analyse_origin(origin, preservica_uuid):
     # the origin will be one of three expected locations
     #   1. The Preservica Bucket
     #   2. The DLCS storage bucket
@@ -17,9 +17,9 @@ def analyse_origin(origin, pres_uuid):
         # The DLCS doesn't know about this image. It might still be in the
         # Preservica bucket, so we can try that. Otherwise, the migrator will
         # have to try to get it from wl.org.
-        origin_info["web_url"] = "{0}{1}".format(settings.DDS_ASSET_PREFIX, pres_uuid)
+        origin_info["web_url"] = "{0}{1}".format(settings.DDS_ASSET_PREFIX, preservica_uuid)
         origin_info["bucket_name"] = settings.CURRENT_PRESERVATION_BUCKET
-        origin_info["bucket_key"] = pres_uuid
+        origin_info["bucket_key"] = preservica_uuid
         return origin_info
 
     if origin.startswith(settings.DDS_ASSET_PREFIX):
@@ -28,7 +28,7 @@ def analyse_origin(origin, pres_uuid):
         origin_info["web_url"] = origin
         origin_info["bucket_name"] = settings.DLCS_SOURCE_BUCKET
         origin_info["bucket_key"] = "{0}/{1}/{2}".format(
-            settings.DLCS_CUSTOMER_ID, settings.DLCS_SPACE, pres_uuid
+            settings.DLCS_CUSTOMER_ID, settings.DLCS_SPACE, preservica_uuid
         )
         # messy, a small %age of DLCS JP2s have a file extension
         origin_info["alt_key"] = origin_info["bucket_key"] + ".jp2"

--- a/bagger/src/storage.py
+++ b/bagger/src/storage.py
@@ -17,7 +17,9 @@ def analyse_origin(origin, preservica_uuid):
         # The DLCS doesn't know about this image. It might still be in the
         # Preservica bucket, so we can try that. Otherwise, the migrator will
         # have to try to get it from wl.org.
-        origin_info["web_url"] = "{0}{1}".format(settings.DDS_ASSET_PREFIX, preservica_uuid)
+        origin_info["web_url"] = "{0}{1}".format(
+            settings.DDS_ASSET_PREFIX, preservica_uuid
+        )
         origin_info["bucket_name"] = settings.CURRENT_PRESERVATION_BUCKET
         origin_info["bucket_key"] = preservica_uuid
         return origin_info


### PR DESCRIPTION
* Records details under __warnings key in error bucket
* Continues processing, so accommodates errors in some files when renumbering AMD identifiers
* Includes a retry operation when fetching missing files from Preservica via DDS