### PR TITLE
Handle the case where a fetch.txt isn't correctly formatted

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/parsers/FetchContents.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/parsers/FetchContents.scala
@@ -57,7 +57,6 @@ object FetchContents {
             )
         }
 
-
       }
   }
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/parsers/FetchContents.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/parsers/FetchContents.scala
@@ -5,6 +5,7 @@ import java.net.URI
 
 import uk.ac.wellcome.platform.archive.common.bagit.models.FetchEntry
 
+import scala.util.Try
 import scala.util.matching.Regex
 
 /** Read/write the contents of a Fetch File as defined by RFC 8493 § 2.2.3.
@@ -31,7 +32,7 @@ object FetchContents {
     "filepath"
   )
 
-  def read(is: InputStream): Seq[FetchEntry] = {
+  def read(is: InputStream): Try[Seq[FetchEntry]] = Try {
     val bufferedReader = new BufferedReader(new InputStreamReader(is))
 
     Iterator


### PR DESCRIPTION
In #198 we'd quite happily let such a fetch.txt through, which is obviously wrong. This throws an exception instead.