### PR TITLE
Give the bagger room to deploy new tasks

### DIFF
--- a/terraform/stack/main.tf
+++ b/terraform/stack/main.tf
@@ -305,10 +305,10 @@ module "bagger" {
   cpu    = "1900"
   memory = "14000"
 
-  min_capacity = "${var.desired_bagger_count / 2}"
+  min_capacity = "${var.desired_bagger_count - 1}"
   max_capacity = "${var.desired_bagger_count}"
 
-  desired_task_count = "${var.desired_bagger_count}"
+  desired_task_count = "${var.desired_bagger_count - 1}"
 
   container_image = "${local.bagger_image}"
 }

--- a/terraform/stack/main.tf
+++ b/terraform/stack/main.tf
@@ -28,6 +28,9 @@ module "bag_unpacker" {
 
   env_vars_length = 6
 
+  cpu    = 1024
+  memory = 2048
+
   container_image = "${local.bag_unpacker_image}"
 }
 
@@ -92,6 +95,9 @@ module "bag_verifier" {
   }
 
   env_vars_length = 5
+
+  cpu    = 1024
+  memory = 2048
 
   container_image = "${local.bag_verifier_image}"
 }
@@ -305,10 +311,10 @@ module "bagger" {
   cpu    = "1900"
   memory = "14000"
 
-  min_capacity = "${var.desired_bagger_count - 1}"
+  min_capacity = "0"
   max_capacity = "${var.desired_bagger_count}"
 
-  desired_task_count = "${var.desired_bagger_count - 1}"
+  desired_task_count = "${var.desired_bagger_count}"
 
   container_image = "${local.bagger_image}"
 }

--- a/terraform/stack/main.tf
+++ b/terraform/stack/main.tf
@@ -305,7 +305,7 @@ module "bagger" {
   cpu    = "1900"
   memory = "14000"
 
-  min_capacity = "${var.desired_bagger_count}"
+  min_capacity = "${var.desired_bagger_count / 2}"
   max_capacity = "${var.desired_bagger_count}"
 
   desired_task_count = "${var.desired_bagger_count}"


### PR DESCRIPTION
Because the bagger is running at the limit of its network interfaces, it can't deploy new task definitions – the old ones never go away, and it can't start new ones.

This frees up a single slot for the bagger to start a new task definition, so it can gradually update itself without needing us to go in and stop all the existing tasks.