### PR TITLE
Improve the replicator tests around destination building

### DIFF
--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicator.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicator.scala
@@ -1,7 +1,6 @@
 package uk.ac.wellcome.platform.archive.bagreplicator.services
 
 import java.io.InputStream
-import java.nio.file.Paths
 import java.time.Instant
 
 import com.amazonaws.services.s3.AmazonS3

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/DestinationBuilder.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/DestinationBuilder.scala
@@ -1,0 +1,24 @@
+package uk.ac.wellcome.platform.archive.bagreplicator.services
+
+import java.nio.file.Paths
+
+import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
+import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
+import uk.ac.wellcome.storage.ObjectLocation
+
+class DestinationBuilder(namespace: String, rootPath: Option[String]) {
+
+  def buildDestination(
+    storageSpace: StorageSpace,
+    externalIdentifier: ExternalIdentifier
+  ): ObjectLocation = ObjectLocation(
+    namespace = namespace,
+    key = Paths
+      .get(
+        rootPath.getOrElse(""),
+        storageSpace.toString,
+        externalIdentifier.toString
+      )
+      .toString
+  )
+}

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
@@ -35,19 +35,19 @@ trait BagReplicatorFixtures
     arn = "arn::default_q"
   )
 
-  def withBagReplicatorWorker[R](
-    ingestTopic: Topic,
-    outgoingTopic: Topic)(
+  def withBagReplicatorWorker[R](ingestTopic: Topic, outgoingTopic: Topic)(
     testWith: TestWith[BagReplicatorWorker, R]
   ): R =
     withLocalS3Bucket { bucket =>
       val config = createReplicatorDestinationConfigWith(bucket)
-      withBagReplicatorWorker(defaultQueue, ingestTopic, outgoingTopic, config) { worker =>
-        testWith(worker)
+      withBagReplicatorWorker(defaultQueue, ingestTopic, outgoingTopic, config) {
+        worker =>
+          testWith(worker)
       }
     }
 
-  def withBagReplicatorWorker[R](bucket: Bucket)(testWith: TestWith[BagReplicatorWorker, R]): R = {
+  def withBagReplicatorWorker[R](bucket: Bucket)(
+    testWith: TestWith[BagReplicatorWorker, R]): R = {
     val config = createReplicatorDestinationConfigWith(bucket)
     withBagReplicatorWorker(config) { worker =>
       testWith(worker)
@@ -63,23 +63,22 @@ trait BagReplicatorFixtures
       }
     }
 
-  def withBagReplicatorWorker[R](
-    ingestTopic: Topic,
-    outgoingTopic: Topic,
-    bucket: Bucket)(
+  def withBagReplicatorWorker[R](ingestTopic: Topic,
+                                 outgoingTopic: Topic,
+                                 bucket: Bucket)(
     testWith: TestWith[BagReplicatorWorker, R]
   ): R = {
     val config = createReplicatorDestinationConfigWith(bucket)
-    withBagReplicatorWorker(defaultQueue, ingestTopic, outgoingTopic, config) { worker =>
-      testWith(worker)
+    withBagReplicatorWorker(defaultQueue, ingestTopic, outgoingTopic, config) {
+      worker =>
+        testWith(worker)
     }
   }
 
-  def withBagReplicatorWorker[R](
-    queue: Queue,
-    ingestTopic: Topic,
-    outgoingTopic: Topic,
-    config: ReplicatorDestinationConfig)(
+  def withBagReplicatorWorker[R](queue: Queue,
+                                 ingestTopic: Topic,
+                                 outgoingTopic: Topic,
+                                 config: ReplicatorDestinationConfig)(
     testWith: TestWith[BagReplicatorWorker, R]): R =
     withActorSystem { implicit actorSystem =>
       withIngestUpdater("replicating", ingestTopic) { ingestUpdater =>
@@ -101,9 +100,10 @@ trait BagReplicatorFixtures
       }
     }
 
-  def createReplicatorDestinationConfigWith(
-    bucket: Bucket,
-    rootPath: Option[String] = Some(randomAlphanumeric())): ReplicatorDestinationConfig =
+  def createReplicatorDestinationConfigWith(bucket: Bucket,
+                                            rootPath: Option[String] = Some(
+                                              randomAlphanumeric()))
+    : ReplicatorDestinationConfig =
     ReplicatorDestinationConfig(
       namespace = bucket.name,
       rootPath = rootPath

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
@@ -48,6 +48,15 @@ trait BagReplicatorFixtures
     }
 
   def withBagReplicatorWorker[R](
+    config: ReplicatorDestinationConfig
+  )(testWith: TestWith[BagReplicatorWorker, R]): R =
+    withLocalSnsTopic { topic =>
+      withBagReplicatorWorker(defaultQueue, topic, topic, config) { worker =>
+        testWith(worker)
+      }
+    }
+
+  def withBagReplicatorWorker[R](
     ingestTopic: Topic,
     outgoingTopic: Topic,
     bucket: Bucket)(

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
@@ -47,6 +47,13 @@ trait BagReplicatorFixtures
       }
     }
 
+  def withBagReplicatorWorker[R](bucket: Bucket)(testWith: TestWith[BagReplicatorWorker, R]): R = {
+    val config = createReplicatorDestinationConfigWith(bucket)
+    withBagReplicatorWorker(config) { worker =>
+      testWith(worker)
+    }
+  }
+
   def withBagReplicatorWorker[R](
     config: ReplicatorDestinationConfig
   )(testWith: TestWith[BagReplicatorWorker, R]): R =
@@ -95,10 +102,11 @@ trait BagReplicatorFixtures
     }
 
   def createReplicatorDestinationConfigWith(
-    bucket: Bucket): ReplicatorDestinationConfig =
+    bucket: Bucket,
+    rootPath: Option[String] = Some(randomAlphanumeric())): ReplicatorDestinationConfig =
     ReplicatorDestinationConfig(
       namespace = bucket.name,
-      rootPath = Some(randomAlphanumeric())
+      rootPath = rootPath
     )
 
   def verifyBagCopied(src: ObjectLocation, dst: ObjectLocation): Assertion = {

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
@@ -22,13 +22,12 @@ class BagReplicatorWorkerTest
   it("replicates a bag successfully and updates both topics") {
     withLocalS3Bucket { ingestsBucket =>
       withLocalS3Bucket { archiveBucket =>
-        val destination = createReplicatorDestinationConfigWith(archiveBucket)
         withLocalSnsTopic { ingestTopic =>
           withLocalSnsTopic { outgoingTopic =>
             withBagReplicatorWorker(
               ingestTopic = ingestTopic,
               outgoingTopic = outgoingTopic,
-              config = destination) { service =>
+              bucket = archiveBucket) { service =>
               withBag(ingestsBucket) {
                 case (srcBagRootLocation, _) =>
                   val payload = createObjectLocationPayloadWith(

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
@@ -70,15 +70,16 @@ class BagReplicatorWorkerTest
       withLocalS3Bucket { ingestsBucket =>
         withLocalS3Bucket { archiveBucket =>
           withBagReplicatorWorker(archiveBucket) { worker =>
-            withBag(ingestsBucket) { case (bagRootLocation, _) =>
-              val payload = createObjectLocationPayloadWith(bagRootLocation)
+            withBag(ingestsBucket) {
+              case (bagRootLocation, _) =>
+                val payload = createObjectLocationPayloadWith(bagRootLocation)
 
-              val future = worker.processMessage(payload)
+                val future = worker.processMessage(payload)
 
-              whenReady(future) { result =>
-                val destination = result.summary.get.destination
-                destination.namespace shouldBe archiveBucket.name
-              }
+                whenReady(future) { result =>
+                  val destination = result.summary.get.destination
+                  destination.namespace shouldBe archiveBucket.name
+                }
             }
           }
         }
@@ -91,25 +92,27 @@ class BagReplicatorWorkerTest
           val config = createReplicatorDestinationConfigWith(archiveBucket)
           withBagReplicatorWorker(config) { worker =>
             val bagInfo = createBagInfo
-            withBag(ingestsBucket, bagInfo = bagInfo) { case (bagRootLocation, storageSpace) =>
-              val payload = createObjectLocationPayloadWith(
-                objectLocation = bagRootLocation,
-                storageSpace = storageSpace
-              )
+            withBag(ingestsBucket, bagInfo = bagInfo) {
+              case (bagRootLocation, storageSpace) =>
+                val payload = createObjectLocationPayloadWith(
+                  objectLocation = bagRootLocation,
+                  storageSpace = storageSpace
+                )
 
-              val future = worker.processMessage(payload)
+                val future = worker.processMessage(payload)
 
-              whenReady(future) { result =>
-                val destination = result.summary.get.destination
-                val expectedKey =
-                  Paths.get(
-                    config.rootPath.get,
-                    storageSpace.underlying,
-                    bagInfo.externalIdentifier.toString
-                  )
-                  .toString
-                destination.key shouldBe expectedKey
-              }
+                whenReady(future) { result =>
+                  val destination = result.summary.get.destination
+                  val expectedKey =
+                    Paths
+                      .get(
+                        config.rootPath.get,
+                        storageSpace.underlying,
+                        bagInfo.externalIdentifier.toString
+                      )
+                      .toString
+                  destination.key shouldBe expectedKey
+                }
             }
           }
         }
@@ -121,22 +124,24 @@ class BagReplicatorWorkerTest
         withLocalS3Bucket { archiveBucket =>
           withBagReplicatorWorker(archiveBucket) { worker =>
             val bagInfo = createBagInfo
-            withBag(ingestsBucket, bagInfo = bagInfo) { case (bagRootLocation, _) =>
-              val payload = createObjectLocationPayloadWith(bagRootLocation)
+            withBag(ingestsBucket, bagInfo = bagInfo) {
+              case (bagRootLocation, _) =>
+                val payload = createObjectLocationPayloadWith(bagRootLocation)
 
-              val future = worker.processMessage(payload)
+                val future = worker.processMessage(payload)
 
-              whenReady(future) { result =>
-                val destination = result.summary.get.destination
-                destination.key should endWith(bagInfo.externalIdentifier.toString)
-              }
+                whenReady(future) { result =>
+                  val destination = result.summary.get.destination
+                  destination.key should endWith(
+                    bagInfo.externalIdentifier.toString)
+                }
             }
           }
         }
       }
     }
 
-    it("prefixes the key with the storage space if no root path is set")  {
+    it("prefixes the key with the storage space if no root path is set") {
       withLocalS3Bucket { ingestsBucket =>
         withLocalS3Bucket { archiveBucket =>
           val config = createReplicatorDestinationConfigWith(
@@ -144,25 +149,26 @@ class BagReplicatorWorkerTest
             rootPath = None
           )
           withBagReplicatorWorker(config) { worker =>
-            withBag(ingestsBucket) { case (bagRootLocation, storageSpace) =>
-              val payload = createObjectLocationPayloadWith(
-                objectLocation = bagRootLocation,
-                storageSpace = storageSpace
-              )
+            withBag(ingestsBucket) {
+              case (bagRootLocation, storageSpace) =>
+                val payload = createObjectLocationPayloadWith(
+                  objectLocation = bagRootLocation,
+                  storageSpace = storageSpace
+                )
 
-              val future = worker.processMessage(payload)
+                val future = worker.processMessage(payload)
 
-              whenReady(future) { result =>
-                val destination = result.summary.get.destination
-                destination.key should startWith(storageSpace.underlying)
-              }
+                whenReady(future) { result =>
+                  val destination = result.summary.get.destination
+                  destination.key should startWith(storageSpace.underlying)
+                }
             }
           }
         }
       }
     }
 
-    it("prefixes the key with the root path if set")  {
+    it("prefixes the key with the root path if set") {
       withLocalS3Bucket { ingestsBucket =>
         withLocalS3Bucket { archiveBucket =>
           val config = createReplicatorDestinationConfigWith(
@@ -170,18 +176,19 @@ class BagReplicatorWorkerTest
             rootPath = Some("rootprefix")
           )
           withBagReplicatorWorker(config) { worker =>
-            withBag(ingestsBucket) { case (bagRootLocation, storageSpace) =>
-              val payload = createObjectLocationPayloadWith(
-                objectLocation = bagRootLocation,
-                storageSpace = storageSpace
-              )
+            withBag(ingestsBucket) {
+              case (bagRootLocation, storageSpace) =>
+                val payload = createObjectLocationPayloadWith(
+                  objectLocation = bagRootLocation,
+                  storageSpace = storageSpace
+                )
 
-              val future = worker.processMessage(payload)
+                val future = worker.processMessage(payload)
 
-              whenReady(future) { result =>
-                val destination = result.summary.get.destination
-                destination.key should startWith("rootprefix/")
-              }
+                whenReady(future) { result =>
+                  val destination = result.summary.get.destination
+                  destination.key should startWith("rootprefix/")
+                }
             }
           }
         }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/DestinationBuilderTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/DestinationBuilderTest.scala
@@ -1,9 +1,16 @@
 package uk.ac.wellcome.platform.archive.bagreplicator.services
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.platform.archive.common.generators.{ExternalIdentifierGenerators, StorageSpaceGenerators}
+import uk.ac.wellcome.platform.archive.common.generators.{
+  ExternalIdentifierGenerators,
+  StorageSpaceGenerators
+}
 
-class DestinationBuilderTest extends FunSpec with Matchers with ExternalIdentifierGenerators with StorageSpaceGenerators {
+class DestinationBuilderTest
+    extends FunSpec
+    with Matchers
+    with ExternalIdentifierGenerators
+    with StorageSpaceGenerators {
 
   it("uses the root path if provided") {
     val builder = new DestinationBuilder(

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/DestinationBuilderTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/DestinationBuilderTest.scala
@@ -1,0 +1,43 @@
+package uk.ac.wellcome.platform.archive.bagreplicator.services
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.platform.archive.common.generators.{ExternalIdentifierGenerators, StorageSpaceGenerators}
+
+class DestinationBuilderTest extends FunSpec with Matchers with ExternalIdentifierGenerators with StorageSpaceGenerators {
+
+  it("uses the root path if provided") {
+    val builder = new DestinationBuilder(
+      namespace = "MyNamespace",
+      rootPath = Some("RootPath")
+    )
+
+    val storageSpace = createStorageSpace
+    val externalIdentifier = createExternalIdentifier
+
+    val location = builder.buildDestination(
+      storageSpace = storageSpace,
+      externalIdentifier = externalIdentifier
+    )
+
+    location.namespace shouldBe "MyNamespace"
+    location.key shouldBe s"RootPath/${storageSpace.underlying}/${externalIdentifier.toString}"
+  }
+
+  it("skips the root path if not provided") {
+    val builder = new DestinationBuilder(
+      namespace = "MyNamespace",
+      rootPath = None
+    )
+
+    val storageSpace = createStorageSpace
+    val externalIdentifier = createExternalIdentifier
+
+    val location = builder.buildDestination(
+      storageSpace = storageSpace,
+      externalIdentifier = externalIdentifier
+    )
+
+    location.namespace shouldBe "MyNamespace"
+    location.key shouldBe s"${storageSpace.underlying}/${externalIdentifier.toString}"
+  }
+}


### PR DESCRIPTION
Refactoring in anticipation of wellcometrust/platform#2777

Our tests checked that the replicator had indeed copied files to the stated destination, but made no attempt to check the destination was sensible! I’m about to change this logic for the new payloads, so let’s get some proper tests around it.