### PR TITLE
Fix the metrics namespace for the ingests API

### DIFF
--- a/terraform/config.tf
+++ b/terraform/config.tf
@@ -14,18 +14,6 @@ data "aws_ssm_parameter" "bagger_working_directory" {
   name = "/storage/config/prod/bagger_working_directory"
 }
 
-data "aws_ssm_parameter" "bagger_drop_bucket_name" {
-  name = "/storage/config/prod/bagger_drop_bucket_name"
-}
-
-data "aws_ssm_parameter" "bagger_drop_bucket_name_mets_only" {
-  name = "/storage/config/prod/bagger_drop_bucket_name_mets_only"
-}
-
-data "aws_ssm_parameter" "bagger_drop_bucket_name_errors" {
-  name = "/storage/config/prod/bagger_drop_bucket_name_errors"
-}
-
 data "aws_ssm_parameter" "bagger_current_preservation_bucket" {
   name = "/storage/config/prod/bagger_current_preservation_bucket"
 }
@@ -60,9 +48,6 @@ locals {
   bagger_mets_bucket_name            = "${data.aws_ssm_parameter.bagger_mets_bucket_name.value}"
   bagger_read_mets_from_fileshare    = "${data.aws_ssm_parameter.bagger_read_mets_from_fileshare.value == "true" ? true : false}"
   bagger_working_directory           = "${data.aws_ssm_parameter.bagger_working_directory.value}"
-  bagger_drop_bucket_name            = "${data.aws_ssm_parameter.bagger_drop_bucket_name.value}"
-  bagger_drop_bucket_name_mets_only  = "${data.aws_ssm_parameter.bagger_drop_bucket_name_mets_only.value}"
-  bagger_drop_bucket_name_errors     = "${data.aws_ssm_parameter.bagger_drop_bucket_name_errors.value}"
   bagger_current_preservation_bucket = "${data.aws_ssm_parameter.bagger_current_preservation_bucket.value}"
 
   bagger_dlcs_entry         = "${data.aws_ssm_parameter.bagger_dlcs_entry.value}"

--- a/terraform/critical/variables.tf
+++ b/terraform/critical/variables.tf
@@ -1,9 +1,6 @@
 variable "namespace" {}
 variable "account_id" {}
 
-variable "service-pl-winslow" {}
-variable "service-wt-winnipeg" {}
-
 variable "billing_mode" {
   default     = "PAY_PER_REQUEST"
   description = "Should be either PAY_PER_REQUEST or PROVISIONED"

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,10 +1,6 @@
 locals {
   namespace = "storage"
 
-  private_subnet_ids = [
-    "${data.aws_subnet.private_new.*.cidr_block}",
-  ]
-
   api_url     = "https://api.wellcomecollection.org"
   domain_name = "storage.api.wellcomecollection.org"
 

--- a/terraform/main_critical.tf
+++ b/terraform/main_critical.tf
@@ -17,9 +17,6 @@ module "critical" {
   namespace  = "${local.namespace}"
   account_id = "${local.account_id}"
 
-  service-wt-winnipeg = "${data.terraform_remote_state.infra_shared.service-wt-winnipeg}"
-  service-pl-winslow  = "${data.terraform_remote_state.infra_shared.service-pl-winslow}"
-
   archive_read_principles = [
     "${local.goobi_task_role_arn}",
     "${aws_iam_user.dds_digirati.arn}",
@@ -38,9 +35,6 @@ module "critical-staging" {
 
   namespace  = "${local.namespace}-staging"
   account_id = "${local.account_id}"
-
-  service-wt-winnipeg = "${data.terraform_remote_state.infra_shared.service-wt-winnipeg}"
-  service-pl-winslow  = "${data.terraform_remote_state.infra_shared.service-pl-winslow}"
 
   archive_read_principles = [
     "${local.goobi_task_role_arn}",

--- a/terraform/modules/service/worker/variables.tf
+++ b/terraform/modules/service/worker/variables.tf
@@ -4,8 +4,6 @@ variable "env_vars" {
 
 variable "env_vars_length" {}
 
-variable "vpc_id" {}
-
 variable "subnets" {
   type = "list"
 }
@@ -18,16 +16,6 @@ variable "cluster_name" {}
 variable "cluster_id" {}
 
 variable "service_name" {}
-
-variable "service_egress_security_group_id" {}
-
-variable "metric_namespace" {
-  default = "storage"
-}
-
-variable "high_metric_name" {
-  default = "empty"
-}
 
 variable "min_capacity" {
   default = "1"

--- a/terraform/stack/api/main.tf
+++ b/terraform/stack/api/main.tf
@@ -10,13 +10,8 @@ module "services" {
   vpc_id     = "${var.vpc_id}"
   nlb_arn    = "${module.nlb.arn}"
 
-  // The number of api tasks MUST be one per AZ
-  // This is due to the behaviour of NLBs that
-  // seem to increase latency significantly if
-  // number of tasks < number of AZs
-  desired_bags_api_count = "3"
-
-  desired_ingests_api_count = "3"
+  desired_bags_api_count    = "${var.desired_bags_api_count}"
+  desired_ingests_api_count = "${var.desired_ingests_api_count}"
 
   # Bags endpoint
 

--- a/terraform/stack/api/variables.tf
+++ b/terraform/stack/api/variables.tf
@@ -51,3 +51,6 @@ variable "domain_name" {}
 variable "cert_domain_name" {}
 
 variable "bag_unpacker_topic_arn" {}
+
+variable "desired_bags_api_count" {}
+variable "desired_ingests_api_count" {}

--- a/terraform/stack/main.tf
+++ b/terraform/stack/main.tf
@@ -3,8 +3,6 @@
 module "bag_unpacker" {
   source = "../modules/service/worker"
 
-  service_egress_security_group_id = "${aws_security_group.service_egress.id}"
-
   security_group_ids = [
     "${aws_security_group.interservice.id}",
     "${aws_security_group.service_egress.id}",
@@ -14,7 +12,6 @@ module "bag_unpacker" {
   cluster_id   = "${aws_ecs_cluster.cluster.id}"
   namespace_id = "${aws_service_discovery_private_dns_namespace.namespace.id}"
   subnets      = "${var.private_subnets}"
-  vpc_id       = "${var.vpc_id}"
   service_name = "${local.bag_unpacker_service_name}"
 
   env_vars = {
@@ -44,8 +41,6 @@ module "bag_unpacker" {
 module "bag_replicator" {
   source = "../modules/service/worker"
 
-  service_egress_security_group_id = "${aws_security_group.service_egress.id}"
-
   security_group_ids = [
     "${aws_security_group.interservice.id}",
     "${aws_security_group.service_egress.id}",
@@ -55,7 +50,6 @@ module "bag_replicator" {
   cluster_id   = "${aws_ecs_cluster.cluster.id}"
   namespace_id = "${aws_service_discovery_private_dns_namespace.namespace.id}"
   subnets      = "${var.private_subnets}"
-  vpc_id       = "${var.vpc_id}"
   service_name = "${local.bag_replicator_service_name}"
 
   env_vars = {
@@ -83,8 +77,6 @@ module "bag_replicator" {
 module "bag_verifier" {
   source = "../modules/service/worker"
 
-  service_egress_security_group_id = "${aws_security_group.service_egress.id}"
-
   security_group_ids = [
     "${aws_security_group.interservice.id}",
     "${aws_security_group.service_egress.id}",
@@ -94,7 +86,6 @@ module "bag_verifier" {
   cluster_id   = "${aws_ecs_cluster.cluster.id}"
   namespace_id = "${aws_service_discovery_private_dns_namespace.namespace.id}"
   subnets      = "${var.private_subnets}"
-  vpc_id       = "${var.vpc_id}"
   service_name = "${local.bag_verifier_service_name}"
 
   env_vars = {
@@ -121,13 +112,11 @@ module "bag_verifier" {
 module "bag_register" {
   source = "../modules/service/worker"
 
-  service_egress_security_group_id = "${aws_security_group.service_egress.id}"
-  cluster_name                     = "${aws_ecs_cluster.cluster.name}"
-  cluster_id                       = "${aws_ecs_cluster.cluster.id}"
-  namespace_id                     = "${aws_service_discovery_private_dns_namespace.namespace.id}"
-  subnets                          = "${var.private_subnets}"
-  vpc_id                           = "${var.vpc_id}"
-  service_name                     = "${var.namespace}-bags"
+  cluster_name = "${aws_ecs_cluster.cluster.name}"
+  cluster_id   = "${aws_ecs_cluster.cluster.id}"
+  namespace_id = "${aws_service_discovery_private_dns_namespace.namespace.id}"
+  subnets      = "${var.private_subnets}"
+  service_name = "${var.namespace}-bags"
 
   env_vars = {
     queue_url         = "${module.bag_register_input_queue.url}"
@@ -153,8 +142,6 @@ module "bag_register" {
 module "notifier" {
   source = "../modules/service/worker"
 
-  service_egress_security_group_id = "${aws_security_group.service_egress.id}"
-
   security_group_ids = [
     "${aws_security_group.interservice.id}",
     "${aws_security_group.service_egress.id}",
@@ -164,7 +151,6 @@ module "notifier" {
   cluster_id   = "${aws_ecs_cluster.cluster.id}"
   namespace_id = "${aws_service_discovery_private_dns_namespace.namespace.id}"
   subnets      = "${var.private_subnets}"
-  vpc_id       = "${var.vpc_id}"
   service_name = "${var.namespace}-notifier"
 
   env_vars = {
@@ -185,13 +171,11 @@ module "notifier" {
 module "ingests" {
   source = "../modules/service/worker"
 
-  service_egress_security_group_id = "${aws_security_group.service_egress.id}"
-  cluster_name                     = "${aws_ecs_cluster.cluster.name}"
-  cluster_id                       = "${aws_ecs_cluster.cluster.id}"
+  cluster_name = "${aws_ecs_cluster.cluster.name}"
+  cluster_id   = "${aws_ecs_cluster.cluster.id}"
 
   namespace_id = "${aws_service_discovery_private_dns_namespace.namespace.id}"
   subnets      = "${var.private_subnets}"
-  vpc_id       = "${var.vpc_id}"
   service_name = "${var.namespace}-ingests"
 
   env_vars = {
@@ -269,6 +253,9 @@ module "api" {
   interservice_security_group_id = "${aws_security_group.interservice.id}"
   alarm_topic_arn                = "${var.alarm_topic_arn}"
   bag_unpacker_topic_arn         = "${module.bag_unpacker_input_topic.arn}"
+
+  desired_bags_api_count    = "${var.desired_bags_api_count}"
+  desired_ingests_api_count = "${var.desired_ingests_api_count}"
 }
 
 # Migration services

--- a/terraform/stack/main.tf
+++ b/terraform/stack/main.tf
@@ -243,8 +243,8 @@ module "api" {
     unpacker_topic_arn            = "${module.bag_unpacker_input_topic.arn}"
     archive_ingest_table_name     = "${var.ingests_table_name}"
     archive_bag_ingest_index_name = "${var.ingests_table_ingest_index_name}"
-    metrics_namespace             = "${local.ingests_service_name}"
-    JAVA_OPTS                     = "-Dcom.amazonaws.sdk.enableDefaultMetrics=cloudwatchRegion=${var.aws_region},metricNameSpace=${local.ingests_service_name}"
+    metrics_namespace             = "${local.ingests_api_service_name}"
+    JAVA_OPTS                     = "-Dcom.amazonaws.sdk.enableDefaultMetrics=cloudwatchRegion=${var.aws_region},metricNameSpace=${local.ingests_api_service_name}"
   }
   ingests_env_vars_length        = 7
   ingests_nginx_container_image  = "${var.nginx_image}"

--- a/terraform/stack/main.tf
+++ b/terraform/stack/main.tf
@@ -253,8 +253,8 @@ module "api" {
   interservice_security_group_id = "${aws_security_group.interservice.id}"
   alarm_topic_arn                = "${var.alarm_topic_arn}"
   bag_unpacker_topic_arn         = "${module.bag_unpacker_input_topic.arn}"
-  desired_bags_api_count    = "${var.desired_bags_api_count}"
-  desired_ingests_api_count = "${var.desired_ingests_api_count}"
+  desired_bags_api_count         = "${var.desired_bags_api_count}"
+  desired_ingests_api_count      = "${var.desired_ingests_api_count}"
 }
 
 # Migration services

--- a/terraform/stack/main.tf
+++ b/terraform/stack/main.tf
@@ -253,7 +253,6 @@ module "api" {
   interservice_security_group_id = "${aws_security_group.interservice.id}"
   alarm_topic_arn                = "${var.alarm_topic_arn}"
   bag_unpacker_topic_arn         = "${module.bag_unpacker_input_topic.arn}"
-
   desired_bags_api_count    = "${var.desired_bags_api_count}"
   desired_ingests_api_count = "${var.desired_ingests_api_count}"
 }

--- a/terraform/stack/variables.tf
+++ b/terraform/stack/variables.tf
@@ -97,14 +97,16 @@ variable "desired_bagger_count" {
   default = 4
 }
 
+variable "desired_ec2_instances" {
+  default = 2
+}
+
+# The number of api tasks MUST be one per AZ.  This is due to the behaviour of
+# NLBs that seem to increase latency significantly if number of tasks < number of AZs.
 variable "desired_bags_api_count" {
   default = 3
 }
 
 variable "desired_ingests_api_count" {
   default = 3
-}
-
-variable "desired_ec2_instances" {
-  default = 2
 }


### PR DESCRIPTION
We should use `${local.ingests_api_service_name}`, but we were actually using `${local.ingests_service_name}`.

One way to detect this is to look for unused locals (which would show us we’d defined this but never used it) – script is in [alexwlchan/junkdrawer#87f5769](https://github.com/alexwlchan/junkdrawer/blob/87f57690969895c0756b9f13ab118a4de9b3b8e8/terraform/find_unused_locals_and_vars.py), cleaning up other unused vars/locals is in this PR.

Hopefully the last piece of https://github.com/wellcometrust/platform/issues/3423.