### PR TITLE
Give a more descriptive error if we can't find a title in the METS

### DIFF
--- a/bagger/src/mets.py
+++ b/bagger/src/mets.py
@@ -267,4 +267,7 @@ def get_physical_file_maps(root):
 
 def get_title(mets_root):
     title_el = mets_root.findall(".//mods:title", namespaces)
-    return title_el[0].text
+    try:
+        return title_el[0].text
+    except IndexError:
+        raise ValueError("Did not find any `.//mods:title` in METS")


### PR DESCRIPTION
Follows https://github.com/wellcometrust/platform/issues/3302

An IndexError isn’t especially helpful, and there might be others lurking we’ve missed – this small change means we can distinguish between this error and another one we haven’t seen yet.