### PR TITLE
Create a version picker for the bag auditor

### DIFF
--- a/bag_auditor/docker-compose.yml
+++ b/bag_auditor/docker-compose.yml
@@ -13,3 +13,7 @@ s3:
     - "S3BACKEND=mem"
   ports:
     - "33333:8000"
+dynamodb:
+  image: "peopleperhour/dynamodb"
+  ports:
+    - "45678:8000"

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/VersionManager.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/VersionManager.scala
@@ -2,17 +2,22 @@ package uk.ac.wellcome.platform.storage.bagauditor.services
 import java.time.Instant
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
-import com.gu.scanamo.{Scanamo, Table}
+import com.amazonaws.services.dynamodbv2.document.internal.InternalUtils
+import com.amazonaws.services.dynamodbv2.document.spec.QuerySpec
+import com.amazonaws.services.dynamodbv2.document.{DynamoDB, Item}
+import com.amazonaws.services.dynamodbv2.model.AttributeValue
+import com.gu.scanamo.error.DynamoReadError
+import com.gu.scanamo.{DynamoFormat, Scanamo, ScanamoFree, Table}
 import uk.ac.wellcome.platform.archive.common.IngestID
 import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
 import uk.ac.wellcome.storage.dynamo._
 
 import scala.concurrent.Future
 
