### PR TITLE
Verify all bags before replicating them to our storage

### DIFF
--- a/terraform/stack/iam_role_policy.tf
+++ b/terraform/stack/iam_role_policy.tf
@@ -73,20 +73,20 @@ resource "aws_iam_role_policy" "bag_replicator_metrics" {
   policy = "${data.aws_iam_policy_document.cloudwatch_put.json}"
 }
 
-# bag_verifier
+# bag_verifier post-replication
 
-resource "aws_iam_role_policy" "bag_verifier_task_read_s3" {
-  role   = "${module.bag_verifier.task_role_name}"
+resource "aws_iam_role_policy" "bag_verifier_post_repl_task_read_s3" {
+  role   = "${module.bag_verifier_post_replication.task_role_name}"
   policy = "${data.aws_iam_policy_document.storage_archive_read.json}"
 }
 
-resource "aws_iam_role_policy" "bag_verifier_task_store_s3" {
-  role   = "${module.bag_verifier.task_role_name}"
+resource "aws_iam_role_policy" "bag_verifier_post_repl_task_store_s3" {
+  role   = "${module.bag_verifier_post_replication.task_role_name}"
   policy = "${data.aws_iam_policy_document.storage_access_read.json}"
 }
 
-resource "aws_iam_role_policy" "bag_verifier_metrics" {
-  role   = "${module.bag_verifier.task_role_name}"
+resource "aws_iam_role_policy" "bag_verifier_post_repl_metrics" {
+  role   = "${module.bag_verifier_post_replication.task_role_name}"
   policy = "${data.aws_iam_policy_document.cloudwatch_put.json}"
 }
 

--- a/terraform/stack/iam_role_policy.tf
+++ b/terraform/stack/iam_role_policy.tf
@@ -56,6 +56,18 @@ resource "aws_iam_role_policy" "ingests_api_archive_ingest_table" {
   policy = "${data.aws_iam_policy_document.archive_ingest_table_read_write_policy.json}"
 }
 
+# bag_verifier pre-replication
+
+resource "aws_iam_role_policy" "bag_verifier_pre_repl_task_store_s3" {
+  role   = "${module.bag_verifier_pre_replication.task_role_name}"
+  policy = "${data.aws_iam_policy_document.ingests_read.json}"
+}
+
+resource "aws_iam_role_policy" "bag_verifier_pre_repl_metrics" {
+  role   = "${module.bag_verifier_pre_replication.task_role_name}"
+  policy = "${data.aws_iam_policy_document.cloudwatch_put.json}"
+}
+
 # bag_replicator
 
 resource "aws_iam_role_policy" "bag_replicator_task_read_ingests_s3" {

--- a/terraform/stack/iam_role_policy.tf
+++ b/terraform/stack/iam_role_policy.tf
@@ -58,7 +58,7 @@ resource "aws_iam_role_policy" "ingests_api_archive_ingest_table" {
 
 # bag_verifier pre-replication
 
-resource "aws_iam_role_policy" "bag_verifier_pre_repl_task_store_s3" {
+resource "aws_iam_role_policy" "bag_verifier_pre_repl_read_s3_ingests" {
   role   = "${module.bag_verifier_pre_replication.task_role_name}"
   policy = "${data.aws_iam_policy_document.ingests_read.json}"
 }
@@ -87,12 +87,12 @@ resource "aws_iam_role_policy" "bag_replicator_metrics" {
 
 # bag_verifier post-replication
 
-resource "aws_iam_role_policy" "bag_verifier_post_repl_task_read_s3" {
+resource "aws_iam_role_policy" "bag_verifier_post_repl_read_s3_archive" {
   role   = "${module.bag_verifier_post_replication.task_role_name}"
   policy = "${data.aws_iam_policy_document.storage_archive_read.json}"
 }
 
-resource "aws_iam_role_policy" "bag_verifier_post_repl_task_store_s3" {
+resource "aws_iam_role_policy" "bag_verifier_post_repl_read_s3_access" {
   role   = "${module.bag_verifier_post_replication.task_role_name}"
   policy = "${data.aws_iam_policy_document.storage_access_read.json}"
 }

--- a/terraform/stack/locals.tf
+++ b/terraform/stack/locals.tf
@@ -9,6 +9,7 @@ locals {
   bag_replicator_service_name         = "${var.namespace}-bag-replicator"
   bag_register_service_name           = "${var.namespace}-bag-register"
   bag_verifier_post_repl_service_name = "${var.namespace}-bag-verifier-post-replication"
+  bag_verifier_pre_repl_service_name  = "${var.namespace}-bag-verifier-pre-replication"
 
   bag_register_image   = "${module.images.services["bag_register"]}"
   bags_api_image       = "${module.images.services["bags_api"]}"

--- a/terraform/stack/locals.tf
+++ b/terraform/stack/locals.tf
@@ -5,10 +5,10 @@ locals {
   notifier_service_name    = "${var.namespace}-notifier"
   bagger_service_name      = "${var.namespace}-bagger"
 
-  bag_unpacker_service_name   = "${var.namespace}-bag-unpacker"
-  bag_replicator_service_name = "${var.namespace}-bag-replicator"
-  bag_register_service_name   = "${var.namespace}-bag-register"
-  bag_verifier_service_name   = "${var.namespace}-bag-verifier"
+  bag_unpacker_service_name           = "${var.namespace}-bag-unpacker"
+  bag_replicator_service_name         = "${var.namespace}-bag-replicator"
+  bag_register_service_name           = "${var.namespace}-bag-register"
+  bag_verifier_post_repl_service_name = "${var.namespace}-bag-verifier-post-replication"
 
   bag_register_image   = "${module.images.services["bag_register"]}"
   bags_api_image       = "${module.images.services["bags_api"]}"

--- a/terraform/stack/main.tf
+++ b/terraform/stack/main.tf
@@ -35,6 +35,41 @@ module "bag_unpacker" {
   container_image = "${local.bag_unpacker_image}"
 }
 
+# bag_verifier
+
+module "bag_verifier_pre_replication" {
+  source = "../modules/service/worker"
+
+  security_group_ids = [
+    "${aws_security_group.interservice.id}",
+    "${aws_security_group.service_egress.id}",
+  ]
+
+  cluster_name = "${aws_ecs_cluster.cluster.name}"
+  cluster_id   = "${aws_ecs_cluster.cluster.id}"
+  namespace_id = "${aws_service_discovery_private_dns_namespace.namespace.id}"
+  subnets      = "${var.private_subnets}"
+  service_name = "${local.bag_verifier_pre_repl_service_name}"
+
+  env_vars = {
+    queue_url          = "${module.bag_verifier_pre_replicate_queue.url}"
+    ingest_topic_arn   = "${module.ingests_topic.arn}"
+    outgoing_topic_arn = "${module.bag_verifier_pre_replicate_output_topic.arn}"
+    metrics_namespace  = "${local.bag_verifier_pre_repl_service_name}"
+    JAVA_OPTS          = "-Dcom.amazonaws.sdk.enableDefaultMetrics=cloudwatchRegion=${var.aws_region},metricNameSpace=${local.bag_verifier_pre_repl_service_name}"
+  }
+
+  env_vars_length = 5
+
+  cpu    = 2048
+  memory = 4096
+
+  min_capacity = "1"
+  max_capacity = "10"
+
+  container_image = "${local.bag_verifier_image}"
+}
+
 # bag_replicator
 
 module "bag_replicator" {

--- a/terraform/stack/main.tf
+++ b/terraform/stack/main.tf
@@ -73,7 +73,7 @@ module "bag_replicator" {
 
 # bag_verifier
 
-module "bag_verifier" {
+module "bag_verifier_post_replication" {
   source = "../modules/service/worker"
 
   security_group_ids = [
@@ -85,14 +85,14 @@ module "bag_verifier" {
   cluster_id   = "${aws_ecs_cluster.cluster.id}"
   namespace_id = "${aws_service_discovery_private_dns_namespace.namespace.id}"
   subnets      = "${var.private_subnets}"
-  service_name = "${local.bag_verifier_service_name}"
+  service_name = "${local.bag_verifier_post_repl_service_name}"
 
   env_vars = {
-    queue_url          = "${module.bag_verifier_input_queue.url}"
+    queue_url          = "${module.bag_verifier_post_replicate_queue.url}"
     ingest_topic_arn   = "${module.ingests_topic.arn}"
-    outgoing_topic_arn = "${module.bag_verifier_output_topic.arn}"
-    metrics_namespace  = "${local.bag_verifier_service_name}"
-    JAVA_OPTS          = "-Dcom.amazonaws.sdk.enableDefaultMetrics=cloudwatchRegion=${var.aws_region},metricNameSpace=${local.bag_verifier_service_name}"
+    outgoing_topic_arn = "${module.bag_verifier_post_replicate_output_topic.arn}"
+    metrics_namespace  = "${local.bag_verifier_post_repl_service_name}"
+    JAVA_OPTS          = "-Dcom.amazonaws.sdk.enableDefaultMetrics=cloudwatchRegion=${var.aws_region},metricNameSpace=${local.bag_verifier_post_repl_service_name}"
   }
 
   env_vars_length = 5

--- a/terraform/stack/messaging.tf
+++ b/terraform/stack/messaging.tf
@@ -8,7 +8,7 @@ module "ingests_topic" {
   role_names = [
     "${module.bag_register.task_role_name}",
     "${module.bag_replicator.task_role_name}",
-    "${module.bag_verifier.task_role_name}",
+    "${module.bag_verifier_post_replication.task_role_name}",
     "${module.bag_unpacker.task_role_name}",
     "${module.ingests.task_role_name}",
     "${module.notifier.task_role_name}",
@@ -170,16 +170,16 @@ module "bag_replicator_output_topic" {
   ]
 }
 
-# bag_verifier
+# bag_verifier post-replication
 
-module "bag_verifier_input_queue" {
+module "bag_verifier_post_replicate_queue" {
   source = "../modules/queue"
 
-  name = "${var.namespace}_bag_verifier_input"
+  name = "${var.namespace}_bag_verifier_post_replicate_input"
 
   topic_names = ["${module.bag_replicator_output_topic.name}"]
 
-  role_names = ["${module.bag_verifier.task_role_name}"]
+  role_names = ["${module.bag_verifier_post_replication.task_role_name}"]
 
   # We keep a high visibility timeout to
   # avoid messages appearing to time out and fail.
@@ -188,24 +188,24 @@ module "bag_verifier_input_queue" {
   max_receive_count = 1
 
   queue_high_actions = [
-    "${module.bag_verifier.scale_up_arn}",
+    "${module.bag_verifier_post_replication.scale_up_arn}",
   ]
 
   queue_low_actions = [
-    "${module.bag_verifier.scale_down_arn}",
+    "${module.bag_verifier_post_replication.scale_down_arn}",
   ]
 
   aws_region    = "${var.aws_region}"
   dlq_alarm_arn = "${var.dlq_alarm_arn}"
 }
 
-module "bag_verifier_output_topic" {
+module "bag_verifier_post_replicate_output_topic" {
   source = "../modules/topic"
 
-  name = "${var.namespace}_bag_verifier_output"
+  name = "${var.namespace}_bag_verifier_post_replicate_output"
 
   role_names = [
-    "${module.bag_verifier.task_role_name}",
+    "${module.bag_verifier_post_replication.task_role_name}",
   ]
 }
 
@@ -216,7 +216,7 @@ module "bag_register_input_queue" {
 
   name = "${var.namespace}_bag_register_input"
 
-  topic_names = ["${module.bag_verifier_output_topic.name}"]
+  topic_names = ["${module.bag_verifier_post_replicate_output_topic.name}"]
 
   role_names = ["${module.bag_register.task_role_name}"]
 

--- a/terraform/stack/messaging.tf
+++ b/terraform/stack/messaging.tf
@@ -8,6 +8,7 @@ module "ingests_topic" {
   role_names = [
     "${module.bag_register.task_role_name}",
     "${module.bag_replicator.task_role_name}",
+    "${module.bag_verifier_pre_replication.task_role_name}",
     "${module.bag_verifier_post_replication.task_role_name}",
     "${module.bag_unpacker.task_role_name}",
     "${module.ingests.task_role_name}",


### PR DESCRIPTION
Closes wellcometrust/platform#3520. This adds a new verification after unpacking succeeds but before we replicate the bag. The new event list looks as follows:

```json
  "events": [
    {
      "createdDate": "2019-04-08T11:06:12.903439Z",
      "description": "Unpacking succeeded",
      "type": "IngestEvent"
    },
    {
      "createdDate": "2019-04-08T11:06:13.406794Z",
      "description": "Verification succeeded",
      "type": "IngestEvent"
    },
    {
      "createdDate": "2019-04-08T11:06:16.357395Z",
      "description": "Replicating succeeded",
      "type": "IngestEvent"
    },
    {
      "createdDate": "2019-04-08T11:06:17.474Z",
      "description": "Verification succeeded",
      "type": "IngestEvent"
    },
    {
      "createdDate": "2019-04-08T11:06:22.412378Z",
      "description": "Register succeeded (completed)",
      "type": "IngestEvent"
    }
  ],
```