### PR TITLE
Bag register submitting metrics in wrong namespace

### DIFF
--- a/terraform/stack/locals.tf
+++ b/terraform/stack/locals.tf
@@ -1,11 +1,12 @@
 locals {
-  bag_register_service_name   = "${var.namespace}-bags"
   bags_api_service_name       = "${var.namespace}-bags-api"
   ingests_service_name        = "${var.namespace}-ingests"
   ingests_api_service_name    = "${var.namespace}-ingests-api"
   notifier_service_name       = "${var.namespace}-notifier"
   bagger_service_name         = "${var.namespace}-bagger"
+
   bag_replicator_service_name = "${var.namespace}-bag-replicator"
+  bag_register_service_name   = "${var.namespace}-bag_register"
   bag_verifier_service_name   = "${var.namespace}-bag-verifier"
   bag_unpacker_service_name   = "${var.namespace}-bag-unpacker"
 


### PR DESCRIPTION
It's using the old namespace "bags" which is a bit confusing, this PR changes it to "bag_register".