-case class BagVersion(
+case class VersionRecord(
   ingestId: IngestID,
   ingestDate: Instant,
-  externalIdentifier: ExternalIdentifier,
+  externalIdentifier: String,
   version: Int
 )
 
@@ -21,22 +26,65 @@ class VersionManager(
   dynamoConfig: DynamoConfig
 ) {
 
-  val table: Table[BagVersion] = Table[BagVersion](dynamoConfig.table)
+  val documentClient = new DynamoDB(dynamoClient)
+
+  val table: Table[VersionRecord] = Table[VersionRecord](dynamoConfig.table)
 
   def assignVersion(
     ingestId: IngestID,
     ingestDate: Instant,
     externalIdentifier: ExternalIdentifier
   ): Future[Int] = {
-    val bagVersion = BagVersion(
+    val newVersion = getLatestVersionRecord(externalIdentifier) match {
+      case Some(existingRecord) => existingRecord.version + 1
+      case None => 1
+    }
+
+    val newRecord = VersionRecord(
       ingestId = ingestId,
       ingestDate = ingestDate,
-      externalIdentifier = externalIdentifier,
-      version = 1
+      externalIdentifier = externalIdentifier.underlying,
+      version = newVersion
     )
 
-    Scanamo.exec(dynamoClient)(table.put(bagVersion))
+    Scanamo.exec(dynamoClient)(table.put(newRecord))
 
-    Future.successful(1)
+    Future.successful(newVersion)
+  }
+
+  /** Find the existing version record with the highest version, or None
+    * if this external ID hasn't been seen before.
+    *
+    */
+  private def getLatestVersionRecord(externalIdentifier: ExternalIdentifier): Option[VersionRecord] = {
+
+    // Query results are sorted by the range key, which in our case is `version`.
+    // By setting `ScanIndexForward` to false, we sort the results in descending order,
+    // so the first result returned is the highest version.
+    val querySpec = new QuerySpec()
+      .withHashKey("externalIdentifier", externalIdentifier.underlying)
+      .withConsistentRead(true)
+      .withScanIndexForward(false)
+      .withMaxResultSize(1)
+
+    val result = documentClient
+      .getTable(dynamoConfig.table)
+      .query(querySpec)
+      .iterator()
+
+    if (result.hasNext) {
+      val item: Item = result.next()
+      asCaseClass[VersionRecord](item) match {
+        case Right(record) => Some(record)
+        case Left(error) => throw new RuntimeException(s"Error parsing $item with Scanamo: $error")
+      }
+    } else {
+      None
+    }
+  }
+
+  private def asCaseClass[T](item: Item)(implicit evidence: DynamoFormat[T]): Either[DynamoReadError, T] = {
+    val attributeValueMap: java.util.Map[String, AttributeValue] = InternalUtils.toAttributeValues(item)
+    ScanamoFree.read[T](attributeValueMap)
   }
 }

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/VersionManager.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/VersionManager.scala
@@ -47,7 +47,13 @@ class VersionManager(
         }
       case None =>
         val newVersion = getLatestVersionRecord(externalIdentifier) match {
-          case Some(existingRecord) => existingRecord.version + 1
+          case Some(existingRecord) =>
+            if (!existingRecord.ingestDate.isBefore(ingestDate)) {
+              throw new RuntimeException(
+                s"Already assigned a version for a newer ingest: ${existingRecord.ingestDate} > $ingestDate"
+              )
+            }
+            existingRecord.version + 1
           case None                 => 1
         }
 

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/VersionManager.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/VersionManager.scala
@@ -1,15 +1,42 @@
 package uk.ac.wellcome.platform.storage.bagauditor.services
 import java.time.Instant
 
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+import com.gu.scanamo.{Scanamo, Table}
 import uk.ac.wellcome.platform.archive.common.IngestID
 import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
+import uk.ac.wellcome.storage.dynamo._
 
 import scala.concurrent.Future
 
-class VersionManager {
+case class BagVersion(
+  ingestId: IngestID,
+  ingestDate: Instant,
+  externalIdentifier: ExternalIdentifier,
+  version: Int
+)
+
+class VersionManager(
+  dynamoClient: AmazonDynamoDB,
+  dynamoConfig: DynamoConfig
+) {
+
+  val table: Table[BagVersion] = Table[BagVersion](dynamoConfig.table)
+
   def assignVersion(
     ingestId: IngestID,
     ingestDate: Instant,
     externalIdentifier: ExternalIdentifier
-  ): Future[Int] = Future.successful(1)
+  ): Future[Int] = {
+    val bagVersion = BagVersion(
+      ingestId = ingestId,
+      ingestDate = ingestDate,
+      externalIdentifier = externalIdentifier,
+      version = 1
+    )
+
+    Scanamo.exec(dynamoClient)(table.put(bagVersion))
+
+    Future.successful(1)
+  }
 }

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/VersionManager.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/VersionManager.scala
@@ -1,0 +1,15 @@
+package uk.ac.wellcome.platform.storage.bagauditor.services
+import java.time.Instant
+
+import uk.ac.wellcome.platform.archive.common.IngestID
+import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
+
+import scala.concurrent.Future
+
+class VersionManager {
+  def assignVersion(
+    ingestId: IngestID,
+    ingestDate: Instant,
+    externalIdentifier: ExternalIdentifier
+  ): Future[Int] = Future.successful(1)
+}

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/services/VersionManagerTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/services/VersionManagerTest.scala
@@ -2,30 +2,120 @@ package uk.ac.wellcome.platform.storage.bagauditor.services
 
 import java.time.Instant
 
+import com.amazonaws.services.dynamodbv2.model._
+import com.amazonaws.services.dynamodbv2.util.TableUtils.waitUntilActive
+import com.gu.scanamo.Scanamo
+import com.gu.scanamo.error.DynamoReadError
+import com.gu.scanamo.syntax._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.platform.archive.common.IngestID
+import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
 import uk.ac.wellcome.platform.archive.common.generators.ExternalIdentifierGenerators
+import uk.ac.wellcome.storage.dynamo._
+import uk.ac.wellcome.storage.fixtures.LocalDynamoDb
+import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
 
-trait VersionManagerFixtures {
-  def withVersionManager[R](testWith: TestWith[VersionManager, R]): R = {
+case class BagVersion(
+  ingestId: IngestID,
+  ingestDate: Instant,
+  externalIdentifier: ExternalIdentifier,
+  version: Int
+)
+
+trait VersionManagerFixtures extends LocalDynamoDb {
+  def withVersionManager[R](table: Table)(testWith: TestWith[VersionManager, R]): R = {
     val versionManager = new VersionManager()
 
     testWith(versionManager)
+  }
+
+  def createTable(table: Table): Table = {
+    dynamoDbClient.createTable(
+      new CreateTableRequest()
+        .withTableName(table.name)
+        .withKeySchema(new KeySchemaElement()
+          .withAttributeName("externalIdentifier")
+          .withKeyType(KeyType.HASH)
+        )
+        .withKeySchema(new KeySchemaElement()
+          .withAttributeName("version")
+          .withKeyType(KeyType.RANGE)
+        )
+        .withAttributeDefinitions(
+          new AttributeDefinition()
+            .withAttributeName("externalIdentifier")
+            .withAttributeType("S"),
+          new AttributeDefinition()
+            .withAttributeName("version")
+            .withAttributeType("N")
+        )
+        .withProvisionedThroughput(new ProvisionedThroughput()
+          .withReadCapacityUnits(1L)
+          .withWriteCapacityUnits(1L)
+        )
+    )
+
+    eventually {
+      waitUntilActive(dynamoDbClient, table.name)
+    }
+
+    table
+  }
+
+  def assertTableHasBagVersion(table: Table, bagVersion: BagVersion): Assertion = {
+    val result: Option[Either[DynamoReadError, BagVersion]] =
+      Scanamo.get[BagVersion](dynamoDbClient)(table.name)(
+        'externalIdentifier -> bagVersion.externalIdentifier and
+        'version -> bagVersion.version)
+
+    result.get.right.get shouldBe bagVersion
   }
 }
 
 class VersionManagerTest extends FunSpec with Matchers with ScalaFutures with ExternalIdentifierGenerators with VersionManagerFixtures {
   it("assigns v1 for an external ID/ingest ID it's never seen before") {
-    withVersionManager { versionManager =>
-      val future = versionManager.assignVersion(
-        ingestId = createIngestID,
-        ingestDate = Instant.now(),
-        externalIdentifier = createExternalIdentifier
-      )
+    withLocalDynamoDbTable { versionTable =>
+      withVersionManager(versionTable) { versionManager =>
+        val future = versionManager.assignVersion(
+          ingestId = createIngestID,
+          ingestDate = Instant.now(),
+          externalIdentifier = createExternalIdentifier
+        )
 
-      whenReady(future) { version =>
-        version shouldBe 1
+        whenReady(future) { version =>
+          version shouldBe 1
+        }
+      }
+    }
+  }
+
+  it("records a version in DynamoDB") {
+    withLocalDynamoDbTable { versionTable =>
+      withVersionManager(versionTable) { versionManager =>
+        val ingestId = createIngestID
+        val ingestDate = Instant.now()
+        val externalIdentifier = createExternalIdentifier
+
+        assertTableEmpty[BagVersion](versionTable)
+
+        val future = versionManager.assignVersion(
+          ingestId = ingestId,
+          ingestDate = ingestDate,
+          externalIdentifier = externalIdentifier
+        )
+
+        whenReady(future) { version =>
+          val expectedBagVersion = BagVersion(
+            ingestId = ingestId,
+            ingestDate = ingestDate,
+            externalIdentifier = externalIdentifier,
+            version = 1
+          )
+
+          assertTableHasBagVersion(versionTable, expectedBagVersion)
+        }
       }
     }
   }

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/services/VersionManagerTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/services/VersionManagerTest.scala
@@ -10,23 +10,17 @@ import com.gu.scanamo.syntax._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.archive.common.IngestID
-import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
 import uk.ac.wellcome.platform.archive.common.generators.ExternalIdentifierGenerators
 import uk.ac.wellcome.storage.dynamo._
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDb
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
 
-case class BagVersion(
-  ingestId: IngestID,
-  ingestDate: Instant,
-  externalIdentifier: ExternalIdentifier,
-  version: Int
-)
-
 trait VersionManagerFixtures extends LocalDynamoDb {
   def withVersionManager[R](table: Table)(testWith: TestWith[VersionManager, R]): R = {
-    val versionManager = new VersionManager()
+    val versionManager = new VersionManager(
+      dynamoClient = dynamoDbClient,
+      dynamoConfig = createDynamoConfigWith(table)
+    )
 
     testWith(versionManager)
   }

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/services/VersionManagerTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/services/VersionManagerTest.scala
@@ -1,0 +1,32 @@
+package uk.ac.wellcome.platform.storage.bagauditor.services
+
+import java.time.Instant
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.platform.archive.common.generators.ExternalIdentifierGenerators
+
+trait VersionManagerFixtures {
+  def withVersionManager[R](testWith: TestWith[VersionManager, R]): R = {
+    val versionManager = new VersionManager()
+
+    testWith(versionManager)
+  }
+}
+
+class VersionManagerTest extends FunSpec with Matchers with ScalaFutures with ExternalIdentifierGenerators with VersionManagerFixtures {
+  it("assigns v1 for an external ID/ingest ID it's never seen before") {
+    withVersionManager { versionManager =>
+      val future = versionManager.assignVersion(
+        ingestId = createIngestID,
+        ingestDate = Instant.now(),
+        externalIdentifier = createExternalIdentifier
+      )
+
+      whenReady(future) { version =>
+        version shouldBe 1
+      }
+    }
+  }
+}


### PR DESCRIPTION
A late-night look at what some of that logic might look like. Definitely not ready to go!

Still to do:

- [ ] More validation if we find an existing record with the same ingest ID. If it doesn’t match on ingest date either, we should reject it.
- [ ] Locking!
- [ ] Tests for error handling when DynamoDB is full of junk/has an error/table doesn't exist