### PR TITLE
Break up ReplicationSummary into different classes for success/failure

### DIFF
--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/models/ReplicationSummary.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/models/ReplicationSummary.scala
@@ -5,23 +5,30 @@ import java.time.Instant
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagLocation
 import uk.ac.wellcome.platform.archive.common.operation.models.Summary
 
-case class ReplicationSummary(
-  source: BagLocation,
-  destination: Option[BagLocation] = None,
+trait ReplicationSummary extends Summary {
+  val srcLocation: BagLocation
+  val dstLocation: Option[BagLocation]
+  val startTime: Instant
+  val endTime: Option[Instant]
+}
+
+case class ReplicationResult(
+  srcLocation: BagLocation,
+  dstLocation: Option[BagLocation] = None,
   startTime: Instant,
   endTime: Option[Instant] = None,
-) extends Summary {
-  def complete: ReplicationSummary = {
+) extends ReplicationSummary {
+  def complete: ReplicationResult =
     this.copy(
       endTime = Some(Instant.now())
     )
-  }
-  override def toString(): String = {
-    val destinationCompletePath = destination match {
+
+  override def toString: String = {
+    val destinationCompletePath = dstLocation match {
       case None                 => "<no-destination>"
       case Some(theDestination) => theDestination.completePath
     }
-    f"""|src=${source.completePath}
+    f"""|src=${srcLocation.completePath}
         |dst=$destinationCompletePath
         |durationSeconds=$durationSeconds
         |duration=$formatDuration""".stripMargin

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicator.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicator.scala
@@ -5,7 +5,10 @@ import java.time.Instant
 
 import com.amazonaws.services.s3.AmazonS3
 import uk.ac.wellcome.platform.archive.bagreplicator.config.ReplicatorDestinationConfig
-import uk.ac.wellcome.platform.archive.bagreplicator.models.ReplicationSummary
+import uk.ac.wellcome.platform.archive.bagreplicator.models.{
+  ReplicationResult,
+  ReplicationSummary
+}
 import uk.ac.wellcome.platform.archive.common.bagit.models.{
   BagInfo,
   BagLocation,
@@ -34,9 +37,9 @@ class BagReplicator(config: ReplicatorDestinationConfig)(
   def replicate(
     location: BagLocation
   ): Future[IngestStepResult[ReplicationSummary]] = {
-    val replicationSummary = ReplicationSummary(
+    val replicationSummary = ReplicationResult(
       startTime = Instant.now(),
-      source = location
+      srcLocation = location
     )
 
     val copyOperation = for {
@@ -63,7 +66,7 @@ class BagReplicator(config: ReplicatorDestinationConfig)(
         Success(
           IngestStepSuccess(
             replicationSummary
-              .copy(destination = Some(dstLocation))
+              .copy(dstLocation = Some(dstLocation))
               .complete))
 
       case Failure(e) =>

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
@@ -4,7 +4,10 @@ import akka.Done
 import uk.ac.wellcome.messaging.sqs.NotificationStream
 import uk.ac.wellcome.platform.archive.common.ingests.models.BagRequest
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
-import uk.ac.wellcome.platform.archive.common.operation.services.{DiagnosticReporter, OutgoingPublisher}
+import uk.ac.wellcome.platform.archive.common.operation.services.{
+  DiagnosticReporter,
+  OutgoingPublisher
+}
 import uk.ac.wellcome.typesafe.Runnable
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.bagreplicator.models.ReplicationCompleted

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
@@ -35,7 +35,7 @@ class BagReplicatorWorker(
         result,
         BagRequest(
           requestId = request.requestId,
-          bagLocation = result.summary.destination
+          bagLocation = result.summary.dstLocation
             .getOrElse(
               throw new RuntimeException(
                 "No destination provided by replication!"

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/operation/models/Timed.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/operation/models/Timed.scala
@@ -6,9 +6,8 @@ trait Timed {
   val startTime: Instant
   val endTime: Option[Instant]
 
-  def duration = {
+  def duration =
     endTime.map(Duration.between(startTime, _))
-  }
 
   def durationSeconds =
     duration.getOrElse(Duration.ofSeconds(0)).getSeconds


### PR DESCRIPTION
Discovered while doing some refactoring for https://github.com/wellcometrust/platform/issues/3504

Right now we set an option of `dstLocation`, and we have to `getOrElse` it to send it downstream. Yuck! Let’s lean on the type system instead – definitely set it on a successful replication, ignore it if not.