### PR TITLE
Use a URL, not a URI, for FetchEntry

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/FetchEntry.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/FetchEntry.scala
@@ -1,9 +1,9 @@
 package uk.ac.wellcome.platform.archive.common.bagit.models
 
-import java.net.URI
+import java.net.URL
 
 case class FetchEntry(
-  url: URI,
+  url: URL,
   length: Option[Int],
   filepath: String
 )

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/parsers/FetchContents.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/parsers/FetchContents.scala
@@ -47,7 +47,7 @@ object FetchContents {
         FETCH_LINE_REGEX.findFirstMatchIn(line) match {
           case Some(m) =>
             FetchEntry(
-              url = new URL(m.group("url")),
+              url = decodeURL(m.group("url")),
               length = decodeLength(m.group("length")),
               filepath = decodeFilepath(m.group("filepath"))
             )
@@ -63,9 +63,15 @@ object FetchContents {
   def write(entries: Seq[FetchEntry]): String =
     entries
       .map { e =>
-        s"${e.url} ${encodeLength(e.length)} ${encodeFilepath(e.filepath)}"
+        s"${encodeURL(e.url)} ${encodeLength(e.length)} ${encodeFilepath(e.filepath)}"
       }
       .mkString("\n")
+
+  private def encodeURL(url: URL): String =
+    url.toString.replaceAll(" ", "%20").replaceAll("\t", "%09")
+
+  private def decodeURL(url: String): URL =
+    new URL(url.replaceAll("%20", " ").replaceAll("%09", "\t"))
 
   private def encodeLength(length: Option[Int]): String =
     length match {

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/parsers/FetchContents.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/parsers/FetchContents.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.archive.common.bagit.parsers
 
 import java.io.{BufferedReader, InputStream, InputStreamReader}
-import java.net.URI
+import java.net.URL
 
 import uk.ac.wellcome.platform.archive.common.bagit.models.FetchEntry
 
@@ -47,7 +47,7 @@ object FetchContents {
         FETCH_LINE_REGEX.findFirstMatchIn(line) match {
           case Some(m) =>
             FetchEntry(
-              url = new URI(m.group("url")),
+              url = new URL(m.group("url")),
               length = decodeLength(m.group("length")),
               filepath = decodeFilepath(m.group("filepath"))
             )

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/parsers/FetchContentsTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/parsers/FetchContentsTest.scala
@@ -64,13 +64,15 @@ class FetchContentsTest extends FunSpec with Matchers {
     }
 
     it("percent encodes whitespace characters in the URL") {
-      val entries = Seq("http://example.org/x y z", "http://example.org/a\tb\tc").map { url =>
-        FetchEntry(
-          url = new URL(url),
-          length = None,
-          filepath = "example.txt"
-        )
-      }
+      val entries =
+        Seq("http://example.org/x y z", "http://example.org/a\tb\tc").map {
+          url =>
+            FetchEntry(
+              url = new URL(url),
+              length = None,
+              filepath = "example.txt"
+            )
+        }
 
       val expected =
         s"""
@@ -139,8 +141,7 @@ class FetchContentsTest extends FunSpec with Matchers {
     }
 
     it("decodes a percent-encoded whitespace character in the URL") {
-      val contents = toInputStream(
-        s"""
+      val contents = toInputStream(s"""
            |http://example.org/x%20y%20z - example.txt
            |http://example.org/a%09b%09c - example.txt
        """.stripMargin)

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/parsers/FetchContentsTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/parsers/FetchContentsTest.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.archive.common.bagit.parsers
 
 import java.io.InputStream
-import java.net.URI
+import java.net.URL
 
 import org.apache.commons.io.IOUtils
 import org.scalatest.{FunSpec, Matchers}
@@ -13,11 +13,11 @@ class FetchContentsTest extends FunSpec with Matchers {
     it("writes the lines of a fetch.txt") {
       val entries = Seq(
         FetchEntry(
-          url = new URI("http://example.org/"),
+          url = new URL("http://example.org/"),
           length = Some(25),
           filepath = "example.txt"),
         FetchEntry(
-          url = new URI("https://wellcome.ac.uk/"),
+          url = new URL("https://wellcome.ac.uk/"),
           length = None,
           filepath = "logo.png")
       )
@@ -37,18 +37,18 @@ class FetchContentsTest extends FunSpec with Matchers {
         "example\nnumber\n2.txt",
         "example\r\nnumber\r\n3.txt").map { filepath =>
         FetchEntry(
-          url = new URI("http://example.org/"),
+          url = new URL("http://example.org/"),
           length = None,
           filepath = filepath)
       }
 
       Seq(
         FetchEntry(
-          url = new URI("http://example.org/"),
+          url = new URL("http://example.org/"),
           length = None,
           filepath = "example.txt"),
         FetchEntry(
-          url = new URI("https://wellcome.ac.uk/"),
+          url = new URL("https://wellcome.ac.uk/"),
           length = None,
           filepath = "logo.png")
       )
@@ -73,11 +73,11 @@ class FetchContentsTest extends FunSpec with Matchers {
 
       val expected = Seq(
         FetchEntry(
-          url = new URI("http://example.org/"),
+          url = new URL("http://example.org/"),
           length = Some(25),
           filepath = "example.txt"),
         FetchEntry(
-          url = new URI("https://wellcome.ac.uk/"),
+          url = new URL("https://wellcome.ac.uk/"),
           length = None,
           filepath = "logo.png")
       )
@@ -94,11 +94,11 @@ class FetchContentsTest extends FunSpec with Matchers {
 
       val expected = Seq(
         FetchEntry(
-          url = new URI("http://example.org/"),
+          url = new URL("http://example.org/"),
           length = Some(25),
           filepath = "example.txt"),
         FetchEntry(
-          url = new URI("https://wellcome.ac.uk/"),
+          url = new URL("https://wellcome.ac.uk/"),
           length = None,
           filepath = "logo.png")
       )


### PR DESCRIPTION
This matches the spec slightly better, and lets me add tests/handling code for percent encoding of whitespace in URLs.