### PR TITLE
API via NLB task count must equal AZ count

### DIFF
--- a/terraform/main_colbert.tf
+++ b/terraform/main_colbert.tf
@@ -13,10 +13,7 @@ module "stack-colbert" {
   domain_name      = "${local.staging_domain_name}"
   cert_domain_name = "${local.cert_domain_name}"
 
-  desired_bagger_count      = 12
-  desired_bags_api_count    = 1
-  desired_ingests_api_count = 1
-
+  desired_bagger_count  = 12
   desired_ec2_instances = 4
 
   vpc_id   = "${local.vpc_id}"

--- a/terraform/stack/api/main.tf
+++ b/terraform/stack/api/main.tf
@@ -14,7 +14,8 @@ module "services" {
   // This is due to the behaviour of NLBs that
   // seem to increase latency significantly if
   // number of tasks < number of AZs
-  desired_bags_api_count    = "3"
+  desired_bags_api_count = "3"
+
   desired_ingests_api_count = "3"
 
   # Bags endpoint

--- a/terraform/stack/api/main.tf
+++ b/terraform/stack/api/main.tf
@@ -10,8 +10,12 @@ module "services" {
   vpc_id     = "${var.vpc_id}"
   nlb_arn    = "${module.nlb.arn}"
 
-  desired_bags_api_count    = "${var.desired_bags_api_count}"
-  desired_ingests_api_count = "${var.desired_ingests_api_count}"
+  // The number of api tasks MUST be one per AZ
+  // This is due to the behaviour of NLBs that
+  // seem to increase latency significantly if
+  // number of tasks < number of AZs
+  desired_bags_api_count    = "3"
+  desired_ingests_api_count = "3"
 
   # Bags endpoint
 

--- a/terraform/stack/api/services/bags.tf
+++ b/terraform/stack/api/services/bags.tf
@@ -30,14 +30,14 @@ module "bags" {
   lb_arn        = "${var.nlb_arn}"
   listener_port = "${var.bags_listener_port}"
 
-  cpu    = 4096
-  memory = 8192
+  cpu    = 2048
+  memory = 4096
 
-  sidecar_cpu    = 512
-  sidecar_memory = 1024
+  sidecar_cpu    = 1024
+  sidecar_memory = 2048
 
-  app_cpu    = 3584
-  app_memory = 7168
+  app_cpu    = 1024
+  app_memory = 2048
 
   task_desired_count = "${var.desired_bags_api_count}"
 }

--- a/terraform/stack/api/services/ingests.tf
+++ b/terraform/stack/api/services/ingests.tf
@@ -30,14 +30,14 @@ module "ingests" {
   lb_arn        = "${var.nlb_arn}"
   listener_port = "${var.ingests_listener_port}"
 
-  cpu    = 4096
-  memory = 8192
+  cpu    = 2048
+  memory = 4096
 
-  sidecar_cpu    = 512
-  sidecar_memory = 1024
+  sidecar_cpu    = 1024
+  sidecar_memory = 2048
 
-  app_cpu    = 3584
-  app_memory = 7168
+  app_cpu    = 1024
+  app_memory = 2048
 
   task_desired_count = "${var.desired_ingests_api_count}"
 }

--- a/terraform/stack/api/variables.tf
+++ b/terraform/stack/api/variables.tf
@@ -13,9 +13,6 @@ variable "cluster_id" {}
 variable "namespace" {}
 variable "namespace_id" {}
 
-variable "desired_bags_api_count" {}
-variable "desired_ingests_api_count" {}
-
 variable "bags_container_image" {}
 variable "bags_container_port" {}
 

--- a/terraform/stack/main.tf
+++ b/terraform/stack/main.tf
@@ -224,9 +224,6 @@ module "api" {
   namespace    = "${var.namespace}"
   namespace_id = "${aws_service_discovery_private_dns_namespace.namespace.id}"
 
-  desired_bags_api_count    = "${var.desired_bags_api_count}"
-  desired_ingests_api_count = "${var.desired_ingests_api_count}"
-
   # Auth
 
   auth_scopes = [


### PR DESCRIPTION
In order to prevent performance issues.