### PR TITLE
Use a TransferManager to upload objects in the unpacker

### DIFF
--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
@@ -81,7 +81,6 @@ class Unpacker(implicit s3Client: AmazonS3, ec: ExecutionContext) {
       )
     }
 
-
     val metadata = new ObjectMetadata()
     metadata.setContentLength(archiveEntrySize)
 

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTest.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.platform.archive.bagunpacker.services
 import java.io.{File, FileInputStream}
 import java.nio.file.Paths
 
+import com.amazonaws.services.s3.model.ListMultipartUploadsRequest
 import org.apache.commons.io.IOUtils
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
@@ -15,6 +16,7 @@ import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.fixtures.S3
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
 
+import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext.Implicits.global
 
 class UnpackerTest
@@ -80,6 +82,55 @@ class UnpackerTest
 
             assertBucketContentsMatchFiles(dstBucket, dstKey, filesInArchive)
           }
+        }
+      }
+    }
+  }
+
+  it("switches to MultipartUpload for files >100MB") {
+    // The upper limit for a single S3 Upload is 5242880 bytes.  If you try
+    // to upload more than that, you get an error:
+    //
+    //    Your proposed upload exceeds the maximum allowed size
+    //
+    // The Docker image we use to mimic S3 doesn't seem to emit this error, so
+    // instead we query S3 for evidence of Multipart uploads.
+    //
+    val bigFile = writeToOutputStream() { outputStream =>
+      (1 to 1000).foreach { _ =>
+        outputStream.write(randomBytes(1000))
+      }
+    }
+
+    withLocalS3Bucket { srcBucket =>
+      withLocalS3Bucket { dstBucket =>
+        val (archiveFile, filesInArchive, _) = createTgzArchiveWithFiles(
+          files = List(bigFile)
+        )
+
+        withArchive(srcBucket, archiveFile) { testArchive =>
+          val dstKey = "unpacked"
+          val summaryResult = unpacker
+            .unpack(
+              testArchive,
+              ObjectLocation(dstBucket.name, dstKey)
+            )
+
+          val multipartUploadListing = s3Client.listMultipartUploads(
+            new ListMultipartUploadsRequest(dstBucket.name)
+          ).getMultipartUploads.asScala.toList
+
+          multipartUploadListing.isEmpty shouldBe false
+
+          whenReady(summaryResult) { unpacked =>
+            unpacked shouldBe a[OperationSuccess[_]]
+
+            val summary = unpacked.summary
+            summary.fileCount shouldBe filesInArchive.size
+            summary.bytesUnpacked shouldBe totalBytes(filesInArchive)
+
+            assertBucketContentsMatchFiles(dstBucket, dstKey, filesInArchive)
+         }
         }
       }
     }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/RandomThings.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/RandomThings.scala
@@ -100,7 +100,8 @@ trait RandomThings {
     }
   }
 
-  def writeToOutputStream(path: String = s"${randomUUID.toString}.test")(writeTo: FileOutputStream => Unit): File = {
+  def writeToOutputStream(path: String = s"${randomUUID.toString}.test")(
+    writeTo: FileOutputStream => Unit): File = {
     val absolutePath = Paths.get(tmpDir, path)
 
     val file = absolutePath.toFile

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/RandomThings.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/RandomThings.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.archive.common.fixtures
 
-import java.io.FileOutputStream
+import java.io.{File, FileOutputStream}
 import java.nio.file.Paths
 import java.time.LocalDate
 import java.util.UUID
@@ -100,12 +100,7 @@ trait RandomThings {
     }
   }
 
-  def randomFile(
-    size: Int = 256,
-    path: String = s"${randomUUID.toString}.test",
-    useBytes: Boolean = false
-  ) = {
-
+  def writeToOutputStream(path: String = s"${randomUUID.toString}.test")(writeTo: FileOutputStream => Unit): File = {
     val absolutePath = Paths.get(tmpDir, path)
 
     val file = absolutePath.toFile
@@ -114,18 +109,26 @@ trait RandomThings {
     parentDir.mkdirs()
 
     val fileOutputStream = new FileOutputStream(file)
-
-    val bytes = if (useBytes) {
-      randomBytes(size)
-    } else {
-      randomAlphanumeric(size).getBytes
-    }
-
-    fileOutputStream.write(bytes)
+    writeTo(fileOutputStream)
     fileOutputStream.close()
 
     file
   }
+
+  def randomFile(
+    size: Int = 256,
+    path: String = s"${randomUUID.toString}.test",
+    useBytes: Boolean = false
+  ) =
+    writeToOutputStream(path) { fileOutputStream =>
+      val bytes = if (useBytes) {
+        randomBytes(size)
+      } else {
+        randomAlphanumeric(size).getBytes
+      }
+
+      fileOutputStream.write(bytes)
+    }
 
   def randomUUID = UUID.randomUUID()
 


### PR DESCRIPTION
A somewhat speculative fix for https://github.com/wellcometrust/platform/issues/3480.

You can’t upload more than 5GB in a single PutObject request to S3 – after that, you’re meant to switch to MultipartUpload. We weren’t doing that, hence why the really big uploads failed.

The Java SDK docs suggest we should be using TransferManager instead: https://docs.aws.amazon.com/AmazonS3/latest/dev/usingHLmpuJava.html

I’m struggling to test it because I can’t reproduce the error with our S3 Docker image (it seems to accept arbitrarily large file uploads with a single PutObject call, or at least bigger than I can create during a test run), but it doesn't break any existing tests. Worth a try?