### PR TITLE
Add config for operation name to all the services

### DIFF
--- a/bag_register/src/main/resources/application.conf
+++ b/bag_register/src/main/resources/application.conf
@@ -5,3 +5,4 @@ aws.vhs.dynamo.tableName=${?vhs_table_name}
 aws.vhs.s3.bucketName=${?vhs_bucket_name}
 aws.vhs.s3.globalPrefix=archive
 aws.metrics.namespace=${?metrics_namespace}
+operation.name=${?operation_name}

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/Main.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/Main.scala
@@ -18,6 +18,7 @@ import uk.ac.wellcome.platform.archive.bag_register.services.{
 import uk.ac.wellcome.platform.archive.bagunpacker.config.builders.AlpakkaSqsWorkerConfigBuilder
 import uk.ac.wellcome.platform.archive.common.config.builders.{
   IngestUpdaterBuilder,
+  OperationNameBuilder,
   OutgoingPublisherBuilder
 }
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
@@ -55,7 +56,8 @@ object Main extends WellcomeTypesafeApp {
       underlying = VHSBuilder.buildVHS[StorageManifest, EmptyMetadata](config)
     )
 
-    val operationName = "register"
+    val operationName = OperationNameBuilder
+      .getName(config, default = "register")
 
     val ingestUpdater = IngestUpdaterBuilder.build(
       config,

--- a/bag_replicator/src/main/resources/application.conf
+++ b/bag_replicator/src/main/resources/application.conf
@@ -3,3 +3,4 @@ aws.ingest.sns.topic.arn=${?ingest_topic_arn}
 aws.outgoing.sns.topic.arn=${?outgoing_topic_arn}
 bag-replicator.storage.destination.bucket=${?destination_bucket_name}
 aws.metrics.namespace=${?metrics_namespace}
+operation.name=${?operation_name}

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/Main.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/Main.scala
@@ -18,6 +18,7 @@ import uk.ac.wellcome.platform.archive.bagreplicator.services.{
 import uk.ac.wellcome.platform.archive.bagunpacker.config.builders.AlpakkaSqsWorkerConfigBuilder
 import uk.ac.wellcome.platform.archive.common.config.builders.{
   IngestUpdaterBuilder,
+  OperationNameBuilder,
   OutgoingPublisherBuilder
 }
 import uk.ac.wellcome.storage.typesafe.S3Builder
@@ -42,7 +43,8 @@ object Main extends WellcomeTypesafeApp {
     implicit val sqsClient: AmazonSQSAsync =
       SQSBuilder.buildSQSAsyncClient(config)
 
-    val operationName = "replicating"
+    val operationName = OperationNameBuilder
+      .getName(config, default = "replicating")
 
     new BagReplicatorWorker(
       alpakkaSQSWorkerConfig = AlpakkaSqsWorkerConfigBuilder.build(config),

--- a/bag_unpacker/src/main/resources/application.conf
+++ b/bag_unpacker/src/main/resources/application.conf
@@ -5,3 +5,4 @@ aws.outgoing.sns.topic.arn=${?outgoing_topic_arn}
 aws.metrics.namespace=${?metrics_namespace}
 destination.namespace=${?destination_bucket_name}
 destination.prefix=unpacked
+operation.name=${?operation_name}

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/Main.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/Main.scala
@@ -19,6 +19,7 @@ import uk.ac.wellcome.platform.archive.bagunpacker.services.{
 }
 import uk.ac.wellcome.platform.archive.common.config.builders.{
   IngestUpdaterBuilder,
+  OperationNameBuilder,
   OutgoingPublisherBuilder
 }
 import uk.ac.wellcome.storage.typesafe.S3Builder._
@@ -53,20 +54,21 @@ object Main extends WellcomeTypesafeApp {
     val unpackerWorkerConfig =
       UnpackerWorkerConfigBuilder.build(config)
 
+    val operationName = OperationNameBuilder
+      .getName(config, default = "unpacking")
+
     val ingestUpdater =
-      IngestUpdaterBuilder.build(config, "unpacking")
+      IngestUpdaterBuilder.build(config, operationName = operationName)
 
     val outgoingPublisher =
-      OutgoingPublisherBuilder.build(config, "unpacking")
-
-    val unpacker =
-      Unpacker(s3Uploader = new S3Uploader())
+      OutgoingPublisherBuilder.build(config, operationName = operationName)
 
     BagUnpackerWorker(
-      alpakkaSQSWorkerConfig,
-      unpackerWorkerConfig,
-      ingestUpdater,
-      outgoingPublisher,
-      unpacker)
+      alpakkaSQSWorkerConfig = alpakkaSQSWorkerConfig,
+      bagUnpackerWorkerConfig = unpackerWorkerConfig,
+      ingestUpdater = ingestUpdater,
+      outgoingPublisher = outgoingPublisher,
+      unpacker = Unpacker(s3Uploader = new S3Uploader())
+    )
   }
 }

--- a/bag_verifier/src/main/resources/application.conf
+++ b/bag_verifier/src/main/resources/application.conf
@@ -2,3 +2,4 @@ aws.sqs.queue.url=${?queue_url}
 aws.ingest.sns.topic.arn=${?ingest_topic_arn}
 aws.outgoing.sns.topic.arn=${?outgoing_topic_arn}
 aws.metrics.namespace=${?metrics_namespace}
+operation.name=${?operation_name}

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/Main.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/Main.scala
@@ -18,6 +18,7 @@ import uk.ac.wellcome.platform.archive.bagverifier.services.{
 }
 import uk.ac.wellcome.platform.archive.common.config.builders.{
   IngestUpdaterBuilder,
+  OperationNameBuilder,
   OutgoingPublisherBuilder
 }
 import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestService
@@ -49,7 +50,8 @@ object Main extends WellcomeTypesafeApp {
       algorithm = MessageDigestAlgorithms.SHA_256
     )
 
-    val operationName = "verification"
+    val operationName = OperationNameBuilder
+      .getName(config, default = "verification")
 
     val ingestUpdater = IngestUpdaterBuilder.build(config, operationName)
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/config/builders/OperationNameBuilder.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/config/builders/OperationNameBuilder.scala
@@ -1,0 +1,9 @@
+package uk.ac.wellcome.platform.archive.common.config.builders
+
+import com.typesafe.config.Config
+import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
+
+object OperationNameBuilder {
+  def getName(config: Config, default: String): String =
+    config.getOrElse[String]("operation.name")(default)
+}

--- a/terraform/stack/main.tf
+++ b/terraform/stack/main.tf
@@ -21,10 +21,11 @@ module "bag_unpacker" {
     ingest_topic_arn        = "${module.ingests_topic.arn}"
     outgoing_topic_arn      = "${module.bag_unpacker_output_topic.arn}"
     metrics_namespace       = "${local.bag_unpacker_service_name}"
+    operation_name          = "unpacking"
     JAVA_OPTS               = "-Dcom.amazonaws.sdk.enableDefaultMetrics=cloudwatchRegion=${var.aws_region},metricNameSpace=${local.bag_unpacker_service_name}"
   }
 
-  env_vars_length = 7
+  env_vars_length = 8
 
   cpu    = 2048
   memory = 4096
@@ -56,10 +57,11 @@ module "bag_verifier_pre_replication" {
     ingest_topic_arn   = "${module.ingests_topic.arn}"
     outgoing_topic_arn = "${module.bag_verifier_pre_replicate_output_topic.arn}"
     metrics_namespace  = "${local.bag_verifier_pre_repl_service_name}"
+    operation_name     = "verification (pre-replicating to archive storage)"
     JAVA_OPTS          = "-Dcom.amazonaws.sdk.enableDefaultMetrics=cloudwatchRegion=${var.aws_region},metricNameSpace=${local.bag_verifier_pre_repl_service_name}"
   }
 
-  env_vars_length = 5
+  env_vars_length = 6
 
   cpu    = 2048
   memory = 4096
@@ -92,13 +94,14 @@ module "bag_replicator" {
     ingest_topic_arn        = "${module.ingests_topic.arn}"
     outgoing_topic_arn      = "${module.bag_replicator_output_topic.arn}"
     metrics_namespace       = "${local.bag_replicator_service_name}"
+    operation_name          = "replicating to archive storage"
     JAVA_OPTS               = "-Dcom.amazonaws.sdk.enableDefaultMetrics=cloudwatchRegion=${var.aws_region},metricNameSpace=${local.bag_replicator_service_name}"
   }
 
+  env_vars_length = 7
+
   cpu    = 1024
   memory = 2048
-
-  env_vars_length = 6
 
   min_capacity = "1"
   max_capacity = "10"
@@ -127,10 +130,11 @@ module "bag_verifier_post_replication" {
     ingest_topic_arn   = "${module.ingests_topic.arn}"
     outgoing_topic_arn = "${module.bag_verifier_post_replicate_output_topic.arn}"
     metrics_namespace  = "${local.bag_verifier_post_repl_service_name}"
+    operation_name     = "verification (inside archive storage)"
     JAVA_OPTS          = "-Dcom.amazonaws.sdk.enableDefaultMetrics=cloudwatchRegion=${var.aws_region},metricNameSpace=${local.bag_verifier_post_repl_service_name}"
   }
 
-  env_vars_length = 5
+  env_vars_length = 6
 
   cpu    = 2048
   memory = 4096
@@ -160,10 +164,11 @@ module "bag_register" {
     vhs_bucket_name   = "${var.vhs_archive_manifest_bucket_name}"
     vhs_table_name    = "${var.vhs_archive_manifest_table_name}"
     metrics_namespace = "${local.bag_register_service_name}"
+    operation_name    = "register"
     JAVA_OPTS         = "-Dcom.amazonaws.sdk.enableDefaultMetrics=cloudwatchRegion=${var.aws_region},metricNameSpace=${local.bag_register_service_name}"
   }
 
-  env_vars_length = 8
+  env_vars_length = 9
 
   min_capacity = "1"
   max_capacity = "10"


### PR DESCRIPTION
So workers can identify themselves. Right now the verifiers and replicator both include some additional context.

For wellcometrust/platform#3601