### PR TITLE
Auditor: Include the external identifier and bag version in the payload it sends

### DIFF
--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/AuditSummary.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/AuditSummary.scala
@@ -9,7 +9,8 @@ import uk.ac.wellcome.storage.ObjectLocation
 
 case class AuditInformation(
   bagRootLocation: ObjectLocation,
-  externalIdentifier: ExternalIdentifier
+  externalIdentifier: ExternalIdentifier,
+  version: Int
 )
 
 case class AuditSummary(

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/AuditSummary.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/AuditSummary.scala
@@ -6,10 +6,14 @@ import uk.ac.wellcome.platform.archive.common.operation.models.Summary
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.ObjectLocation
 
+case class AuditInformation(
+  bagRoot: ObjectLocation
+)
+
 case class AuditSummary(
   unpackLocation: ObjectLocation,
   storageSpace: StorageSpace,
-  maybeRoot: Option[ObjectLocation] = None,
+  maybeAuditInformation: Option[AuditInformation] = None,
   startTime: Instant,
   endTime: Option[Instant] = None,
 ) extends Summary {
@@ -18,8 +22,11 @@ case class AuditSummary(
       endTime = Some(Instant.now())
     )
 
-  def root: ObjectLocation =
-    maybeRoot.getOrElse(
-      throw new RuntimeException("No root provided by auditor!")
+  def auditInformation: AuditInformation =
+    maybeAuditInformation.getOrElse(
+      throw new RuntimeException("No info provided by auditor!")
     )
+
+  def root: ObjectLocation =
+    auditInformation.bagRoot
 }

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/AuditSummary.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/AuditSummary.scala
@@ -2,12 +2,14 @@ package uk.ac.wellcome.platform.storage.bagauditor.models
 
 import java.time.Instant
 
+import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
 import uk.ac.wellcome.platform.archive.common.operation.models.Summary
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.ObjectLocation
 
 case class AuditInformation(
-  bagRoot: ObjectLocation
+  bagRootLocation: ObjectLocation,
+  externalIdentifier: ExternalIdentifier
 )
 
 case class AuditSummary(
@@ -27,6 +29,8 @@ case class AuditSummary(
       throw new RuntimeException("No info provided by auditor!")
     )
 
-  def root: ObjectLocation =
-    auditInformation.bagRoot
+  def root: ObjectLocation = auditInformation.bagRootLocation
+
+  def externalIdentifier: ExternalIdentifier =
+    auditInformation.externalIdentifier
 }

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
@@ -67,7 +67,8 @@ class BagAuditor(implicit s3Client: AmazonS3, ec: ExecutionContext) {
       }
   }
 
-  private def chooseVersion(externalIdentifier: ExternalIdentifier): Future[Int] =
+  private def chooseVersion(
+    externalIdentifier: ExternalIdentifier): Future[Int] =
     Future.successful(1)
 
   private def getBagIdentifier(

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
@@ -42,9 +42,11 @@ class BagAuditor(implicit s3Client: AmazonS3, ec: ExecutionContext) {
         s3BagLocator.locateBagRoot(unpackLocation)
       }
       externalIdentifier <- getBagIdentifier(bagRootLocation)
+      version <- chooseVersion(externalIdentifier)
       info = AuditInformation(
         bagRootLocation = bagRootLocation,
-        externalIdentifier = externalIdentifier
+        externalIdentifier = externalIdentifier,
+        version = version
       )
     } yield info
 
@@ -65,6 +67,9 @@ class BagAuditor(implicit s3Client: AmazonS3, ec: ExecutionContext) {
       }
   }
 
+  private def chooseVersion(externalIdentifier: ExternalIdentifier): Future[Int] =
+    Future.successful(1)
+
   private def getBagIdentifier(
     bagRootLocation: ObjectLocation): Future[ExternalIdentifier] =
     for {
@@ -74,5 +79,4 @@ class BagAuditor(implicit s3Client: AmazonS3, ec: ExecutionContext) {
       inputStream: InputStream <- bagInfoLocation.toInputStream
       bagInfo: BagInfo <- BagInfoParser.create(inputStream)
     } yield bagInfo.externalIdentifier
-
 }

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
@@ -1,8 +1,15 @@
 package uk.ac.wellcome.platform.storage.bagauditor.services
 
