### PR TITLE
Add a couple of new PRONOM mappings to the bagger

### DIFF
--- a/bagger/src/mappings.py
+++ b/bagger/src/mappings.py
@@ -18,6 +18,15 @@ PRONOM = {
     "Acrobat PDF/X - Portable Document Format - Exchange 1a:2001": "fmt/157",
     "Acrobat PDF/X - Portable Document Format - Exchange PDF/X-4": "fmt/488",
     "Extensible Markup Language 1.0": "fmt/101",
+
+    "JPEG File Interchange Format 1.01": "fmt/43",
+
+    "OLE2 Compound Document Format": "fmt/111",
+
+    "Plain Text File": "x-fmt/111",
+
+    "Tagged Image File Format": "fmt/353",
+
     "Waveform Audio (PCMWAVEFORMAT)": "fmt/141",
 }
 

--- a/bagger/src/mappings.py
+++ b/bagger/src/mappings.py
@@ -19,15 +19,10 @@ PRONOM = {
     "Acrobat PDF/X - Portable Document Format - Exchange 1a:2001": "fmt/157",
     "Acrobat PDF/X - Portable Document Format - Exchange PDF/X-4": "fmt/488",
     "Extensible Markup Language 1.0": "fmt/101",
-
     "JPEG File Interchange Format 1.01": "fmt/43",
-
     "OLE2 Compound Document Format": "fmt/111",
-
     "Plain Text File": "x-fmt/111",
-
     "Tagged Image File Format": "fmt/353",
-
     "Waveform Audio (PCMWAVEFORMAT)": "fmt/141",
 }
 

--- a/bagger/src/mappings.py
+++ b/bagger/src/mappings.py
@@ -15,6 +15,7 @@ PRONOM = {
     "Acrobat PDF 1.5 - Portable Document Format 1.5": "fmt/19",
     "Acrobat PDF 1.6 - Portable Document Format 1.6": "fmt/20",
     "Acrobat PDF 1.7 - Portable Document Format 1.7": "fmt/276",
+    "Acrobat PDF/A - Portable Document Format 1b": "fmt/354",
     "Acrobat PDF/X - Portable Document Format - Exchange 1a:2001": "fmt/157",
     "Acrobat PDF/X - Portable Document Format - Exchange PDF/X-4": "fmt/488",
     "Extensible Markup Language 1.0": "fmt/101",

--- a/bagger/src/tech_md.py
+++ b/bagger/src/tech_md.py
@@ -81,8 +81,10 @@ def remodel_file_technical_metadata(root, id_map):
         )
         format_registry_name.text = "PRONOM"  # assume this is always used
         format_registry_key = make_child(format_registry, "premis", "formatRegistryKey")
-        format_registry_key.text = mappings.PRONOM[
-            format_name.text
-        ]  # allow this to raise error if missing key!
+
+        try:
+            format_registry_key.text = mappings.PRONOM[format_name.text]
+        except KeyError:
+            raise KeyError("Unrecognised PRONOM format: %s" % format_name.text)
 
         remove_first_child(xmldata)

--- a/bagger/src/tech_md.py
+++ b/bagger/src/tech_md.py
@@ -19,6 +19,10 @@ def add_premis_significant_prop(premis_file, p_type, value):
     value_el.text = value
 
 
+class UnrecognisedPRONOMFormatError(KeyError):
+    pass
+
+
 def remodel_file_technical_metadata(root, id_map):
     logging.debug("transforming Tessella techMD")
     x_path = ".//mets:xmlData[tessella:File]"
@@ -85,6 +89,6 @@ def remodel_file_technical_metadata(root, id_map):
         try:
             format_registry_key.text = mappings.PRONOM[format_name.text]
         except KeyError:
-            raise KeyError("Unrecognised PRONOM format: %s" % format_name.text)
+            raise UnrecognisedPRONOMFormatError(format_name.text)
 
         remove_first_child(xmldata)

--- a/terraform/main_colbert.tf
+++ b/terraform/main_colbert.tf
@@ -13,8 +13,8 @@ module "stack-colbert" {
   domain_name      = "${local.staging_domain_name}"
   cert_domain_name = "${local.cert_domain_name}"
 
-  desired_bagger_count  = 12
-  desired_ec2_instances = 4
+  desired_bagger_count  = 0
+  desired_ec2_instances = 0
 
   vpc_id   = "${local.vpc_id}"
   vpc_cidr = "${local.vpc_cidr}"

--- a/terraform/main_stewart.tf
+++ b/terraform/main_stewart.tf
@@ -13,8 +13,8 @@ module "stack-stewart" {
   domain_name      = "${local.domain_name}"
   cert_domain_name = "${local.cert_domain_name}"
 
-  desired_bagger_count  = 0  # 3
-  desired_ec2_instances = 0  # 1
+  desired_bagger_count  = 0 # 3
+  desired_ec2_instances = 0 # 1
 
   vpc_id   = "${local.vpc_id}"
   vpc_cidr = "${local.vpc_cidr}"

--- a/terraform/main_stewart.tf
+++ b/terraform/main_stewart.tf
@@ -13,6 +13,9 @@ module "stack-stewart" {
   domain_name      = "${local.domain_name}"
   cert_domain_name = "${local.cert_domain_name}"
 
+  desired_bagger_count  = 12
+  desired_ec2_instances = 4
+
   vpc_id   = "${local.vpc_id}"
   vpc_cidr = "${local.vpc_cidr}"
 
@@ -20,8 +23,6 @@ module "stack-stewart" {
 
   ssh_key_name = "${local.key_name}"
   infra_bucket = "${aws_s3_bucket.infra.id}"
-
-  desired_ec2_instances = 1
 
   lambda_error_alarm_arn = "${local.lambda_error_alarm_arn}"
   dlq_alarm_arn          = "${local.dlq_alarm_arn}"

--- a/terraform/main_stewart.tf
+++ b/terraform/main_stewart.tf
@@ -13,8 +13,8 @@ module "stack-stewart" {
   domain_name      = "${local.domain_name}"
   cert_domain_name = "${local.cert_domain_name}"
 
-  desired_bagger_count  = 12
-  desired_ec2_instances = 4
+  desired_bagger_count  = 0  # 3
+  desired_ec2_instances = 0  # 1
 
   vpc_id   = "${local.vpc_id}"
   vpc_cidr = "${local.vpc_cidr}"


### PR DESCRIPTION
This adds a couple of new PRONOM mappings that the bagger doesn't recognise (based on the errors in the dashboard), and makes the error a bit more descriptive when it occurs.

For wellcometrust/platform#3322.