### PR TITLE
Also set the multipart upload threshold to the buffer size

### DIFF
--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/S3Uploader.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/S3Uploader.scala
@@ -47,7 +47,17 @@ class S3Uploader(bufferSize: Int)(implicit s3Client: AmazonS3) {
     requestClientOptions
       .setReadLimit(bufferSize)
 
-    val upload: Upload = transferManager.upload(putObjectRequest)
+    // Match the readLimit for the multipart upload threshold
+    // As per:
+    // https://github.com/aws/aws-sdk-java/issues/427#issuecomment-162082586
+
+    transferManager.getConfiguration
+      .setMultipartUploadThreshold(
+        bufferSize.toLong
+      )
+
+    val upload: Upload = transferManager
+      .upload(putObjectRequest)
 
     upload.waitForUploadResult()
   }


### PR DESCRIPTION
Because otherwise the ResetException will still occur when trying to do multipart uploads.