+import java.io.InputStream
 import java.time.Instant
 
 import com.amazonaws.services.s3.AmazonS3
+import uk.ac.wellcome.platform.archive.common.ConvertibleToInputStream._
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagInfo,
+  ExternalIdentifier
+}
+import uk.ac.wellcome.platform.archive.common.bagit.parsers.BagInfoParser
 import uk.ac.wellcome.platform.archive.common.storage.models.{
   IngestFailed,
   IngestStepResult,
@@ -10,45 +17,62 @@ import uk.ac.wellcome.platform.archive.common.storage.models.{
   StorageSpace
 }
 import uk.ac.wellcome.platform.archive.common.storage.services.S3BagLocator
-import uk.ac.wellcome.platform.storage.bagauditor.models.{AuditInformation, AuditSummary}
+import uk.ac.wellcome.platform.storage.bagauditor.models.{
+  AuditInformation,
+  AuditSummary
+}
 import uk.ac.wellcome.storage.ObjectLocation
 
-import scala.util.{Failure, Success, Try}
+import scala.concurrent.{ExecutionContext, Future}
 
-class BagAuditor(implicit s3Client: AmazonS3) {
+class BagAuditor(implicit s3Client: AmazonS3, ec: ExecutionContext) {
   val s3BagLocator = new S3BagLocator(s3Client)
 
   def getAuditSummary(
     unpackLocation: ObjectLocation,
-    storageSpace: StorageSpace): Try[IngestStepResult[AuditSummary]] = {
+    storageSpace: StorageSpace): Future[IngestStepResult[AuditSummary]] = {
     val auditSummary = AuditSummary(
       startTime = Instant.now(),
       unpackLocation = unpackLocation,
       storageSpace = storageSpace
     )
 
-    buildAuditInformation(unpackLocation) match {
-      case Success(info) =>
-        Success(
-          IngestStepSucceeded(
-            auditSummary
-              .copy(maybeAuditInformation = Some(info))
-              .complete
-          )
+    val auditInformation = for {
+      bagRootLocation <- Future.fromTry {
+        s3BagLocator.locateBagRoot(unpackLocation)
+      }
+      externalIdentifier <- getBagIdentifier(bagRootLocation)
+      info = AuditInformation(
+        bagRootLocation = bagRootLocation,
+        externalIdentifier = externalIdentifier
+      )
+    } yield info
+
+    auditInformation
+      .map { info =>
+        IngestStepSucceeded(
+          auditSummary
+            .copy(maybeAuditInformation = Some(info))
+            .complete
         )
-      case Failure(e) =>
-        Success(
+      }
+      .recover {
+        case t: Throwable =>
           IngestFailed(
             auditSummary.complete,
-            e
+            t
           )
-        )
-    }
+      }
   }
 
-  private def buildAuditInformation(unpackLocation: ObjectLocation): Try[AuditInformation] = {
+  private def getBagIdentifier(
+    bagRootLocation: ObjectLocation): Future[ExternalIdentifier] =
     for {
-      bagRootLocation <- s3BagLocator.locateBagRoot(unpackLocation)
-    } yield AuditInformation(bagRootLocation)
-  }
+      bagInfoLocation <- Future.fromTry {
+        s3BagLocator.locateBagInfo(bagRootLocation)
+      }
+      inputStream: InputStream <- bagInfoLocation.toInputStream
+      bagInfo: BagInfo <- BagInfoParser.create(inputStream)
+    } yield bagInfo.externalIdentifier
+
 }

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
@@ -46,7 +46,7 @@ class BagAuditor(implicit s3Client: AmazonS3) {
     }
   }
 
-  def buildAuditInformation(unpackLocation: ObjectLocation): Try[AuditInformation] = {
+  private def buildAuditInformation(unpackLocation: ObjectLocation): Try[AuditInformation] = {
     for {
       bagRootLocation <- s3BagLocator.locateBagRoot(unpackLocation)
     } yield AuditInformation(bagRootLocation)

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
@@ -10,7 +10,10 @@ import uk.ac.wellcome.messaging.sqsworker.alpakka.{
 }
 import uk.ac.wellcome.messaging.worker.models.Result
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
-import uk.ac.wellcome.platform.archive.common.ObjectLocationPayload
+import uk.ac.wellcome.platform.archive.common.{
+  BagInformationPayload,
+  ObjectLocationPayload
+}
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services._
 import uk.ac.wellcome.platform.archive.common.storage.models.IngestStepWorker
@@ -48,7 +51,15 @@ class BagAuditorWorker(
       _ <- ingestUpdater.send(payload.ingestId, auditSummary)
       _ <- outgoingPublisher.sendIfSuccessful(
         auditSummary,
-        payload.copy(objectLocation = auditSummary.summary.auditInformation.bagRootLocation)
+        BagInformationPayload(
+          ingestId = payload.ingestId,
+          storageSpace = payload.storageSpace,
+          bagRootLocation =
+            auditSummary.summary.auditInformation.bagRootLocation,
+          externalIdentifier =
+            auditSummary.summary.auditInformation.externalIdentifier,
+          version = auditSummary.summary.auditInformation.version
+        )
       )
     } yield toResult(auditSummary)
 

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
@@ -48,7 +48,7 @@ class BagAuditorWorker(
       _ <- ingestUpdater.send(payload.ingestId, auditSummary)
       _ <- outgoingPublisher.sendIfSuccessful(
         auditSummary,
-        payload.copy(objectLocation = auditSummary.summary.root)
+        payload.copy(objectLocation = auditSummary.summary.auditInformation.bagRootLocation)
       )
     } yield toResult(auditSummary)
 

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
@@ -54,8 +54,7 @@ class BagAuditorWorker(
         BagInformationPayload(
           ingestId = payload.ingestId,
           storageSpace = payload.storageSpace,
-          objectLocation =
-            auditSummary.summary.auditInformation.bagRootLocation,
+          objectLocation = auditSummary.summary.auditInformation.bagRootLocation,
           externalIdentifier =
             auditSummary.summary.auditInformation.externalIdentifier,
           version = auditSummary.summary.auditInformation.version

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
@@ -42,7 +42,7 @@ class BagAuditorWorker(
     payload: ObjectLocationPayload): Future[Result[AuditSummary]] =
     for {
       auditSummary <- Future.fromTry(
-        bagAuditor.locateBagRoot(
+        bagAuditor.getAuditSummary(
           unpackLocation = payload.objectLocation,
           storageSpace = payload.storageSpace
         )

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
@@ -41,11 +41,9 @@ class BagAuditorWorker(
   def processMessage(
     payload: ObjectLocationPayload): Future[Result[AuditSummary]] =
     for {
-      auditSummary <- Future.fromTry(
-        bagAuditor.getAuditSummary(
-          unpackLocation = payload.objectLocation,
-          storageSpace = payload.storageSpace
-        )
+      auditSummary <- bagAuditor.getAuditSummary(
+        unpackLocation = payload.objectLocation,
+        storageSpace = payload.storageSpace
       )
       _ <- ingestUpdater.send(payload.ingestId, auditSummary)
       _ <- outgoingPublisher.sendIfSuccessful(

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
@@ -54,7 +54,7 @@ class BagAuditorWorker(
         BagInformationPayload(
           ingestId = payload.ingestId,
           storageSpace = payload.storageSpace,
-          bagRootLocation =
+          objectLocation =
             auditSummary.summary.auditInformation.bagRootLocation,
           externalIdentifier =
             auditSummary.summary.auditInformation.externalIdentifier,

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
@@ -1,5 +1,7 @@
 package uk.ac.wellcome.platform.storage.bagauditor
 
+import java.nio.file.Paths
+
 import org.scalatest.FunSpec
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
@@ -16,32 +18,27 @@ class BagAuditorFeatureTest
 
   it("detects a bag in the root of the bagLocation") {
     withLocalS3Bucket { bucket =>
-      createObjectsWith(
-        bucket,
-        "bag123/bag-info.txt",
-        "bag123/data/1.jpg",
-        "bag123/data/2.jpg"
-      )
+      withBag(bucket) { bagLocation =>
+        val searchRoot = bagLocation.objectLocation
+        val payload = createObjectLocationPayloadWith(searchRoot)
+        val expectedPayload = payload
 
-      val searchRoot = createObjectLocationWith(bucket, "bag123")
-      val payload = createObjectLocationPayloadWith(searchRoot)
-      val expectedPayload = payload
+        withLocalSqsQueue { queue =>
+          withLocalSnsTopic { ingestTopic =>
+            withLocalSnsTopic { outgoingTopic =>
+              withAuditorWorker(queue, ingestTopic, outgoingTopic) { _ =>
+                sendNotificationToSQS(queue, payload)
 
-      withLocalSqsQueue { queue =>
-        withLocalSnsTopic { ingestTopic =>
-          withLocalSnsTopic { outgoingTopic =>
-            withAuditorWorker(queue, ingestTopic, outgoingTopic) { _ =>
-              sendNotificationToSQS(queue, payload)
+                eventually {
+                  assertQueueEmpty(queue)
 
-              eventually {
-                assertQueueEmpty(queue)
+                  assertSnsReceivesOnly(expectedPayload, outgoingTopic)
 
-                assertSnsReceivesOnly(expectedPayload, outgoingTopic)
-
-                assertTopicReceivesIngestEvent(payload.ingestId, ingestTopic) {
-                  events =>
-                    events should have size 1
-                    events.head.description shouldBe "Locating bag root succeeded"
+                  assertTopicReceivesIngestEvent(payload.ingestId, ingestTopic) {
+                    events =>
+                      events should have size 1
+                      events.head.description shouldBe "Locating bag root succeeded"
+                  }
                 }
               }
             }
@@ -53,34 +50,31 @@ class BagAuditorFeatureTest
 
   it("detects a bag in a subdirectory of the bagLocation") {
     withLocalS3Bucket { bucket =>
-      createObjectsWith(
-        bucket,
-        "bag123/subdir/bag-info.txt",
-        "bag123/subdir/data/1.jpg",
-        "bag123/subdir/data/2.jpg"
-      )
+      withBag(bucket, bagRootDirectory = Some("subdir")) { bagLocation =>
+        val searchRoot = bagLocation.objectLocation
+        val bagRoot = bagLocation.objectLocation.copy(
+          key = Paths.get(bagLocation.completePath, "subdir").toString
+        )
 
-      val searchRoot = createObjectLocationWith(bucket, "bag123")
-      val bagRoot = createObjectLocationWith(bucket, "bag123/subdir")
+        val payload = createObjectLocationPayloadWith(searchRoot)
+        val expectedPayload = payload.copy(objectLocation = bagRoot)
 
-      val payload = createObjectLocationPayloadWith(searchRoot)
-      val expectedPayload = payload.copy(objectLocation = bagRoot)
+        withLocalSqsQueue { queue =>
+          withLocalSnsTopic { ingestTopic =>
+            withLocalSnsTopic { outgoingTopic =>
+              withAuditorWorker(queue, ingestTopic, outgoingTopic) { _ =>
+                sendNotificationToSQS(queue, payload)
 
-      withLocalSqsQueue { queue =>
-        withLocalSnsTopic { ingestTopic =>
-          withLocalSnsTopic { outgoingTopic =>
-            withAuditorWorker(queue, ingestTopic, outgoingTopic) { _ =>
-              sendNotificationToSQS(queue, payload)
+                eventually {
+                  assertQueueEmpty(queue)
 
-              eventually {
-                assertQueueEmpty(queue)
+                  assertSnsReceivesOnly(expectedPayload, outgoingTopic)
 
-                assertSnsReceivesOnly(expectedPayload, outgoingTopic)
-
-                assertTopicReceivesIngestEvent(payload.ingestId, ingestTopic) {
-                  events =>
-                    events should have size 1
-                    events.head.description shouldBe "Locating bag root succeeded"
+                  assertTopicReceivesIngestEvent(payload.ingestId, ingestTopic) {
+                    events =>
+                      events should have size 1
+                      events.head.description shouldBe "Locating bag root succeeded"
+                  }
                 }
               }
             }
@@ -92,38 +86,34 @@ class BagAuditorFeatureTest
 
   it("errors if the bag is nested too deep") {
     withLocalS3Bucket { bucket =>
-      createObjectsWith(
-        bucket,
-        "bag123/subdir1/subdir2/subdir3/bag-info.txt",
-        "bag123/subdir1/subdir2/subdir3/data/1.jpg",
-        "bag123/subdir1/subdir2/subdir3/data/2.jpg"
-      )
+      withBag(bucket, bagRootDirectory = Some("subdir1/subdir2/subdir3")) {
+        bagLocation =>
+          val searchRoot = bagLocation.objectLocation
+          val payload = createObjectLocationPayloadWith(searchRoot)
 
-      val searchRoot = createObjectLocationWith(bucket, "bag123")
-      val payload = createObjectLocationPayloadWith(searchRoot)
+          withLocalSqsQueue { queue =>
+            withLocalSnsTopic { ingestTopic =>
+              withLocalSnsTopic { outgoingTopic =>
+                withAuditorWorker(queue, ingestTopic, outgoingTopic) { _ =>
+                  sendNotificationToSQS(queue, payload)
 
-      withLocalSqsQueue { queue =>
-        withLocalSnsTopic { ingestTopic =>
-          withLocalSnsTopic { outgoingTopic =>
-            withAuditorWorker(queue, ingestTopic, outgoingTopic) { _ =>
-              sendNotificationToSQS(queue, payload)
+                  eventually {
+                    assertQueueEmpty(queue)
 
-              eventually {
-                assertQueueEmpty(queue)
+                    assertSnsReceivesNothing(outgoingTopic)
 
-                assertSnsReceivesNothing(outgoingTopic)
-
-                assertTopicReceivesIngestStatus(
-                  payload.ingestId,
-                  status = Ingest.Failed,
-                  ingestTopic = ingestTopic) { events =>
-                  events should have size 1
-                  events.head.description shouldBe "Locating bag root failed"
+                    assertTopicReceivesIngestStatus(
+                      payload.ingestId,
+                      status = Ingest.Failed,
+                      ingestTopic = ingestTopic) { events =>
+                      events should have size 1
+                      events.head.description shouldBe "Locating bag root failed"
+                    }
+                  }
                 }
               }
             }
           }
-        }
       }
     }
   }

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorTest.scala
@@ -30,6 +30,7 @@ class BagAuditorTest
 
           auditInformation.bagRootLocation shouldBe bagLocation.objectLocation
           auditInformation.externalIdentifier shouldBe bagInfo.externalIdentifier
+          auditInformation.version shouldBe 1
         }
       }
     }

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorTest.scala
@@ -1,0 +1,37 @@
+package uk.ac.wellcome.platform.storage.bagauditor.services
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.platform.archive.common.fixtures.BagLocationFixtures
+import uk.ac.wellcome.platform.archive.common.storage.models.IngestFailed
+
+class BagAuditorTest extends FunSpec with Matchers with BagLocationFixtures {
+  val bagAuditor = new BagAuditor()
+
+  it("gets the audit information for a valid bag") {
+    withLocalS3Bucket { bucket =>
+      withBag(bucket) { bagLocation =>
+        val result = bagAuditor.getAuditSummary(
+          unpackLocation = bagLocation.objectLocation,
+          storageSpace = bagLocation.storageSpace
+        )
+
+        val auditSummary = result.get.summary
+        val auditInformation = auditSummary.auditInformation
+
+        auditInformation.bagRoot shouldBe bagLocation.objectLocation
+      }
+    }
+  }
+
+  it("errors if it cannot find the bag root") {
+    withLocalS3Bucket { bucket =>
+      withBag(bucket, bagRootDirectory = Some("1/2/3")) { bagLocation =>
+        val result = bagAuditor.getAuditSummary(
+          unpackLocation = createObjectLocationWith(bucket, key = "1/"),
+          storageSpace = bagLocation.storageSpace
+        )
+
+        result.get shouldBe a[IngestFailed[_]]
+      }
+    }
+  }
+}

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
@@ -17,7 +17,9 @@ case class ObjectLocationPayload(
 case class BagInformationPayload(
   ingestId: IngestID,
   storageSpace: StorageSpace,
-  bagRootLocation: ObjectLocation,
+  objectLocation: ObjectLocation,
   externalIdentifier: ExternalIdentifier,
   version: Int
-)
+) {
+  def bagRootLocation: ObjectLocation = objectLocation
+}

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.platform.archive.common
 
+import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.ObjectLocation
 
@@ -12,3 +13,11 @@ case class ObjectLocationPayload(
   storageSpace: StorageSpace,
   objectLocation: ObjectLocation
 ) extends PipelinePayload
+
+case class BagInformationPayload(
+  ingestId: IngestID,
+  storageSpace: StorageSpace,
+  bagRootLocation: ObjectLocation,
+  externalIdentifier: ExternalIdentifier,
+  version: Int
+)

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -1,6 +1,11 @@
 package uk.ac.wellcome.platform.archive.common.generators
 
-import uk.ac.wellcome.platform.archive.common.ObjectLocationPayload
+import uk.ac.wellcome.platform.archive.common.{
+  BagInformationPayload,
+  IngestID,
+  ObjectLocationPayload
+}
+import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.fixtures.S3
@@ -13,6 +18,19 @@ trait PayloadGenerators extends StorageSpaceGenerators with S3 {
       ingestId = createIngestID,
       storageSpace = storageSpace,
       objectLocation = objectLocation
+    )
+
+  def createBagInformationPayloadWith(ingestId: IngestID = createIngestID,
+                                      bagRootLocation: ObjectLocation,
+                                      storageSpace: StorageSpace,
+                                      externalIdentifier: ExternalIdentifier,
+                                      version: Int = 1): BagInformationPayload =
+    BagInformationPayload(
+      ingestId = ingestId,
+      storageSpace = storageSpace,
+      bagRootLocation = bagRootLocation,
+      externalIdentifier = externalIdentifier,
+      version = version
     )
 
   def createObjectLocationPayload: ObjectLocationPayload =

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -28,7 +28,7 @@ trait PayloadGenerators extends StorageSpaceGenerators with S3 {
     BagInformationPayload(
       ingestId = ingestId,
       storageSpace = storageSpace,
-      bagRootLocation = bagRootLocation,
+      objectLocation = bagRootLocation,
       externalIdentifier = externalIdentifier,
       version = version
     )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,9 +4,9 @@ object WellcomeDependencies {
   lazy val versions = new {
     val fixtures   = "1.0.0"
     val json       = "1.1.1"
-    val messaging  = "1.11.2"
+    val messaging  = "1.12.0"
     val monitoring = "2.1.0"
-    val storage    = "3.7.2"
+    val storage    = "3.9.0"
     val typesafe   = "1.0.0"
   }
 


### PR DESCRIPTION
For wellcometrust/platform#2777

These payloads are backwards-compatible, so the verifier/replicator will ignore the extra information for now.