### PR TITLE
Unpacker config

### DIFF
--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/config/builders/UnpackerConfigBuilder.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/config/builders/UnpackerConfigBuilder.scala
@@ -2,17 +2,21 @@ package uk.ac.wellcome.platform.archive.bagunpacker.config.builders
 
 import com.typesafe.config.Config
 import uk.ac.wellcome.platform.archive.bagunpacker.config.models.UnpackerConfig
-import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 
 object UnpackerConfigBuilder {
+  val BUFFER_SIZE_DEFAULT = 8192
+  val BUFFER_SIZE_PATH = "unpacker.buffer.size"
+
   def build(config: Config): UnpackerConfig = {
-    val DEFAULT_BUFFER_SIZE = 8192
-
-    val bufferSize =
-      config.getOrElse[Int]("unpacker.buffer.size")(DEFAULT_BUFFER_SIZE)
-
     UnpackerConfig(
-      bufferSize = bufferSize
+      bufferSize = parseBufferSize(config)
     )
   }
+
+  private def parseBufferSize(config: Config): Int =
+    if (config.hasPath(BUFFER_SIZE_PATH)) {
+      config.getInt(BUFFER_SIZE_PATH)
+    } else {
+      BUFFER_SIZE_DEFAULT
+    }
 }

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/config/builders/UnpackerConfigBuilder.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/config/builders/UnpackerConfigBuilder.scala
@@ -1,10 +1,11 @@
 package uk.ac.wellcome.platform.archive.bagunpacker.config.builders
 
+import com.amazonaws.RequestClientOptions
 import com.typesafe.config.Config
 import uk.ac.wellcome.platform.archive.bagunpacker.config.models.UnpackerConfig
 
 object UnpackerConfigBuilder {
-  val BUFFER_SIZE_DEFAULT = 8192
+  val BUFFER_SIZE_DEFAULT: Int = RequestClientOptions.DEFAULT_STREAM_BUFFER_SIZE
   val BUFFER_SIZE_PATH = "unpacker.buffer.size"
 
   def build(config: Config): UnpackerConfig = {

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/config/builders/UnpackerConfigBuilderTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/config/builders/UnpackerConfigBuilderTest.scala
@@ -22,7 +22,8 @@ class UnpackerConfigBuilderTest extends FunSpec with Matchers {
   }
 
   it("throws a ConfigException if the type is wrong") {
-    val config: Config = ConfigFactory.parseString("unpacker.buffer.size=A string")
+    val config: Config =
+      ConfigFactory.parseString("unpacker.buffer.size=A string")
 
     assertThrows[ConfigException] {
       UnpackerConfigBuilder.build(config)
@@ -38,7 +39,8 @@ class UnpackerConfigBuilderTest extends FunSpec with Matchers {
   //   unpacker.buffer.size=1
   // hence this test
   it("parses a number wrapped in a String") {
-    val config: Config = ConfigFactory.parseString("unpacker.buffer.size=\"12\"")
+    val config: Config =
+      ConfigFactory.parseString("unpacker.buffer.size=\"12\"")
 
     val unpackerConfig = UnpackerConfigBuilder.build(config)
 

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/config/builders/UnpackerConfigBuilderTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/config/builders/UnpackerConfigBuilderTest.scala
@@ -1,0 +1,47 @@
+package uk.ac.wellcome.platform.archive.bagunpacker.config.builders
+
+import com.typesafe.config.{Config, ConfigException, ConfigFactory}
+import org.scalatest.{FunSpec, Matchers}
+
+class UnpackerConfigBuilderTest extends FunSpec with Matchers {
+
+  it("parses a valid bufferSize") {
+    val config: Config = ConfigFactory.parseString("unpacker.buffer.size=1")
+
+    val unpackerConfig = UnpackerConfigBuilder.build(config)
+
+    unpackerConfig.bufferSize shouldBe 1
+  }
+
+  it("defaults if bufferSize is absent") {
+    val config: Config = ConfigFactory.parseString("some.other.config=2")
+
+    val unpackerConfig = UnpackerConfigBuilder.build(config)
+
+    unpackerConfig.bufferSize shouldBe UnpackerConfigBuilder.BUFFER_SIZE_DEFAULT
+  }
+
+  it("throws a ConfigException if the type is wrong") {
+    val config: Config = ConfigFactory.parseString("unpacker.buffer.size=A string")
+
+    assertThrows[ConfigException] {
+      UnpackerConfigBuilder.build(config)
+    }
+  }
+
+  // Typesafe PropertiesParser appears to interpolate an
+  // environment variable as a String, so a config with:
+  //   unpacker.buffer.size=${?unpacker_buffer_size}
+  // is equivalent to
+  //   unpacker.buffer.size="1"
+  // rather than:
+  //   unpacker.buffer.size=1
+  // hence this test
+  it("parses a number wrapped in a String") {
+    val config: Config = ConfigFactory.parseString("unpacker.buffer.size=\"12\"")
+
+    val unpackerConfig = UnpackerConfigBuilder.build(config)
+
+    unpackerConfig.bufferSize shouldBe 12
+  }
+}

--- a/terraform/stack/main.tf
+++ b/terraform/stack/main.tf
@@ -21,7 +21,7 @@ module "bag_unpacker" {
     queue_url               = "${module.bag_unpacker_queue.url}"
     queue_parallelism       = "10"
     destination_bucket_name = "${var.ingest_bucket_name}"
-    unpacker_buffer_size    = "131073" # 128 Kb
+    unpacker_buffer_size    = "131073"                                                                                                                         # 128 Kb
     ingest_topic_arn        = "${module.ingests_topic.arn}"
     outgoing_topic_arn      = "${module.bag_unpacker_output_topic.arn}"
     metrics_namespace       = "${local.bag_unpacker_service_name}"

--- a/terraform/stack/main.tf
+++ b/terraform/stack/main.tf
@@ -21,7 +21,7 @@ module "bag_unpacker" {
     queue_url               = "${module.bag_unpacker_queue.url}"
     queue_parallelism       = "10"
     destination_bucket_name = "${var.ingest_bucket_name}"
-    unpacker_buffer_size    = "8192"
+    unpacker_buffer_size    = "131073" # 128 Kb
     ingest_topic_arn        = "${module.ingests_topic.arn}"
     outgoing_topic_arn      = "${module.bag_unpacker_output_topic.arn}"
     metrics_namespace       = "${local.bag_unpacker_service_name}"


### PR DESCRIPTION
Parse the unpacker config `unpacker.buffer.size` even if it is an integer wrapped in a String.  This looks to be the way Typesafe Config behaves when replacing environment variables.

Consider moving this more genrally to the EnrichConfig builders.