### PR TITLE
Prepare for payloads!

### DIFF
--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/AuditSummary.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/AuditSummary.scala
@@ -2,12 +2,13 @@ package uk.ac.wellcome.platform.storage.bagauditor.models
 
 import java.time.Instant
 
-import uk.ac.wellcome.platform.archive.common.bagit.models.BagLocation
 import uk.ac.wellcome.platform.archive.common.operation.models.Summary
+import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.ObjectLocation
 
 case class AuditSummary(
-  source: BagLocation,
+  unpackLocation: ObjectLocation,
+  storageSpace: StorageSpace,
   maybeRoot: Option[ObjectLocation] = None,
   startTime: Instant,
   endTime: Option[Instant] = None,

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
@@ -3,14 +3,15 @@ package uk.ac.wellcome.platform.storage.bagauditor.services
 import java.time.Instant
 
 import com.amazonaws.services.s3.AmazonS3
-import uk.ac.wellcome.platform.archive.common.bagit.models.BagLocation
 import uk.ac.wellcome.platform.archive.common.storage.models.{
   IngestFailed,
   IngestStepResult,
-  IngestStepSucceeded
+  IngestStepSucceeded,
+  StorageSpace
 }
 import uk.ac.wellcome.platform.archive.common.storage.services.S3BagLocator
 import uk.ac.wellcome.platform.storage.bagauditor.models.AuditSummary
+import uk.ac.wellcome.storage.ObjectLocation
 
 import scala.util.{Failure, Success, Try}
 
@@ -18,13 +19,15 @@ class BagAuditor(implicit s3Client: AmazonS3) {
   val s3BagLocator = new S3BagLocator(s3Client)
 
   def locateBagRoot(
-    bagLocation: BagLocation): Try[IngestStepResult[AuditSummary]] = {
+    unpackLocation: ObjectLocation,
+    storageSpace: StorageSpace): Try[IngestStepResult[AuditSummary]] = {
     val auditSummary = AuditSummary(
       startTime = Instant.now(),
-      source = bagLocation
+      unpackLocation = unpackLocation,
+      storageSpace = storageSpace
     )
 
-    s3BagLocator.locateBagRoot(bagLocation.objectLocation) match {
+    s3BagLocator.locateBagRoot(unpackLocation) match {
       case Success(root) =>
         Success(
           IngestStepSucceeded(

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/models/RegistrationSummary.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/models/RegistrationSummary.scala
@@ -2,11 +2,14 @@ package uk.ac.wellcome.platform.archive.bag_register.models
 
 import java.time.Instant
 
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, BagLocation}
+import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
 import uk.ac.wellcome.platform.archive.common.operation.models.Summary
+import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
+import uk.ac.wellcome.storage.ObjectLocation
 
 case class RegistrationSummary(
-  location: BagLocation,
+  bagRootLocation: ObjectLocation,
+  storageSpace: StorageSpace,
   bagId: Option[BagId] = None,
   startTime: Instant,
   endTime: Option[Instant] = None
@@ -17,7 +20,8 @@ case class RegistrationSummary(
     )
 
   override def toString: String =
-    f"""|bag=${location.completePath}
+    f"""|bag=$bagRootLocation
+        |space=$storageSpace
         |id=${bagId.getOrElse("<unknown-bag>")}
         |durationSeconds=$durationSeconds
         |duration=$formatDuration""".stripMargin

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorker.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorker.scala
@@ -43,7 +43,10 @@ class BagRegisterWorker(
   def processMessage(
     bagRequest: BagRequest): Future[Result[RegistrationSummary]] =
     for {
-      registrationSummary <- register.update(bagRequest.bagLocation)
+      registrationSummary <- register.update(
+        bagRootLocation = bagRequest.bagLocation.objectLocation,
+        storageSpace = bagRequest.bagLocation.storageSpace
+      )
       _ <- ingestUpdater.send(
         bagRequest.ingestId,
         registrationSummary,

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/Register.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/Register.scala
@@ -3,16 +3,17 @@ package uk.ac.wellcome.platform.archive.bag_register.services
 import java.time.Instant
 
 import uk.ac.wellcome.platform.archive.bag_register.models.RegistrationSummary
-import uk.ac.wellcome.platform.archive.common.bagit.models.BagLocation
 import uk.ac.wellcome.platform.archive.common.storage.models.{
   IngestCompleted,
   IngestFailed,
-  IngestStepResult
+  IngestStepResult,
+  StorageSpace
 }
 import uk.ac.wellcome.platform.archive.common.storage.services.{
   StorageManifestService,
   StorageManifestVHS
 }
+import uk.ac.wellcome.storage.ObjectLocation
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
@@ -25,17 +26,21 @@ class Register(
   type FutureSummary =
     Future[IngestStepResult[RegistrationSummary]]
 
-  def update(bagLocation: BagLocation): FutureSummary = {
+  def update(
+    bagRootLocation: ObjectLocation,
+    storageSpace: StorageSpace
+  ): FutureSummary = {
     val registration = RegistrationSummary(
       startTime = Instant.now(),
-      location = bagLocation
+      bagRootLocation = bagRootLocation,
+      storageSpace = storageSpace
     )
 
     for {
       manifest <- storageManifestService
         .createManifest(
-          bagRootLocation = bagLocation.objectLocation,
-          storageSpace = bagLocation.storageSpace
+          bagRootLocation = bagRootLocation,
+          storageSpace = storageSpace
         )
 
       registrationWithBagId = registration.copy(bagId = Some(manifest.id))

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/Register.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/Register.scala
@@ -20,24 +20,23 @@ import scala.util.{Failure, Success}
 class Register(
   storageManifestService: StorageManifestService,
   storageManifestVHS: StorageManifestVHS
-) {
+)(implicit ec: ExecutionContext) {
 
   type FutureSummary =
     Future[IngestStepResult[RegistrationSummary]]
 
-  def update(
-    location: BagLocation
-  )(implicit
-    ec: ExecutionContext): FutureSummary = {
-
+  def update(bagLocation: BagLocation): FutureSummary = {
     val registration = RegistrationSummary(
       startTime = Instant.now(),
-      location = location
+      location = bagLocation
     )
 
     for {
       manifest <- storageManifestService
-        .createManifest(location)
+        .createManifest(
+          bagRootLocation = bagLocation.objectLocation,
+          storageSpace = bagLocation.storageSpace
+        )
 
       registrationWithBagId = registration.copy(bagId = Some(manifest.id))
 

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/BagRegisterFeatureTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/BagRegisterFeatureTest.scala
@@ -37,15 +37,14 @@ class BagRegisterFeatureTest
       case (_, table, bucket, ingestTopic, _, queuePair) =>
         val createdAfterDate = Instant.now()
         val bagInfo = createBagInfo
-        val storagePrefix = "storagePrefix"
 
-        withBag(bucket, bagInfo, storagePrefix) { location =>
+        withBag(bucket, bagInfo = bagInfo) { bagLocation =>
           val bagId = BagId(
-            space = location.storageSpace,
+            space = bagLocation.storageSpace,
             externalIdentifier = bagInfo.externalIdentifier
           )
 
-          val bagRequest = createBagRequestWith(location)
+          val bagRequest = createBagRequestWith(bagLocation)
 
           sendNotificationToSQS(queuePair.queue, bagRequest)
 
@@ -59,7 +58,7 @@ class BagRegisterFeatureTest
             storageManifest.locations shouldBe List(
               StorageLocation(
                 provider = InfrequentAccessStorageProvider,
-                location = location.objectLocation
+                location = bagLocation.objectLocation
               )
             )
 

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
@@ -80,28 +80,26 @@ class BagRegisterWorkerTest
       case (service, _, bucket, ingestTopic, _, _) =>
         val bagInfo = createBagInfo
 
-        withBag(bucket, bagInfo = bagInfo, storagePrefix = "access") {
-          accessBagLocation =>
-            val bagRequest =
-              createBagRequestWith(accessBagLocation)
+        withBag(bucket, bagInfo = bagInfo) { bagLocation =>
+          val bagRequest = createBagRequestWith(bagLocation)
 
-            val bagId = BagId(
-              space = accessBagLocation.storageSpace,
-              externalIdentifier = bagInfo.externalIdentifier
-            )
+          val bagId = BagId(
+            space = bagLocation.storageSpace,
+            externalIdentifier = bagInfo.externalIdentifier
+          )
 
-            val future = service.processMessage(bagRequest)
+          val future = service.processMessage(bagRequest)
 
-            whenReady(future) { _ =>
-              assertTopicReceivesIngestStatus(
-                ingestId = bagRequest.ingestId,
-                ingestTopic = ingestTopic,
-                status = Ingest.Failed,
-                expectedBag = Some(bagId)) { events =>
-                events.size should be >= 1
-                events.head.description shouldBe "Register failed"
-              }
+          whenReady(future) { _ =>
+            assertTopicReceivesIngestStatus(
+              ingestId = bagRequest.ingestId,
+              ingestTopic = ingestTopic,
+              status = Ingest.Failed,
+              expectedBag = Some(bagId)) { events =>
+              events.size should be >= 1
+              events.head.description shouldBe "Register failed"
             }
+          }
         }
     }
   }

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/models/ReplicationSummary.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/models/ReplicationSummary.scala
@@ -4,9 +4,12 @@ import java.time.Instant
 
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagLocation
 import uk.ac.wellcome.platform.archive.common.operation.models.Summary
+import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
+import uk.ac.wellcome.storage.ObjectLocation
 
 case class ReplicationSummary(
-  source: BagLocation,
+  bagRootLocation: ObjectLocation,
+  storageSpace: StorageSpace,
   maybeDestination: Option[BagLocation] = None,
   startTime: Instant,
   endTime: Option[Instant] = None,
@@ -29,7 +32,7 @@ case class ReplicationSummary(
       case None              => "<no-destination>"
       case Some(destination) => destination.completePath
     }
-    f"""|src=${source.completePath}
+    f"""|src=$bagRootLocation
         |dst=$destinationCompletePath
         |durationSeconds=$durationSeconds
         |duration=$formatDuration""".stripMargin

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicator.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicator.scala
@@ -33,9 +33,8 @@ class BagReplicator(config: ReplicatorDestinationConfig)(
   val s3PrefixCopier = S3PrefixCopier(s3Client)
   val s3BagLocator = new S3BagLocator(s3Client)
 
-  def replicate(
-    bagRootLocation: ObjectLocation,
-    storageSpace: StorageSpace): Future[IngestStepResult[ReplicationSummary]] = {
+  def replicate(bagRootLocation: ObjectLocation, storageSpace: StorageSpace)
+    : Future[IngestStepResult[ReplicationSummary]] = {
     val replicationSummary = ReplicationSummary(
       startTime = Instant.now(),
       bagRootLocation = bagRootLocation,

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicator.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicator.scala
@@ -6,6 +6,7 @@ import java.time.Instant
 import com.amazonaws.services.s3.AmazonS3
 import uk.ac.wellcome.platform.archive.bagreplicator.config.ReplicatorDestinationConfig
 import uk.ac.wellcome.platform.archive.bagreplicator.models.ReplicationSummary
+import uk.ac.wellcome.platform.archive.common.ConvertibleToInputStream._
 import uk.ac.wellcome.platform.archive.common.bagit.models.{
   BagInfo,
   BagLocation,
@@ -13,15 +14,15 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.{
   ExternalIdentifier
 }
 import uk.ac.wellcome.platform.archive.common.bagit.parsers.BagInfoParser
-import uk.ac.wellcome.platform.archive.common.ConvertibleToInputStream._
 import uk.ac.wellcome.platform.archive.common.storage.models.{
   IngestFailed,
   IngestStepResult,
-  IngestStepSucceeded
+  IngestStepSucceeded,
+  StorageSpace
 }
 import uk.ac.wellcome.platform.archive.common.storage.services.S3BagLocator
 import uk.ac.wellcome.storage.ObjectLocation
-import uk.ac.wellcome.storage.s3.S3PrefixCopier
+import uk.ac.wellcome.storage.s3.{S3PrefixCopier, S3PrefixCopierResult}
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
@@ -33,23 +34,24 @@ class BagReplicator(config: ReplicatorDestinationConfig)(
   val s3BagLocator = new S3BagLocator(s3Client)
 
   def replicate(
-    location: BagLocation
-  ): Future[IngestStepResult[ReplicationSummary]] = {
+    bagRootLocation: ObjectLocation,
+    storageSpace: StorageSpace): Future[IngestStepResult[ReplicationSummary]] = {
     val replicationSummary = ReplicationSummary(
       startTime = Instant.now(),
-      source = location
+      bagRootLocation = bagRootLocation,
+      storageSpace = storageSpace
     )
 
     val copyOperation = for {
-      identifier <- getBagIdentifier(location)
+      identifier <- getBagIdentifier(bagRootLocation)
 
       destination = buildDestination(
-        location,
-        identifier
+        storageSpace = storageSpace,
+        id = identifier
       )
 
       bagRoot <- Future.fromTry {
-        s3BagLocator.locateBagRoot(location.objectLocation)
+        s3BagLocator.locateBagRoot(bagRootLocation)
       }
 
       _ <- copyBag(
@@ -79,7 +81,7 @@ class BagReplicator(config: ReplicatorDestinationConfig)(
   private def copyBag(
     bagRoot: ObjectLocation,
     destination: BagLocation
-  ) =
+  ): Future[S3PrefixCopierResult] =
     s3PrefixCopier
       .copyObjects(
         srcLocationPrefix = bagRoot,
@@ -87,20 +89,20 @@ class BagReplicator(config: ReplicatorDestinationConfig)(
       )
 
   private def buildDestination(
-    location: BagLocation,
+    storageSpace: StorageSpace,
     id: ExternalIdentifier
   ) = BagLocation(
     storageNamespace = config.namespace,
     storagePrefix = config.rootPath,
-    storageSpace = location.storageSpace,
+    storageSpace = storageSpace,
     bagPath = BagPath(id.underlying)
   )
 
   private def getBagIdentifier(
-    bagLocation: BagLocation): Future[ExternalIdentifier] =
+    bagRootLocation: ObjectLocation): Future[ExternalIdentifier] =
     for {
       bagInfoLocation <- Future.fromTry {
-        s3BagLocator.locateBagInfo(bagLocation.objectLocation)
+        s3BagLocator.locateBagInfo(bagRootLocation)
       }
       inputStream: InputStream <- bagInfoLocation.toInputStream
       bagInfo: BagInfo <- BagInfoParser.create(inputStream)

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/models/VerificationSummary.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/models/VerificationSummary.scala
@@ -2,14 +2,12 @@ package uk.ac.wellcome.platform.archive.bagverifier.models
 
 import java.time.Instant
 
-import uk.ac.wellcome.platform.archive.common.bagit.models.{
-  BagDigestFile,
-  BagLocation
-}
+import uk.ac.wellcome.platform.archive.common.bagit.models.BagDigestFile
 import uk.ac.wellcome.platform.archive.common.operation.models.Summary
+import uk.ac.wellcome.storage.ObjectLocation
 
 case class VerificationSummary(
-  bagLocation: BagLocation,
+  bagRootLocation: ObjectLocation,
   successfulVerifications: Seq[BagDigestFile] = List.empty,
   failedVerifications: Seq[FailedVerification] = List.empty,
   startTime: Instant = Instant.now(),
@@ -24,7 +22,7 @@ case class VerificationSummary(
         "successful"
       else
         "failed"
-    f"""|bag=${bagLocation.completePath}
+    f"""|bag=$bagRootLocation
         |status=$status
         |verified=${successfulVerifications.size}
         |failed=${failedVerifications.size}

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorker.scala
@@ -46,9 +46,8 @@ class BagVerifierWorker(
 
   def processMessage(request: BagRequest): Future[Result[VerificationSummary]] =
     for {
-
       verificationSummary: IngestStepResult[VerificationSummary] <- verifier
-        .verify(request.bagLocation)
+        .verify(request.bagLocation.objectLocation)
       _ <- ingestUpdater.send(request.ingestId, verificationSummary)
       _ <- outgoingPublisher.sendIfSuccessful(verificationSummary, request)
     } yield toResult(verificationSummary)

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/Verifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/Verifier.scala
@@ -57,7 +57,10 @@ class Verifier(
 
       digestFiles = fileManifest.files ++ tagManifest.files
 
-      result <- verifyFiles(actualBagRootLocation, digestFiles, verificationSummary)
+      result <- verifyFiles(
+        actualBagRootLocation,
+        digestFiles,
+        verificationSummary)
     } yield result
 
     verification.map {

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/Verifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/Verifier.scala
@@ -10,10 +10,7 @@ import uk.ac.wellcome.platform.archive.bagverifier.models.{
   FailedVerification,
   VerificationSummary
 }
-import uk.ac.wellcome.platform.archive.common.bagit.models.{
-  BagDigestFile,
-  BagLocation
-}
+import uk.ac.wellcome.platform.archive.common.bagit.models.BagDigestFile
 import uk.ac.wellcome.platform.archive.common.storage.models.{
   FileManifest,
   IngestFailed,
@@ -34,31 +31,33 @@ class Verifier(
   storageManifestService: StorageManifestService,
   s3Client: AmazonS3,
   algorithm: String
-)(implicit ec: ExecutionContext, mat: Materializer)
+)(implicit ec: ExecutionContext, materializer: Materializer)
     extends Logging {
   val s3BagLocator = new S3BagLocator(s3Client)
 
   def verify(
-    bagLocation: BagLocation
+    bagRootLocation: ObjectLocation
   ): Future[IngestStepResult[VerificationSummary]] = {
 
-    val verificationInit =
-      VerificationSummary(bagLocation = bagLocation, startTime = Instant.now)
+    val verificationSummary = VerificationSummary(
+      bagRootLocation = bagRootLocation,
+      startTime = Instant.now
+    )
 
     val verification = for {
-      bagRootLocation <- Future.fromTry {
-        s3BagLocator.locateBagRoot(bagLocation.objectLocation)
+      actualBagRootLocation <- Future.fromTry {
+        s3BagLocator.locateBagRoot(bagRootLocation)
       }
       fileManifest <- getManifest("file manifest") {
-        storageManifestService.createFileManifest(bagRootLocation)
+        storageManifestService.createFileManifest(actualBagRootLocation)
       }
       tagManifest <- getManifest("tag manifest") {
-        storageManifestService.createTagManifest(bagRootLocation)
+        storageManifestService.createTagManifest(actualBagRootLocation)
       }
 
       digestFiles = fileManifest.files ++ tagManifest.files
 
-      result <- verifyFiles(bagRootLocation, digestFiles, verificationInit)
+      result <- verifyFiles(actualBagRootLocation, digestFiles, verificationSummary)
     } yield result
 
     verification.map {
@@ -69,7 +68,7 @@ class Verifier(
           new RuntimeException("Verification failed")
         )
     } recover {
-      case e: Throwable => IngestFailed(verificationInit, e)
+      case e: Throwable => IngestFailed(verificationSummary, e)
     }
   }
 
@@ -84,7 +83,7 @@ class Verifier(
     bagRootLocation: ObjectLocation,
     digestFiles: Seq[BagDigestFile],
     bagVerification: VerificationSummary
-  )(implicit mat: Materializer): Future[VerificationSummary] = {
+  ): Future[VerificationSummary] = {
     Source[BagDigestFile](
       digestFiles.toList
     ).mapAsync(10) { digestFile: BagDigestFile =>

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/models/VerificationSummaryTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/models/VerificationSummaryTest.scala
@@ -9,15 +9,17 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.{
 }
 import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
 import uk.ac.wellcome.platform.archive.common.generators.BagLocationGenerators
+import uk.ac.wellcome.storage.fixtures.S3
 
 class VerificationSummaryTest
     extends FunSpec
     with Matchers
     with RandomThings
-    with BagLocationGenerators {
+    with BagLocationGenerators
+    with S3 {
   it("reports a verification with no failures as successful") {
     val result = VerificationSummary(
-      createBagLocation(),
+      createObjectLocation,
       successfulVerifications =
         Seq(createBagDigestFile, createBagDigestFile, createBagDigestFile),
       failedVerifications = List.empty
@@ -28,7 +30,7 @@ class VerificationSummaryTest
 
   it("reports a verification with some problems as unsuccessful") {
     val result = VerificationSummary(
-      createBagLocation(),
+      createObjectLocation,
       successfulVerifications = Seq(createBagDigestFile, createBagDigestFile),
       failedVerifications = List(
         FailedVerification(
@@ -43,7 +45,7 @@ class VerificationSummaryTest
 
   it("calculates duration once completed") {
     val result = VerificationSummary(
-      createBagLocation(),
+      createObjectLocation,
       startTime = Instant.now.minus(Duration.ofSeconds(1))
     )
     val completed = result.complete
@@ -53,7 +55,7 @@ class VerificationSummaryTest
 
   it("calculates duration as None when verification is not completed") {
     val result = VerificationSummary(
-      createBagLocation(),
+      createObjectLocation,
       startTime = Instant.now
     )
     result.duration shouldBe None

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/VerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/VerifierTest.scala
@@ -41,7 +41,7 @@ class VerifierTest
             algorithm = MessageDigestAlgorithms.SHA_256
           )
 
-          val future = service.verify(bagLocation)
+          val future = service.verify(bagLocation.objectLocation)
 
           whenReady(future) { result =>
             result shouldBe a[IngestStepSucceeded[_]]
@@ -63,18 +63,14 @@ class VerifierTest
         dataFileCount = dataFileCount,
         bagRootDirectory = Some("bag")) { bagLocation =>
         withActorSystem { actorSystem =>
-          implicit val ec = actorSystem.dispatcher
-
-          withMaterializer { mat =>
-            implicit val _mat = mat
-
+          withMaterializer { implicit materializer =>
             val service = new Verifier(
               storageManifestService = new StorageManifestService(),
               s3Client = s3Client,
               algorithm = MessageDigestAlgorithms.SHA_256
             )
 
-            val future = service.verify(bagLocation)
+            val future = service.verify(bagLocation.objectLocation)
 
             whenReady(future) { result =>
               result shouldBe a[IngestStepSucceeded[_]]
@@ -97,17 +93,14 @@ class VerifierTest
         dataFileCount = dataFileCount,
         createDataManifest = dataManifestWithWrongChecksum) { bagLocation =>
         withActorSystem { actorSystem =>
-          implicit val ec = actorSystem.dispatcher
-          withMaterializer { mat =>
-            implicit val _mat = mat
-
+          withMaterializer { implicit materializer =>
             val service = new Verifier(
               storageManifestService = new StorageManifestService(),
               s3Client = s3Client,
               algorithm = MessageDigestAlgorithms.SHA_256
             )
 
-            val future = service.verify(bagLocation)
+            val future = service.verify(bagLocation.objectLocation)
 
             whenReady(future) { result =>
               result shouldBe a[IngestFailed[_]]
@@ -143,7 +136,7 @@ class VerifierTest
               s3Client = s3Client,
               algorithm = MessageDigestAlgorithms.SHA_256
             )
-            val future = service.verify(bagLocation)
+            val future = service.verify(bagLocation.objectLocation)
             whenReady(future) { result =>
               result shouldBe a[IngestFailed[_]]
 
@@ -175,9 +168,7 @@ class VerifierTest
         dataFileCount = dataFileCount,
         createDataManifest = createDataManifestWithExtraFile) { bagLocation =>
         withActorSystem { actorSystem =>
-          implicit val ec = actorSystem.dispatcher
-          withMaterializer { mat =>
-            implicit val _mat = mat
+          withMaterializer { implicit materializer =>
 
             val service = new Verifier(
               storageManifestService = new StorageManifestService(),
@@ -185,7 +176,7 @@ class VerifierTest
               algorithm = MessageDigestAlgorithms.SHA_256
             )
 
-            val future = service.verify(bagLocation)
+            val future = service.verify(bagLocation.objectLocation)
             whenReady(future) { result =>
               result shouldBe a[IngestFailed[_]]
 
@@ -213,9 +204,7 @@ class VerifierTest
       withBag(bucket, createDataManifest = dontCreateTheDataManifest) {
         bagLocation =>
           withActorSystem { actorSystem =>
-            implicit val ec = actorSystem.dispatcher
-            withMaterializer { mat =>
-              implicit val _mat = mat
+            withMaterializer { implicit mat =>
 
               val service = new Verifier(
                 storageManifestService = new StorageManifestService(),
@@ -223,7 +212,7 @@ class VerifierTest
                 algorithm = MessageDigestAlgorithms.SHA_256
               )
 
-              val future = service.verify(bagLocation)
+              val future = service.verify(bagLocation.objectLocation)
 
               whenReady(future) { result =>
                 result shouldBe a[IngestFailed[_]]
@@ -248,9 +237,7 @@ class VerifierTest
       withBag(bucket, createTagManifest = dontCreateTheTagManifest) {
         bagLocation =>
           withActorSystem { actorSystem =>
-            implicit val ec = actorSystem.dispatcher
-            withMaterializer { mat =>
-              implicit val _mat = mat
+            withMaterializer { implicit materializer =>
 
               val service = new Verifier(
                 storageManifestService = new StorageManifestService(),
@@ -258,7 +245,7 @@ class VerifierTest
                 algorithm = MessageDigestAlgorithms.SHA_256
               )
 
-              val future = service.verify(bagLocation)
+              val future = service.verify(bagLocation.objectLocation)
 
               whenReady(future) { result =>
                 result shouldBe a[IngestFailed[_]]

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/VerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/VerifierTest.scala
@@ -22,7 +22,10 @@ class VerifierTest
 
   val dataFileCount = 3
 
-  val expectedFileCount: Int = dataFileCount + List("manifest-sha256.txt", "bagit.txt", "bag-info.txt").size
+  val expectedFileCount: Int = dataFileCount + List(
+    "manifest-sha256.txt",
+    "bagit.txt",
+    "bag-info.txt").size
 
   it("passes a bag with correct checksums") {
     withLocalS3Bucket { bucket =>
@@ -119,7 +122,7 @@ class VerifierTest
 
   it("fails a bag if the file manifest refers to a non-existent file") {
     def createDataManifestWithExtraFile(
-                                         dataFiles: List[(String, String)]): Option[FileEntry] =
+      dataFiles: List[(String, String)]): Option[FileEntry] =
       createValidDataManifest(
         dataFiles ++ List(("doesnotexist", "doesnotexist")))
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/VerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/VerifierTest.scala
@@ -1,9 +1,8 @@
 package uk.ac.wellcome.platform.archive.bagverifier.services
 
-import org.apache.commons.codec.digest.MessageDigestAlgorithms
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.akka.fixtures.Akka
+import uk.ac.wellcome.platform.archive.bagverifier.fixtures.BagVerifierFixtures
 import uk.ac.wellcome.platform.archive.bagverifier.models.VerificationSummary
 import uk.ac.wellcome.platform.archive.common.fixtures.{
   BagLocationFixtures,
@@ -13,42 +12,30 @@ import uk.ac.wellcome.platform.archive.common.storage.models.{
   IngestFailed,
   IngestStepSucceeded
 }
-import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestService
-import uk.ac.wellcome.storage.fixtures.S3
-
-import scala.concurrent.ExecutionContext.Implicits.global
 
 class VerifierTest
     extends FunSpec
     with Matchers
     with ScalaFutures
-    with S3
-    with Akka
-    with BagLocationFixtures {
+    with BagLocationFixtures
+    with BagVerifierFixtures {
 
   val dataFileCount = 3
 
-  // Data files plus manifest-sha256.txt, bagit.txt, bag-info.txt
-  val expectedDataFileCount = dataFileCount + 3
+  val expectedFileCount: Int = dataFileCount + List("manifest-sha256.txt", "bagit.txt", "bag-info.txt").size
 
   it("passes a bag with correct checksums") {
     withLocalS3Bucket { bucket =>
       withBag(bucket, dataFileCount = dataFileCount) { bagLocation =>
-        withMaterializer { implicit materializer =>
-          val service = new Verifier(
-            storageManifestService = new StorageManifestService(),
-            s3Client = s3Client,
-            algorithm = MessageDigestAlgorithms.SHA_256
-          )
-
-          val future = service.verify(bagLocation.objectLocation)
+        withVerifier { verifier =>
+          val future = verifier.verify(bagLocation.objectLocation)
 
           whenReady(future) { result =>
             result shouldBe a[IngestStepSucceeded[_]]
 
             val summary = result.summary
 
-            summary.successfulVerifications should have size expectedDataFileCount
+            summary.successfulVerifications should have size expectedFileCount
             summary.failedVerifications shouldBe Seq.empty
           }
         }
@@ -62,24 +49,16 @@ class VerifierTest
         bucket = bucket,
         dataFileCount = dataFileCount,
         bagRootDirectory = Some("bag")) { bagLocation =>
-        withActorSystem { actorSystem =>
-          withMaterializer { implicit materializer =>
-            val service = new Verifier(
-              storageManifestService = new StorageManifestService(),
-              s3Client = s3Client,
-              algorithm = MessageDigestAlgorithms.SHA_256
-            )
+        withVerifier { verifier =>
+          val future = verifier.verify(bagLocation.objectLocation)
 
-            val future = service.verify(bagLocation.objectLocation)
+          whenReady(future) { result =>
+            result shouldBe a[IngestStepSucceeded[_]]
 
-            whenReady(future) { result =>
-              result shouldBe a[IngestStepSucceeded[_]]
+            val summary = result.summary
 
-              val summary = result.summary
-
-              summary.successfulVerifications should have size expectedDataFileCount
-              summary.failedVerifications shouldBe Seq.empty
-            }
+            summary.successfulVerifications should have size expectedFileCount
+            summary.failedVerifications shouldBe Seq.empty
           }
         }
       }
@@ -92,28 +71,20 @@ class VerifierTest
         bucket,
         dataFileCount = dataFileCount,
         createDataManifest = dataManifestWithWrongChecksum) { bagLocation =>
-        withActorSystem { actorSystem =>
-          withMaterializer { implicit materializer =>
-            val service = new Verifier(
-              storageManifestService = new StorageManifestService(),
-              s3Client = s3Client,
-              algorithm = MessageDigestAlgorithms.SHA_256
-            )
+        withVerifier { verifier =>
+          val future = verifier.verify(bagLocation.objectLocation)
 
-            val future = service.verify(bagLocation.objectLocation)
+          whenReady(future) { result =>
+            result shouldBe a[IngestFailed[_]]
 
-            whenReady(future) { result =>
-              result shouldBe a[IngestFailed[_]]
+            val summary = result.summary
+            summary.successfulVerifications should have size expectedFileCount - 1
+            summary.failedVerifications should have size 1
 
-              val summary = result.summary
-              summary.successfulVerifications should have size expectedDataFileCount - 1
-              summary.failedVerifications should have size 1
-
-              val brokenFile = summary.failedVerifications.head
-              brokenFile.reason shouldBe a[RuntimeException]
-              brokenFile.reason.getMessage should startWith(
-                "Checksums do not match:")
-            }
+            val brokenFile = summary.failedVerifications.head
+            brokenFile.reason shouldBe a[RuntimeException]
+            brokenFile.reason.getMessage should startWith(
+              "Checksums do not match:")
           }
         }
       }
@@ -126,30 +97,20 @@ class VerifierTest
         bucket,
         dataFileCount = dataFileCount,
         createTagManifest = tagManifestWithWrongChecksum) { bagLocation =>
-        withActorSystem { actorSystem =>
-          implicit val ec = actorSystem.dispatcher
-          withMaterializer { mat =>
-            implicit val _mat = mat
+        withVerifier { verifier =>
+          val future = verifier.verify(bagLocation.objectLocation)
+          whenReady(future) { result =>
+            result shouldBe a[IngestFailed[_]]
 
-            val service = new Verifier(
-              storageManifestService = new StorageManifestService(),
-              s3Client = s3Client,
-              algorithm = MessageDigestAlgorithms.SHA_256
-            )
-            val future = service.verify(bagLocation.objectLocation)
-            whenReady(future) { result =>
-              result shouldBe a[IngestFailed[_]]
+            val summary = result.summary
 
-              val summary = result.summary
+            summary.successfulVerifications should have size expectedFileCount - 1
+            summary.failedVerifications should have size 1
 
-              summary.successfulVerifications should have size expectedDataFileCount - 1
-              summary.failedVerifications should have size 1
-
-              val brokenFile = summary.failedVerifications.head
-              brokenFile.reason shouldBe a[RuntimeException]
-              brokenFile.reason.getMessage should startWith(
-                "Checksums do not match:")
-            }
+            val brokenFile = summary.failedVerifications.head
+            brokenFile.reason shouldBe a[RuntimeException]
+            brokenFile.reason.getMessage should startWith(
+              "Checksums do not match:")
           }
         }
       }
@@ -158,7 +119,7 @@ class VerifierTest
 
   it("fails a bag if the file manifest refers to a non-existent file") {
     def createDataManifestWithExtraFile(
-      dataFiles: List[(String, String)]): Option[FileEntry] =
+                                         dataFiles: List[(String, String)]): Option[FileEntry] =
       createValidDataManifest(
         dataFiles ++ List(("doesnotexist", "doesnotexist")))
 
@@ -167,29 +128,20 @@ class VerifierTest
         bucket,
         dataFileCount = dataFileCount,
         createDataManifest = createDataManifestWithExtraFile) { bagLocation =>
-        withActorSystem { actorSystem =>
-          withMaterializer { implicit materializer =>
+        withVerifier { verifier =>
+          val future = verifier.verify(bagLocation.objectLocation)
+          whenReady(future) { result =>
+            result shouldBe a[IngestFailed[_]]
 
-            val service = new Verifier(
-              storageManifestService = new StorageManifestService(),
-              s3Client = s3Client,
-              algorithm = MessageDigestAlgorithms.SHA_256
-            )
+            val summary = result.summary
 
-            val future = service.verify(bagLocation.objectLocation)
-            whenReady(future) { result =>
-              result shouldBe a[IngestFailed[_]]
+            summary.successfulVerifications should have size expectedFileCount
+            summary.failedVerifications should have size 1
 
-              val summary = result.summary
-
-              summary.successfulVerifications should have size expectedDataFileCount
-              summary.failedVerifications should have size 1
-
-              val brokenFile = summary.failedVerifications.head
-              brokenFile.reason shouldBe a[RuntimeException]
-              brokenFile.reason.getMessage should startWith(
-                "The specified key does not exist")
-            }
+            val brokenFile = summary.failedVerifications.head
+            brokenFile.reason shouldBe a[RuntimeException]
+            brokenFile.reason.getMessage should startWith(
+              "The specified key does not exist")
           }
         }
       }
@@ -203,26 +155,17 @@ class VerifierTest
     withLocalS3Bucket { bucket =>
       withBag(bucket, createDataManifest = dontCreateTheDataManifest) {
         bagLocation =>
-          withActorSystem { actorSystem =>
-            withMaterializer { implicit mat =>
+          withVerifier { verifier =>
+            val future = verifier.verify(bagLocation.objectLocation)
 
-              val service = new Verifier(
-                storageManifestService = new StorageManifestService(),
-                s3Client = s3Client,
-                algorithm = MessageDigestAlgorithms.SHA_256
-              )
+            whenReady(future) { result =>
+              result shouldBe a[IngestFailed[_]]
+              val err = result
+                .asInstanceOf[IngestFailed[VerificationSummary]]
+                .e
 
-              val future = service.verify(bagLocation.objectLocation)
-
-              whenReady(future) { result =>
-                result shouldBe a[IngestFailed[_]]
-                val err = result
-                  .asInstanceOf[IngestFailed[VerificationSummary]]
-                  .e
-
-                err shouldBe a[RuntimeException]
-                err.getMessage should startWith("Error getting file manifest")
-              }
+              err shouldBe a[RuntimeException]
+              err.getMessage should startWith("Error getting file manifest")
             }
           }
       }
@@ -236,26 +179,17 @@ class VerifierTest
     withLocalS3Bucket { bucket =>
       withBag(bucket, createTagManifest = dontCreateTheTagManifest) {
         bagLocation =>
-          withActorSystem { actorSystem =>
-            withMaterializer { implicit materializer =>
+          withVerifier { verifier =>
+            val future = verifier.verify(bagLocation.objectLocation)
 
-              val service = new Verifier(
-                storageManifestService = new StorageManifestService(),
-                s3Client = s3Client,
-                algorithm = MessageDigestAlgorithms.SHA_256
-              )
+            whenReady(future) { result =>
+              result shouldBe a[IngestFailed[_]]
+              val err = result
+                .asInstanceOf[IngestFailed[VerificationSummary]]
+                .e
 
-              val future = service.verify(bagLocation.objectLocation)
-
-              whenReady(future) { result =>
-                result shouldBe a[IngestFailed[_]]
-                val err = result
-                  .asInstanceOf[IngestFailed[VerificationSummary]]
-                  .e
-
-                err shouldBe a[RuntimeException]
-                err.getMessage should startWith("Error getting tag manifest")
-              }
+              err shouldBe a[RuntimeException]
+              err.getMessage should startWith("Error getting tag manifest")
             }
           }
       }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
@@ -1,0 +1,14 @@
+package uk.ac.wellcome.platform.archive.common
+
+import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
+import uk.ac.wellcome.storage.ObjectLocation
+
+sealed trait PipelinePayload {
+  val ingestId: IngestID
+}
+
+case class ObjectLocationPayload(
+  ingestId: IngestID,
+  storageSpace: StorageSpace,
+  objectLocation: ObjectLocation
+) extends PipelinePayload

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagLocationFixtures.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagLocationFixtures.scala
@@ -24,7 +24,6 @@ trait BagLocationFixtures
   def withBag[R](
     bucket: Bucket,
     bagInfo: BagInfo = createBagInfo,
-    storagePrefix: String = "storagePrefix",
     dataFileCount: Int = 1,
     storageSpace: StorageSpace = createStorageSpace,
     createDataManifest: List[(String, String)] => Option[FileEntry] =
@@ -45,7 +44,7 @@ trait BagLocationFixtures
 
     val bagLocation = BagLocation(
       storageNamespace = bucket.name,
-      storagePrefix = Some(storagePrefix),
+      storagePrefix = None,
       storageSpace = storageSpace,
       bagPath = BagPath(bagIdentifier.toString)
     )

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
@@ -25,17 +25,13 @@ class StorageManifestServiceTest
     with BagRequestGenerators
     with S3 {
 
-  implicit val _s3Client = s3Client
-
   val service = new StorageManifestService()
 
   it("returns a StorageManifest if reading a bag location succeeds") {
     withLocalS3Bucket { bucket =>
       val bagInfo = createBagInfo
       withBag(bucket, bagInfo = bagInfo) { bagLocation =>
-        val bagRequest = createBagRequestWith(bagLocation)
-
-        val future = service.createManifest(bagRequest.bagLocation)
+        val future = service.createManifest(bagLocation)
 
         whenReady(future) { storageManifest =>
           storageManifest.space shouldBe bagLocation.storageSpace
@@ -81,9 +77,7 @@ class StorageManifestServiceTest
           bagPath = randomBagPath
         )
 
-        val bagRequest = createBagRequestWith(bagLocation)
-
-        val future = service.createManifest(bagRequest.bagLocation)
+        val future = service.createManifest(bagLocation)
 
         whenReady(future.failed) { err =>
           err shouldBe a[RuntimeException]
@@ -100,9 +94,7 @@ class StorageManifestServiceTest
             bagLocation.completePath + "/bag-info.txt"
           )
 
-          val bagRequest = createBagRequestWith(bagLocation)
-
-          val future = service.createManifest(bagRequest.bagLocation)
+          val future = service.createManifest(bagLocation)
 
           whenReady(future.failed) { err =>
             err shouldBe a[RuntimeException]
@@ -120,9 +112,7 @@ class StorageManifestServiceTest
             bagLocation.completePath + "/manifest-sha256.txt"
           )
 
-          val bagRequest = createBagRequestWith(bagLocation)
-
-          val future = service.createManifest(bagRequest.bagLocation)
+          val future = service.createManifest(bagLocation)
 
           whenReady(future.failed) { err =>
             err shouldBe a[RuntimeException]
@@ -139,9 +129,7 @@ class StorageManifestServiceTest
           createDataManifest =
             _ => Some(FileEntry("manifest-sha256.txt", "bleeergh!"))) {
           bagLocation =>
-            val bagRequest = createBagRequestWith(bagLocation)
-
-            val future = service.createManifest(bagRequest.bagLocation)
+            val future = service.createManifest(bagLocation)
 
             whenReady(future.failed) { err =>
               err shouldBe a[RuntimeException]
@@ -159,9 +147,7 @@ class StorageManifestServiceTest
             bagLocation.completePath + "/tagmanifest-sha256.txt"
           )
 
-          val bagRequest = createBagRequestWith(bagLocation)
-
-          val future = service.createManifest(bagRequest.bagLocation)
+          val future = service.createManifest(bagLocation)
 
           whenReady(future.failed) { err =>
             err shouldBe a[RuntimeException]
@@ -178,9 +164,7 @@ class StorageManifestServiceTest
           createTagManifest =
             _ => Some(FileEntry("tagmanifest-sha256.txt", "blaaargh!"))) {
           bagLocation =>
-            val bagRequest = createBagRequestWith(bagLocation)
-
-            val future = service.createManifest(bagRequest.bagLocation)
+            val future = service.createManifest(bagLocation)
 
             whenReady(future.failed) { err =>
               err shouldBe a[RuntimeException]

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.platform.archive.common.storage.services
 
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.platform.archive.common.bagit.models.BagLocation
 import uk.ac.wellcome.platform.archive.common.fixtures.{
   BagLocationFixtures,
   FileEntry
@@ -31,7 +30,10 @@ class StorageManifestServiceTest
     withLocalS3Bucket { bucket =>
       val bagInfo = createBagInfo
       withBag(bucket, bagInfo = bagInfo) { bagLocation =>
-        val future = service.createManifest(bagLocation)
+        val future = service.createManifest(
+          bagRootLocation = bagLocation.objectLocation,
+          storageSpace = bagLocation.storageSpace
+        )
 
         whenReady(future) { storageManifest =>
           storageManifest.space shouldBe bagLocation.storageSpace
@@ -70,14 +72,10 @@ class StorageManifestServiceTest
   describe("returns a Left upon error") {
     it("if no files are at the BagLocation") {
       withLocalS3Bucket { bucket =>
-        val bagLocation = BagLocation(
-          storageNamespace = bucket.name,
-          storagePrefix = Some("archive"),
-          storageSpace = createStorageSpace,
-          bagPath = randomBagPath
+        val future = service.createManifest(
+          bagRootLocation = createObjectLocationWith(bucket),
+          storageSpace = createStorageSpace
         )
-
-        val future = service.createManifest(bagLocation)
 
         whenReady(future.failed) { err =>
           err shouldBe a[RuntimeException]
@@ -94,7 +92,10 @@ class StorageManifestServiceTest
             bagLocation.completePath + "/bag-info.txt"
           )
 
-          val future = service.createManifest(bagLocation)
+          val future = service.createManifest(
+            bagRootLocation = bagLocation.objectLocation,
+            storageSpace = bagLocation.storageSpace
+          )
 
           whenReady(future.failed) { err =>
             err shouldBe a[RuntimeException]
@@ -112,7 +113,10 @@ class StorageManifestServiceTest
             bagLocation.completePath + "/manifest-sha256.txt"
           )
 
-          val future = service.createManifest(bagLocation)
+          val future = service.createManifest(
+            bagRootLocation = bagLocation.objectLocation,
+            storageSpace = bagLocation.storageSpace
+          )
 
           whenReady(future.failed) { err =>
             err shouldBe a[RuntimeException]
@@ -129,7 +133,10 @@ class StorageManifestServiceTest
           createDataManifest =
             _ => Some(FileEntry("manifest-sha256.txt", "bleeergh!"))) {
           bagLocation =>
-            val future = service.createManifest(bagLocation)
+            val future = service.createManifest(
+              bagRootLocation = bagLocation.objectLocation,
+              storageSpace = bagLocation.storageSpace
+            )
 
             whenReady(future.failed) { err =>
               err shouldBe a[RuntimeException]
@@ -147,7 +154,10 @@ class StorageManifestServiceTest
             bagLocation.completePath + "/tagmanifest-sha256.txt"
           )
 
-          val future = service.createManifest(bagLocation)
+          val future = service.createManifest(
+            bagRootLocation = bagLocation.objectLocation,
+            storageSpace = bagLocation.storageSpace
+          )
 
           whenReady(future.failed) { err =>
             err shouldBe a[RuntimeException]
@@ -164,7 +174,10 @@ class StorageManifestServiceTest
           createTagManifest =
             _ => Some(FileEntry("tagmanifest-sha256.txt", "blaaargh!"))) {
           bagLocation =>
-            val future = service.createManifest(bagLocation)
+            val future = service.createManifest(
+              bagRootLocation = bagLocation.objectLocation,
+              storageSpace = bagLocation.storageSpace
+            )
 
             whenReady(future.failed) { err =>
               err shouldBe a[RuntimeException]

--- a/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlService.scala
+++ b/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlService.scala
@@ -1,13 +1,13 @@
 package uk.ac.wellcome.platform.archive.notifier.services
 
-import java.net.URL
+import java.net.{URI, URL}
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.platform.archive.common.ingests.models.CallbackNotification
+import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
 import uk.ac.wellcome.platform.archive.display.ResponseDisplayIngest
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -17,12 +17,13 @@ class CallbackUrlService(contextUrl: URL)(implicit actorSystem: ActorSystem,
                                           ec: ExecutionContext)
     extends Logging {
   def getHttpResponse(
-    callbackNotification: CallbackNotification): Future[Try[HttpResponse]] = {
+    ingest: Ingest,
+    callbackUri: URI): Future[Try[HttpResponse]] = {
     for {
       jsonString <- Future.fromTry(
         toJson(
           ResponseDisplayIngest(
-            ingest = callbackNotification.payload,
+            ingest = ingest,
             contextUrl = contextUrl
           ))
       )
@@ -31,7 +32,6 @@ class CallbackUrlService(contextUrl: URL)(implicit actorSystem: ActorSystem,
         string = jsonString
       )
 
-      callbackUri = callbackNotification.callbackUri
       _ = debug(s"POST to $callbackUri request:$entity")
 
       request = HttpRequest(

--- a/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlService.scala
+++ b/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlService.scala
@@ -16,9 +16,8 @@ import scala.util.{Failure, Success, Try}
 class CallbackUrlService(contextUrl: URL)(implicit actorSystem: ActorSystem,
                                           ec: ExecutionContext)
     extends Logging {
-  def getHttpResponse(
-    ingest: Ingest,
-    callbackUri: URI): Future[Try[HttpResponse]] = {
+  def getHttpResponse(ingest: Ingest,
+                      callbackUri: URI): Future[Try[HttpResponse]] = {
     for {
       jsonString <- Future.fromTry(
         toJson(

--- a/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/services/NotifierWorker.scala
+++ b/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/services/NotifierWorker.scala
@@ -43,7 +43,10 @@ class NotifierWorker(
   def processMessage(callbackNotification: CallbackNotification)
     : Future[Result[IngestCallbackStatusUpdate]] = {
     val future = for {
-      httpResponse <- callbackUrlService.getHttpResponse(callbackNotification)
+      httpResponse <- callbackUrlService.getHttpResponse(
+        ingest = callbackNotification.payload,
+        callbackUri = callbackNotification.callbackUri
+      )
       ingestUpdate = PrepareNotificationService.prepare(
         id = callbackNotification.ingestId,
         httpResponse = httpResponse

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlServiceTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlServiceTest.scala
@@ -29,8 +29,8 @@ class CallbackUrlServiceTest
 
         val future = service.getHttpResponse(
           ingest = ingest,
-          callbackUri = new URI(
-            s"http://$callbackHost:$callbackPort/callback/${ingest.id}")
+          callbackUri =
+            new URI(s"http://$callbackHost:$callbackPort/callback/${ingest.id}")
         )
 
         whenReady(future) { result =>
@@ -48,8 +48,7 @@ class CallbackUrlServiceTest
 
         val future = service.getHttpResponse(
           ingest = ingest,
-          callbackUri = new URI(
-            s"http://nope.nope/callback/${ingest.id}")
+          callbackUri = new URI(s"http://nope.nope/callback/${ingest.id}")
         )
 
         whenReady(future) { result =>

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlServiceTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlServiceTest.scala
@@ -7,7 +7,6 @@ import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
-import uk.ac.wellcome.platform.archive.common.ingests.models.CallbackNotification
 import uk.ac.wellcome.platform.archive.notifier.fixtures.{
   LocalWireMockFixture,
   NotifierFixtures
@@ -26,14 +25,12 @@ class CallbackUrlServiceTest
   it("returns a Success if the request succeeds") {
     withActorSystem { implicit actorSystem =>
       withCallbackUrlService { service =>
-        val ingestID = createIngestID
+        val ingest = createIngest
+
         val future = service.getHttpResponse(
-          callbackNotification = CallbackNotification(
-            ingestId = ingestID,
-            callbackUri =
-              new URI(s"http://$callbackHost:$callbackPort/callback/$ingestID"),
-            payload = createIngest
-          )
+          ingest = ingest,
+          callbackUri = new URI(
+            s"http://$callbackHost:$callbackPort/callback/${ingest.id}")
         )
 
         whenReady(future) { result =>
@@ -47,13 +44,12 @@ class CallbackUrlServiceTest
   it("returns a failed future if the HTTP request fails") {
     withActorSystem { implicit actorSystem =>
       withCallbackUrlService { service =>
-        val ingestId = createIngestID
+        val ingest = createIngest
+
         val future = service.getHttpResponse(
-          callbackNotification = CallbackNotification(
-            ingestId = ingestId,
-            callbackUri = new URI(s"http://nope.nope/callback/$ingestId"),
-            payload = createIngest
-          )
+          ingest = ingest,
+          callbackUri = new URI(
+            s"http://nope.nope/callback/${ingest.id}")
         )
 
         whenReady(future) { result =>


### PR DESCRIPTION
This patch doesn't change the external interfaces of any of the apps, but it does add the initial `ObjectLocationPayload` case class and do a bunch of refactoring internally so the change to the external interfaces should be a smaller patch.