### PR TITLE
Use the new payloads in the bag verifier and bag replicator

### DIFF
--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicator.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicator.scala
@@ -28,12 +28,10 @@ class BagReplicator(config: ReplicatorDestinationConfig)(
     rootPath = config.rootPath
   )
 
-  def replicate(
-    bagRootLocation: ObjectLocation,
-    storageSpace: StorageSpace,
-    externalIdentifier: ExternalIdentifier,
-    version: Int)
-    : Future[IngestStepResult[ReplicationSummary]] = {
+  def replicate(bagRootLocation: ObjectLocation,
+                storageSpace: StorageSpace,
+                externalIdentifier: ExternalIdentifier,
+                version: Int): Future[IngestStepResult[ReplicationSummary]] = {
     val replicationSummary = ReplicationSummary(
       startTime = Instant.now(),
       bagRootLocation = bagRootLocation,

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicator.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicator.scala
@@ -34,7 +34,8 @@ class BagReplicator(config: ReplicatorDestinationConfig)(
   def replicate(
     bagRootLocation: ObjectLocation,
     storageSpace: StorageSpace,
-    externalIdentifier: ExternalIdentifier)
+    externalIdentifier: ExternalIdentifier,
+    version: Int)
     : Future[IngestStepResult[ReplicationSummary]] = {
     val replicationSummary = ReplicationSummary(
       startTime = Instant.now(),
@@ -44,7 +45,8 @@ class BagReplicator(config: ReplicatorDestinationConfig)(
 
     val destination = destinationBuilder.buildDestination(
       storageSpace = storageSpace,
-      externalIdentifier = externalIdentifier
+      externalIdentifier = externalIdentifier,
+      version = version
     )
 
     val copyOperation = for {

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.messaging.sqsworker.alpakka.{
 import uk.ac.wellcome.messaging.worker.models.Result
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
 import uk.ac.wellcome.platform.archive.bagreplicator.models.ReplicationSummary
-import uk.ac.wellcome.platform.archive.common.ObjectLocationPayload
+import uk.ac.wellcome.platform.archive.common.BagInformationPayload
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services._
 import uk.ac.wellcome.platform.archive.common.storage.models.IngestStepWorker
@@ -32,19 +32,17 @@ class BagReplicatorWorker(
     extends Runnable
     with Logging
     with IngestStepWorker {
-  private val worker
-    : AlpakkaSQSWorker[ObjectLocationPayload, ReplicationSummary] =
-    AlpakkaSQSWorker[ObjectLocationPayload, ReplicationSummary](
-      alpakkaSQSWorkerConfig) {
+  private val worker =
+    AlpakkaSQSWorker[BagInformationPayload, ReplicationSummary](alpakkaSQSWorkerConfig) {
       processMessage
     }
 
   def processMessage(
-    payload: ObjectLocationPayload,
+    payload: BagInformationPayload,
   ): Future[Result[ReplicationSummary]] =
     for {
       replicationSummary <- bagReplicator.replicate(
-        bagRootLocation = payload.objectLocation,
+        bagRootLocation = payload.bagRootLocation,
         storageSpace = payload.storageSpace
       )
       _ <- ingestUpdater.send(payload.ingestId, replicationSummary)

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
@@ -33,7 +33,8 @@ class BagReplicatorWorker(
     with Logging
     with IngestStepWorker {
   private val worker =
-    AlpakkaSQSWorker[BagInformationPayload, ReplicationSummary](alpakkaSQSWorkerConfig) {
+    AlpakkaSQSWorker[BagInformationPayload, ReplicationSummary](
+      alpakkaSQSWorkerConfig) {
       processMessage
     }
 

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
@@ -43,7 +43,8 @@ class BagReplicatorWorker(
     for {
       replicationSummary <- bagReplicator.replicate(
         bagRootLocation = payload.bagRootLocation,
-        storageSpace = payload.storageSpace
+        storageSpace = payload.storageSpace,
+        externalIdentifier = payload.externalIdentifier
       )
       _ <- ingestUpdater.send(payload.ingestId, replicationSummary)
       _ <- outgoingPublisher.sendIfSuccessful(

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
@@ -44,7 +44,8 @@ class BagReplicatorWorker(
       replicationSummary <- bagReplicator.replicate(
         bagRootLocation = payload.bagRootLocation,
         storageSpace = payload.storageSpace,
-        externalIdentifier = payload.externalIdentifier
+        externalIdentifier = payload.externalIdentifier,
+        version = payload.version
       )
       _ <- ingestUpdater.send(payload.ingestId, replicationSummary)
       _ <- outgoingPublisher.sendIfSuccessful(

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/DestinationBuilder.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/DestinationBuilder.scala
@@ -10,14 +10,16 @@ class DestinationBuilder(namespace: String, rootPath: Option[String]) {
 
   def buildDestination(
     storageSpace: StorageSpace,
-    externalIdentifier: ExternalIdentifier
+    externalIdentifier: ExternalIdentifier,
+    version: Int
   ): ObjectLocation = ObjectLocation(
     namespace = namespace,
     key = Paths
       .get(
         rootPath.getOrElse(""),
         storageSpace.toString,
-        externalIdentifier.toString
+        externalIdentifier.toString,
+        s"v$version"
       )
       .toString
   )

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
@@ -37,8 +37,8 @@ class BagReplicatorFeatureTest
 
                 withBag(ingestsBucket, bagInfo = bagInfo) {
                   case (srcBagRootLocation, storageSpace) =>
-                    val payload = createObjectLocationPayloadWith(
-                      objectLocation = srcBagRootLocation,
+                    val payload = createBagInformationPayloadWith(
+                      bagRootLocation = srcBagRootLocation,
                       storageSpace = storageSpace
                     )
 

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
@@ -48,7 +48,8 @@ class BagReplicatorFeatureTest
                           .get(
                             destination.rootPath.getOrElse(""),
                             payload.storageSpace.toString,
-                            payload.externalIdentifier.toString
+                            payload.externalIdentifier.toString,
+                            s"v${payload.version}"
                           )
                           .toString
                       )

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
@@ -33,13 +33,10 @@ class BagReplicatorFeatureTest
                 ingestTopic = ingestTopic,
                 outgoingTopic = outgoingTopic,
                 config = destination) { _ =>
-                val bagInfo = createBagInfo
-
-                withBag(ingestsBucket, bagInfo = bagInfo) {
-                  case (srcBagRootLocation, storageSpace) =>
+                withBag(ingestsBucket) {
+                  case (srcBagRootLocation, _) =>
                     val payload = createBagInformationPayloadWith(
-                      bagRootLocation = srcBagRootLocation,
-                      storageSpace = storageSpace
+                      bagRootLocation = srcBagRootLocation
                     )
 
                     sendNotificationToSQS(queue, payload)
@@ -50,8 +47,8 @@ class BagReplicatorFeatureTest
                         key = Paths
                           .get(
                             destination.rootPath.getOrElse(""),
-                            storageSpace.toString,
-                            bagInfo.externalIdentifier.toString
+                            payload.storageSpace.toString,
+                            payload.externalIdentifier.toString
                           )
                           .toString
                       )

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
@@ -108,7 +108,8 @@ class BagReplicatorWorkerTest
                   Paths.get(
                     config.rootPath.get,
                     payload.storageSpace.underlying,
-                    payload.externalIdentifier.toString
+                    payload.externalIdentifier.toString,
+                    s"v${payload.version}"
                   )
                   .toString
                 destination.key shouldBe expectedKey
@@ -119,20 +120,21 @@ class BagReplicatorWorkerTest
       }
     }
 
-    it("key ends with the external identifier of the bag") {
+    it("key ends with the external identifier and version of the bag") {
       withLocalS3Bucket { ingestsBucket =>
         withLocalS3Bucket { archiveBucket =>
           withBagReplicatorWorker(archiveBucket) { worker =>
             withBag(ingestsBucket) { case (bagRootLocation, _) =>
               val payload = createBagInformationPayloadWith(
-                bagRootLocation = bagRootLocation
+                bagRootLocation = bagRootLocation,
+                version = 3
               )
 
                 val future = worker.processMessage(payload)
 
               whenReady(future) { result =>
                 val destination = result.summary.get.destination
-                destination.key should endWith(payload.externalIdentifier.toString)
+                destination.key should endWith(s"/${payload.externalIdentifier.toString}/v3")
               }
             }
           }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
@@ -95,25 +95,27 @@ class BagReplicatorWorkerTest
           val config = createReplicatorDestinationConfigWith(archiveBucket)
           withBagReplicatorWorker(config) { worker =>
             val bagInfo = createBagInfo
-            withBag(ingestsBucket, bagInfo = bagInfo) { case (bagRootLocation, _) =>
-              val payload = createBagInformationPayloadWith(
-                bagRootLocation = bagRootLocation
-              )
+            withBag(ingestsBucket, bagInfo = bagInfo) {
+              case (bagRootLocation, _) =>
+                val payload = createBagInformationPayloadWith(
+                  bagRootLocation = bagRootLocation
+                )
 
-              val future = worker.processMessage(payload)
+                val future = worker.processMessage(payload)
 
-              whenReady(future) { result =>
-                val destination = result.summary.get.destination
-                val expectedKey =
-                  Paths.get(
-                    config.rootPath.get,
-                    payload.storageSpace.underlying,
-                    payload.externalIdentifier.toString,
-                    s"v${payload.version}"
-                  )
-                  .toString
-                destination.key shouldBe expectedKey
-              }
+                whenReady(future) { result =>
+                  val destination = result.summary.get.destination
+                  val expectedKey =
+                    Paths
+                      .get(
+                        config.rootPath.get,
+                        payload.storageSpace.underlying,
+                        payload.externalIdentifier.toString,
+                        s"v${payload.version}"
+                      )
+                      .toString
+                  destination.key shouldBe expectedKey
+                }
             }
           }
         }
@@ -124,18 +126,20 @@ class BagReplicatorWorkerTest
       withLocalS3Bucket { ingestsBucket =>
         withLocalS3Bucket { archiveBucket =>
           withBagReplicatorWorker(archiveBucket) { worker =>
-            withBag(ingestsBucket) { case (bagRootLocation, _) =>
-              val payload = createBagInformationPayloadWith(
-                bagRootLocation = bagRootLocation,
-                version = 3
-              )
+            withBag(ingestsBucket) {
+              case (bagRootLocation, _) =>
+                val payload = createBagInformationPayloadWith(
+                  bagRootLocation = bagRootLocation,
+                  version = 3
+                )
 
                 val future = worker.processMessage(payload)
 
-              whenReady(future) { result =>
-                val destination = result.summary.get.destination
-                destination.key should endWith(s"/${payload.externalIdentifier.toString}/v3")
-              }
+                whenReady(future) { result =>
+                  val destination = result.summary.get.destination
+                  destination.key should endWith(
+                    s"/${payload.externalIdentifier.toString}/v3")
+                }
             }
           }
         }
@@ -150,17 +154,19 @@ class BagReplicatorWorkerTest
             rootPath = None
           )
           withBagReplicatorWorker(config) { worker =>
-            withBag(ingestsBucket) { case (bagRootLocation, _) =>
-              val payload = createBagInformationPayloadWith(
-                bagRootLocation = bagRootLocation
-              )
+            withBag(ingestsBucket) {
+              case (bagRootLocation, _) =>
+                val payload = createBagInformationPayloadWith(
+                  bagRootLocation = bagRootLocation
+                )
 
-              val future = worker.processMessage(payload)
+                val future = worker.processMessage(payload)
 
-              whenReady(future) { result =>
-                val destination = result.summary.get.destination
-                destination.key should startWith(payload.storageSpace.underlying)
-              }
+                whenReady(future) { result =>
+                  val destination = result.summary.get.destination
+                  destination.key should startWith(
+                    payload.storageSpace.underlying)
+                }
             }
           }
         }
@@ -175,17 +181,18 @@ class BagReplicatorWorkerTest
             rootPath = Some("rootprefix")
           )
           withBagReplicatorWorker(config) { worker =>
-            withBag(ingestsBucket) { case (bagRootLocation, _) =>
-              val payload = createBagInformationPayloadWith(
-                bagRootLocation = bagRootLocation
-              )
+            withBag(ingestsBucket) {
+              case (bagRootLocation, _) =>
+                val payload = createBagInformationPayloadWith(
+                  bagRootLocation = bagRootLocation
+                )
 
-              val future = worker.processMessage(payload)
+                val future = worker.processMessage(payload)
 
-              whenReady(future) { result =>
-                val destination = result.summary.get.destination
-                destination.key should startWith("rootprefix/")
-              }
+                whenReady(future) { result =>
+                  val destination = result.summary.get.destination
+                  destination.key should startWith("rootprefix/")
+                }
             }
           }
         }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
@@ -31,9 +31,10 @@ class BagReplicatorWorkerTest
               outgoingTopic = outgoingTopic,
               bucket = archiveBucket) { service =>
               withBag(ingestsBucket) {
-                case (srcBagRootLocation, _) =>
-                  val payload = createObjectLocationPayloadWith(
-                    srcBagRootLocation
+                case (srcBagRootLocation, storageSpace) =>
+                  val payload = createBagInformationPayloadWith(
+                    bagRootLocation = srcBagRootLocation,
+                    storageSpace = storageSpace
                   )
 
                   val future = service.processMessage(payload)
@@ -202,7 +203,7 @@ class BagReplicatorWorkerTest
         withBagReplicatorWorker(
           ingestTopic = ingestTopic,
           outgoingTopic = outgoingTopic) { service =>
-          val payload = createObjectLocationPayload
+          val payload = createBagInformationPayload
 
           val future = service.processMessage(payload)
 

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
@@ -95,26 +95,24 @@ class BagReplicatorWorkerTest
           val config = createReplicatorDestinationConfigWith(archiveBucket)
           withBagReplicatorWorker(config) { worker =>
             val bagInfo = createBagInfo
-            withBag(ingestsBucket, bagInfo = bagInfo) {
-              case (bagRootLocation, storageSpace) =>
-                val payload = createBagInformationPayloadWith(
-                  bagRootLocation = bagRootLocation,
-                  storageSpace = storageSpace
-                )
+            withBag(ingestsBucket, bagInfo = bagInfo) { case (bagRootLocation, _) =>
+              val payload = createBagInformationPayloadWith(
+                bagRootLocation = bagRootLocation
+              )
 
-                val future = worker.processMessage(payload)
+              val future = worker.processMessage(payload)
 
-                whenReady(future) { result =>
-                  val destination = result.summary.get.destination
-                  val expectedKey =
-                    Paths.get(
-                      config.rootPath.get,
-                      storageSpace.underlying,
-                      bagInfo.externalIdentifier.toString
-                    )
-                      .toString
-                  destination.key shouldBe expectedKey
-                }
+              whenReady(future) { result =>
+                val destination = result.summary.get.destination
+                val expectedKey =
+                  Paths.get(
+                    config.rootPath.get,
+                    payload.storageSpace.underlying,
+                    payload.externalIdentifier.toString
+                  )
+                  .toString
+                destination.key shouldBe expectedKey
+              }
             }
           }
         }
@@ -125,19 +123,17 @@ class BagReplicatorWorkerTest
       withLocalS3Bucket { ingestsBucket =>
         withLocalS3Bucket { archiveBucket =>
           withBagReplicatorWorker(archiveBucket) { worker =>
-            val bagInfo = createBagInfo
-            withBag(ingestsBucket, bagInfo = bagInfo) { case (bagRootLocation, _) =>
+            withBag(ingestsBucket) { case (bagRootLocation, _) =>
               val payload = createBagInformationPayloadWith(
                 bagRootLocation = bagRootLocation
               )
 
                 val future = worker.processMessage(payload)
 
-                whenReady(future) { result =>
-                  val destination = result.summary.get.destination
-                  destination.key should endWith(
-                    bagInfo.externalIdentifier.toString)
-                }
+              whenReady(future) { result =>
+                val destination = result.summary.get.destination
+                destination.key should endWith(payload.externalIdentifier.toString)
+              }
             }
           }
         }
@@ -152,19 +148,17 @@ class BagReplicatorWorkerTest
             rootPath = None
           )
           withBagReplicatorWorker(config) { worker =>
-            withBag(ingestsBucket) {
-              case (bagRootLocation, storageSpace) =>
-                val payload = createBagInformationPayloadWith(
-                  bagRootLocation = bagRootLocation,
-                  storageSpace = storageSpace
-                )
+            withBag(ingestsBucket) { case (bagRootLocation, _) =>
+              val payload = createBagInformationPayloadWith(
+                bagRootLocation = bagRootLocation
+              )
 
-                val future = worker.processMessage(payload)
+              val future = worker.processMessage(payload)
 
-                whenReady(future) { result =>
-                  val destination = result.summary.get.destination
-                  destination.key should startWith(storageSpace.underlying)
-                }
+              whenReady(future) { result =>
+                val destination = result.summary.get.destination
+                destination.key should startWith(payload.storageSpace.underlying)
+              }
             }
           }
         }
@@ -179,19 +173,17 @@ class BagReplicatorWorkerTest
             rootPath = Some("rootprefix")
           )
           withBagReplicatorWorker(config) { worker =>
-            withBag(ingestsBucket) {
-              case (bagRootLocation, storageSpace) =>
-                val payload = createBagInformationPayloadWith(
-                  bagRootLocation = bagRootLocation,
-                  storageSpace = storageSpace
-                )
+            withBag(ingestsBucket) { case (bagRootLocation, _) =>
+              val payload = createBagInformationPayloadWith(
+                bagRootLocation = bagRootLocation
+              )
 
-                val future = worker.processMessage(payload)
+              val future = worker.processMessage(payload)
 
-                whenReady(future) { result =>
-                  val destination = result.summary.get.destination
-                  destination.key should startWith("rootprefix/")
-                }
+              whenReady(future) { result =>
+                val destination = result.summary.get.destination
+                destination.key should startWith("rootprefix/")
+              }
             }
           }
         }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
@@ -73,7 +73,9 @@ class BagReplicatorWorkerTest
           withBagReplicatorWorker(archiveBucket) { worker =>
             withBag(ingestsBucket) {
               case (bagRootLocation, _) =>
-                val payload = createObjectLocationPayloadWith(bagRootLocation)
+                val payload = createBagInformationPayloadWith(
+                  bagRootLocation = bagRootLocation
+                )
 
                 val future = worker.processMessage(payload)
 
@@ -95,8 +97,8 @@ class BagReplicatorWorkerTest
             val bagInfo = createBagInfo
             withBag(ingestsBucket, bagInfo = bagInfo) {
               case (bagRootLocation, storageSpace) =>
-                val payload = createObjectLocationPayloadWith(
-                  objectLocation = bagRootLocation,
+                val payload = createBagInformationPayloadWith(
+                  bagRootLocation = bagRootLocation,
                   storageSpace = storageSpace
                 )
 
@@ -105,12 +107,11 @@ class BagReplicatorWorkerTest
                 whenReady(future) { result =>
                   val destination = result.summary.get.destination
                   val expectedKey =
-                    Paths
-                      .get(
-                        config.rootPath.get,
-                        storageSpace.underlying,
-                        bagInfo.externalIdentifier.toString
-                      )
+                    Paths.get(
+                      config.rootPath.get,
+                      storageSpace.underlying,
+                      bagInfo.externalIdentifier.toString
+                    )
                       .toString
                   destination.key shouldBe expectedKey
                 }
@@ -125,9 +126,10 @@ class BagReplicatorWorkerTest
         withLocalS3Bucket { archiveBucket =>
           withBagReplicatorWorker(archiveBucket) { worker =>
             val bagInfo = createBagInfo
-            withBag(ingestsBucket, bagInfo = bagInfo) {
-              case (bagRootLocation, _) =>
-                val payload = createObjectLocationPayloadWith(bagRootLocation)
+            withBag(ingestsBucket, bagInfo = bagInfo) { case (bagRootLocation, _) =>
+              val payload = createBagInformationPayloadWith(
+                bagRootLocation = bagRootLocation
+              )
 
                 val future = worker.processMessage(payload)
 
@@ -152,8 +154,8 @@ class BagReplicatorWorkerTest
           withBagReplicatorWorker(config) { worker =>
             withBag(ingestsBucket) {
               case (bagRootLocation, storageSpace) =>
-                val payload = createObjectLocationPayloadWith(
-                  objectLocation = bagRootLocation,
+                val payload = createBagInformationPayloadWith(
+                  bagRootLocation = bagRootLocation,
                   storageSpace = storageSpace
                 )
 
@@ -179,8 +181,8 @@ class BagReplicatorWorkerTest
           withBagReplicatorWorker(config) { worker =>
             withBag(ingestsBucket) {
               case (bagRootLocation, storageSpace) =>
-                val payload = createObjectLocationPayloadWith(
-                  objectLocation = bagRootLocation,
+                val payload = createBagInformationPayloadWith(
+                  bagRootLocation = bagRootLocation,
                   storageSpace = storageSpace
                 )
 

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/DestinationBuilderTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/DestinationBuilderTest.scala
@@ -23,11 +23,12 @@ class DestinationBuilderTest
 
     val location = builder.buildDestination(
       storageSpace = storageSpace,
-      externalIdentifier = externalIdentifier
+      externalIdentifier = externalIdentifier,
+      version = 1
     )
 
     location.namespace shouldBe "MyNamespace"
-    location.key shouldBe s"RootPath/${storageSpace.underlying}/${externalIdentifier.toString}"
+    location.key shouldBe s"RootPath/${storageSpace.underlying}/${externalIdentifier.toString}/v1"
   }
 
   it("skips the root path if not provided") {
@@ -41,10 +42,11 @@ class DestinationBuilderTest
 
     val location = builder.buildDestination(
       storageSpace = storageSpace,
-      externalIdentifier = externalIdentifier
+      externalIdentifier = externalIdentifier,
+      version = 2
     )
 
     location.namespace shouldBe "MyNamespace"
-    location.key shouldBe s"${storageSpace.underlying}/${externalIdentifier.toString}"
+    location.key shouldBe s"${storageSpace.underlying}/${externalIdentifier.toString}/v2"
   }
 }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/VerifierFeatureTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/VerifierFeatureTest.scala
@@ -30,8 +30,8 @@ class VerifierFeatureTest
               withLocalS3Bucket { bucket =>
                 withBag(bucket) {
                   case (bagRootLocation, _) =>
-                    val payload = createObjectLocationPayloadWith(
-                      bagRootLocation
+                    val payload = createBagInformationPayloadWith(
+                      bagRootLocation = bagRootLocation
                     )
 
                     sendNotificationToSQS(queue, payload)
@@ -73,8 +73,8 @@ class VerifierFeatureTest
                   bucket,
                   createDataManifest = dataManifestWithWrongChecksum) {
                   case (bagRootLocation, _) =>
-                    val payload = createObjectLocationPayloadWith(
-                      bagRootLocation
+                    val payload = createBagInformationPayloadWith(
+                      bagRootLocation = bagRootLocation
                     )
 
                     sendNotificationToSQS(queue, payload)

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/VerifierWorkerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/VerifierWorkerTest.scala
@@ -31,8 +31,8 @@ class VerifierWorkerTest
           withLocalS3Bucket { bucket =>
             withBag(bucket) {
               case (bagRootLocation, _) =>
-                val payload = createObjectLocationPayloadWith(
-                  bagRootLocation
+                val payload = createBagInformationPayloadWith(
+                  bagRootLocation = bagRootLocation
                 )
 
                 val future = service.processMessage(payload)
@@ -67,8 +67,8 @@ class VerifierWorkerTest
           withLocalS3Bucket { bucket =>
             withBag(bucket, createDataManifest = dataManifestWithWrongChecksum) {
               case (bagRootLocation, _) =>
-                val payload = createObjectLocationPayloadWith(
-                  bagRootLocation
+                val payload = createBagInformationPayloadWith(
+                  bagRootLocation = bagRootLocation
                 )
 
                 val future = service.processMessage(payload)
@@ -104,8 +104,8 @@ class VerifierWorkerTest
           withLocalS3Bucket { bucket =>
             withBag(bucket, createDataManifest = dontCreateTheDataManifest) {
               case (bagRootLocation, _) =>
-                val payload = createObjectLocationPayloadWith(
-                  bagRootLocation
+                val payload = createBagInformationPayloadWith(
+                  bagRootLocation = bagRootLocation
                 )
 
                 val future = service.processMessage(payload)
@@ -140,8 +140,8 @@ class VerifierWorkerTest
         withLocalS3Bucket { bucket =>
           withBag(bucket) {
             case (bagRootLocation, _) =>
-              val payload = createObjectLocationPayloadWith(
-                bagRootLocation
+              val payload = createBagInformationPayloadWith(
+                bagRootLocation = bagRootLocation
               )
 
               val future = service.processMessage(payload)

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -10,7 +10,10 @@ import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.fixtures.S3
 
-trait PayloadGenerators extends ExternalIdentifierGenerators with StorageSpaceGenerators with S3 {
+trait PayloadGenerators
+    extends ExternalIdentifierGenerators
+    with StorageSpaceGenerators
+    with S3 {
   def createObjectLocationPayloadWith(
     objectLocation: ObjectLocation = createObjectLocation,
     storageSpace: StorageSpace = createStorageSpace): ObjectLocationPayload =

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -10,7 +10,7 @@ import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.fixtures.S3
 
-trait PayloadGenerators extends StorageSpaceGenerators with S3 {
+trait PayloadGenerators extends ExternalIdentifierGenerators with StorageSpaceGenerators with S3 {
   def createObjectLocationPayloadWith(
     objectLocation: ObjectLocation = createObjectLocation,
     storageSpace: StorageSpace = createStorageSpace): ObjectLocationPayload =
@@ -20,11 +20,12 @@ trait PayloadGenerators extends StorageSpaceGenerators with S3 {
       objectLocation = objectLocation
     )
 
-  def createBagInformationPayloadWith(ingestId: IngestID = createIngestID,
-                                      bagRootLocation: ObjectLocation,
-                                      storageSpace: StorageSpace,
-                                      externalIdentifier: ExternalIdentifier,
-                                      version: Int = 1): BagInformationPayload =
+  def createBagInformationPayloadWith(
+    ingestId: IngestID = createIngestID,
+    bagRootLocation: ObjectLocation,
+    storageSpace: StorageSpace = createStorageSpace,
+    externalIdentifier: ExternalIdentifier = createExternalIdentifier,
+    version: Int = 1): BagInformationPayload =
     BagInformationPayload(
       ingestId = ingestId,
       storageSpace = storageSpace,

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -20,9 +20,12 @@ trait PayloadGenerators extends ExternalIdentifierGenerators with StorageSpaceGe
       objectLocation = objectLocation
     )
 
+  def createObjectLocationPayload: ObjectLocationPayload =
+    createObjectLocationPayloadWith()
+
   def createBagInformationPayloadWith(
     ingestId: IngestID = createIngestID,
-    bagRootLocation: ObjectLocation,
+    bagRootLocation: ObjectLocation = createObjectLocation,
     storageSpace: StorageSpace = createStorageSpace,
     externalIdentifier: ExternalIdentifier = createExternalIdentifier,
     version: Int = 1): BagInformationPayload =
@@ -34,6 +37,6 @@ trait PayloadGenerators extends ExternalIdentifierGenerators with StorageSpaceGe
       version = version
     )
 
-  def createObjectLocationPayload: ObjectLocationPayload =
-    createObjectLocationPayloadWith()
+  def createBagInformationPayload: BagInformationPayload =
+    createBagInformationPayloadWith()
 }


### PR DESCRIPTION
Another step towards wellcometrust/platform#2777!

The verifier passes through the result transparently.

The replicator is a bigger change – we tweak the way we construct the destination, add a `v1`/`v2`/`vN` suffix to paths, and get to simplify some of its internal code!