### PR TITLE
Send more information about the audit results

### DIFF
--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/Main.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/Main.scala
@@ -43,7 +43,7 @@ object Main extends WellcomeTypesafeApp {
       SQSBuilder.buildSQSAsyncClient(config)
 
     val operationName = OperationNameBuilder
-      .getName(config, default = "locating bag root")
+      .getName(config, default = "auditing bag")
 
     new BagAuditorWorker(
       alpakkaSQSWorkerConfig = AlpakkaSqsWorkerConfigBuilder.build(config),

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/BetterAudit.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/BetterAudit.scala
@@ -1,0 +1,14 @@
+package uk.ac.wellcome.platform.storage.bagauditor.models
+
+import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
+import uk.ac.wellcome.storage.ObjectLocation
+
+sealed trait BetterAudit
+
+case class AuditSuccess(
+  root: ObjectLocation,
+  externalIdentifier: ExternalIdentifier,
+  version: Int
+) extends BetterAudit
+
+case class AuditFailure(e: Throwable) extends BetterAudit

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/BetterAuditSummary.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/BetterAuditSummary.scala
@@ -1,0 +1,74 @@
+package uk.ac.wellcome.platform.storage.bagauditor.models
+
+import java.time.Instant
+
+import uk.ac.wellcome.platform.archive.common.operation.models.Summary
+import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
+import uk.ac.wellcome.storage.ObjectLocation
+
+sealed trait BetterAuditSummary extends Summary {
+  val location: ObjectLocation
+  val space: StorageSpace
+  val startTime: Instant
+}
+
+case class AuditIncompleteSummary(
+  location: ObjectLocation,
+  space: StorageSpace,
+  e: Throwable,
+  startTime: Instant,
+  endTime: Option[Instant] = None
+) extends BetterAuditSummary
+
+case class AuditFailureSummary(
+  location: ObjectLocation,
+  space: StorageSpace,
+  startTime: Instant,
+  endTime: Option[Instant]
+) extends BetterAuditSummary
+
+case class AuditSuccessSummary(
+  location: ObjectLocation,
+  space: StorageSpace,
+  startTime: Instant,
+  audit: AuditSuccess,
+  endTime: Option[Instant]
+) extends BetterAuditSummary
+
+case object BetterAuditSummary {
+  def incomplete(
+    location: ObjectLocation,
+    space: StorageSpace,
+    e: Throwable,
+    t: Instant): AuditIncompleteSummary =
+    AuditIncompleteSummary(
+      location = location,
+      space = space,
+      e = e,
+      startTime = t,
+      endTime = None
+    )
+
+  def create(
+    location: ObjectLocation,
+    space: StorageSpace,
+    audit: BetterAudit,
+    t: Instant
+  ): BetterAuditSummary = audit match {
+    case f @ AuditFailure(e) =>
+      AuditFailureSummary(
+        location = location,
+        space = space,
+        startTime = t,
+        endTime = Some(Instant.now())
+      )
+    case s @ AuditSuccess(_, _, _) =>
+      AuditSuccessSummary(
+        location = location,
+        space = space,
+        startTime = t,
+        audit = s,
+        endTime = Some(Instant.now())
+      )
+  }
+}

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/BetterAuditSummary.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/BetterAuditSummary.scala
@@ -36,11 +36,10 @@ case class AuditSuccessSummary(
 ) extends BetterAuditSummary
 
 case object BetterAuditSummary {
-  def incomplete(
-    location: ObjectLocation,
-    space: StorageSpace,
-    e: Throwable,
-    t: Instant): AuditIncompleteSummary =
+  def incomplete(location: ObjectLocation,
+                 space: StorageSpace,
+                 e: Throwable,
+                 t: Instant): AuditIncompleteSummary =
     AuditIncompleteSummary(
       location = location,
       space = space,

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
@@ -4,7 +4,6 @@ import java.io.InputStream
 import java.time.Instant
 
 import com.amazonaws.services.s3.AmazonS3
-import uk.ac.wellcome.platform.archive.common.ConvertibleToInputStream._
 import uk.ac.wellcome.platform.archive.common.bagit.models.{
   BagInfo,
   ExternalIdentifier
@@ -17,67 +16,79 @@ import uk.ac.wellcome.platform.archive.common.storage.models.{
   StorageSpace
 }
 import uk.ac.wellcome.platform.archive.common.storage.services.S3BagLocator
-import uk.ac.wellcome.platform.storage.bagauditor.models.{
-  AuditInformation,
-  AuditSummary
-}
+import uk.ac.wellcome.platform.storage.bagauditor.models._
 import uk.ac.wellcome.storage.ObjectLocation
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
 
-class BagAuditor(implicit s3Client: AmazonS3, ec: ExecutionContext) {
+class BagAuditor(implicit s3Client: AmazonS3) {
   val s3BagLocator = new S3BagLocator(s3Client)
 
   def getAuditSummary(
     unpackLocation: ObjectLocation,
-    storageSpace: StorageSpace): Future[IngestStepResult[AuditSummary]] = {
-    val auditSummary = AuditSummary(
-      startTime = Instant.now(),
-      unpackLocation = unpackLocation,
-      storageSpace = storageSpace
-    )
+    storageSpace: StorageSpace): Try[IngestStepResult[BetterAuditSummary]] = Try {
 
-    val auditInformation = for {
-      bagRootLocation <- Future.fromTry {
-        s3BagLocator.locateBagRoot(unpackLocation)
-      }
-      externalIdentifier <- getBagIdentifier(bagRootLocation)
+    val startTime = Instant.now()
+
+    val auditTry: Try[AuditSuccess] = for {
+      root <- s3BagLocator.locateBagRoot(unpackLocation)
+      externalIdentifier <- getBagIdentifier(root)
       version <- chooseVersion(externalIdentifier)
-      info = AuditInformation(
-        bagRootLocation = bagRootLocation,
+      auditSuccess = AuditSuccess(
+        root = root,
         externalIdentifier = externalIdentifier,
         version = version
       )
-    } yield info
+    } yield auditSuccess
 
-    auditInformation
-      .map { info =>
+    auditTry recover {
+      case e => AuditFailure(e)
+    } match {
+      case Success(audit @ AuditSuccess(_, _, _)) =>
         IngestStepSucceeded(
-          auditSummary
-            .copy(maybeAuditInformation = Some(info))
-            .complete
-        )
-      }
-      .recover {
-        case t: Throwable =>
-          IngestFailed(
-            auditSummary.complete,
-            t
+          BetterAuditSummary.create(
+            location = unpackLocation,
+            space = storageSpace,
+            audit = audit,
+            t = startTime
           )
-      }
+        )
+      case Success(audit @ AuditFailure(e)) =>
+        IngestFailed(
+          summary = BetterAuditSummary.create(
+            location = unpackLocation,
+            space = storageSpace,
+            audit = audit,
+            t = startTime
+          ),
+          e
+        )
+      case Failure(e) =>
+        IngestFailed(
+          summary = BetterAuditSummary.incomplete(
+            location = unpackLocation,
+            space = storageSpace,
+            e = e,
+            t = startTime
+          ),
+          e
+        )
+    }
   }
 
   private def chooseVersion(
-    externalIdentifier: ExternalIdentifier): Future[Int] =
-    Future.successful(1)
+    externalIdentifier: ExternalIdentifier): Try[Int] =
+    Success(1)
 
   private def getBagIdentifier(
-    bagRootLocation: ObjectLocation): Future[ExternalIdentifier] =
+    bagRootLocation: ObjectLocation): Try[ExternalIdentifier] =
     for {
-      bagInfoLocation <- Future.fromTry {
-        s3BagLocator.locateBagInfo(bagRootLocation)
+      bagInfoLocation <- s3BagLocator.locateBagInfo(bagRootLocation)
+      inputStream: InputStream <- Try {
+        s3Client
+          .getObject(bagInfoLocation.namespace, bagInfoLocation.key)
+          .getObjectContent
       }
-      inputStream: InputStream <- bagInfoLocation.toInputStream
       bagInfo: BagInfo <- BagInfoParser.create(inputStream)
     } yield bagInfo.externalIdentifier
 }

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
@@ -43,7 +43,8 @@ class BagAuditorWorker(
     with Logging
     with IngestStepWorker {
   private val worker =
-    AlpakkaSQSWorker[UnpackedBagPayload, BetterAuditSummary](alpakkaSQSWorkerConfig) {
+    AlpakkaSQSWorker[UnpackedBagPayload, BetterAuditSummary](
+      alpakkaSQSWorkerConfig) {
       processMessage
     }
 

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
@@ -16,8 +16,15 @@ import uk.ac.wellcome.platform.archive.common.{
 }
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services._
-import uk.ac.wellcome.platform.archive.common.storage.models.IngestStepWorker
-import uk.ac.wellcome.platform.storage.bagauditor.models.AuditSummary
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  IngestStepResult,
+  IngestStepSucceeded,
+  IngestStepWorker
+}
+import uk.ac.wellcome.platform.storage.bagauditor.models.{
+  AuditSuccessSummary,
+  BetterAuditSummary
+}
 import uk.ac.wellcome.typesafe.Runnable
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -36,34 +43,42 @@ class BagAuditorWorker(
     with Logging
     with IngestStepWorker {
   private val worker =
-    AlpakkaSQSWorker[UnpackedBagPayload, AuditSummary](alpakkaSQSWorkerConfig) {
+    AlpakkaSQSWorker[UnpackedBagPayload, BetterAuditSummary](alpakkaSQSWorkerConfig) {
       processMessage
     }
 
   def processMessage(
-    payload: UnpackedBagPayload): Future[Result[AuditSummary]] =
+    payload: UnpackedBagPayload): Future[Result[BetterAuditSummary]] =
     for {
       _ <- ingestUpdater.start(ingestId = payload.ingestId)
 
-      auditSummary <- bagAuditor.getAuditSummary(
-        unpackLocation = payload.unpackedBagLocation,
-        storageSpace = payload.storageSpace
-      )
-
-      _ <- ingestUpdater.send(payload.ingestId, auditSummary)
-      _ <- outgoingPublisher.sendIfSuccessful(
-        auditSummary,
-        BagInformationPayload(
-          ingestId = payload.ingestId,
-          storageSpace = payload.storageSpace,
-          bagRootLocation =
-            auditSummary.summary.auditInformation.bagRootLocation,
-          externalIdentifier =
-            auditSummary.summary.auditInformation.externalIdentifier,
-          version = auditSummary.summary.auditInformation.version
+      auditStep <- Future.fromTry {
+        bagAuditor.getAuditSummary(
+          unpackLocation = payload.unpackedBagLocation,
+          storageSpace = payload.storageSpace
         )
-      )
-    } yield toResult(auditSummary)
+      }
+
+      _ <- ingestUpdater.send(payload.ingestId, auditStep)
+      _ <- sendSuccessful(payload)(auditStep)
+    } yield toResult(auditStep)
+
+  private def sendSuccessful(payload: UnpackedBagPayload)(
+    step: IngestStepResult[BetterAuditSummary]): Future[Unit] =
+    step match {
+      case IngestStepSucceeded(summary: AuditSuccessSummary) =>
+        outgoingPublisher.sendIfSuccessful(
+          step,
+          BagInformationPayload(
+            ingestId = payload.ingestId,
+            storageSpace = payload.storageSpace,
+            bagRootLocation = summary.audit.root,
+            externalIdentifier = summary.audit.externalIdentifier,
+            version = summary.audit.version
+          )
+        )
+      case _ => Future.successful(())
+    }
 
   override def run(): Future[Any] = worker.start
 }

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
@@ -48,8 +48,11 @@ class BagAuditorFeatureTest
                       payload.ingestId,
                       ingestTopic,
                       expectedDescriptions = Seq(
-                        "Locating bag root started",
-                        "Locating bag root succeeded"
+                        "Auditing bag started",
+                        s"Detected bag root as $bagRootLocation",
+                        s"Detected bag identifier as ${bagInfo.externalIdentifier}",
+                        s"Assigned bag version 1",
+                        "Auditing bag succeeded"
                       )
                     )
                   }
@@ -66,7 +69,7 @@ class BagAuditorFeatureTest
       val bagInfo = createBagInfo
       withBag(bucket, bagInfo = bagInfo, bagRootDirectory = Some("subdir")) {
         case (unpackedBagLocation, storageSpace) =>
-          val bagRoot = unpackedBagLocation.join("subdir")
+          val bagRootLocation = unpackedBagLocation.join("subdir")
 
           val payload = createUnpackedBagPayloadWith(
             unpackedBagLocation = unpackedBagLocation,
@@ -75,7 +78,7 @@ class BagAuditorFeatureTest
 
           val expectedPayload = createBagInformationPayloadWith(
             ingestId = payload.ingestId,
-            bagRootLocation = bagRoot,
+            bagRootLocation = bagRootLocation,
             storageSpace = storageSpace,
             externalIdentifier = bagInfo.externalIdentifier
           )
@@ -95,8 +98,11 @@ class BagAuditorFeatureTest
                       payload.ingestId,
                       ingestTopic,
                       expectedDescriptions = Seq(
-                        "Locating bag root started",
-                        "Locating bag root succeeded"
+                        "Auditing bag started",
+                        s"Detected bag root as $bagRootLocation",
+                        s"Detected bag identifier as ${bagInfo.externalIdentifier}",
+                        s"Assigned bag version 1",
+                        "Auditing bag succeeded"
                       )
                     )
                   }
@@ -131,12 +137,12 @@ class BagAuditorFeatureTest
                       ingestUpdates.size shouldBe 2
 
                       val ingestStart = ingestUpdates.head
-                      ingestStart.events.head.description shouldBe "Locating bag root started"
+                      ingestStart.events.head.description shouldBe "Auditing bag started"
 
                       val ingestFailed =
                         ingestUpdates.tail.head.asInstanceOf[IngestStatusUpdate]
                       ingestFailed.status shouldBe Ingest.Failed
-                      ingestFailed.events.head.description shouldBe "Locating bag root failed"
+                      ingestFailed.events.head.description shouldBe "Auditing bag failed"
                     }
                   }
                 }
@@ -168,12 +174,12 @@ class BagAuditorFeatureTest
                     ingestUpdates.size shouldBe 2
 
                     val ingestStart = ingestUpdates.head
-                    ingestStart.events.head.description shouldBe "Locating bag root started"
+                    ingestStart.events.head.description shouldBe "Auditing bag started"
 
                     val ingestFailed =
                       ingestUpdates.tail.head.asInstanceOf[IngestStatusUpdate]
                     ingestFailed.status shouldBe Ingest.Failed
-                    ingestFailed.events.head.description shouldBe "Locating bag root failed"
+                    ingestFailed.events.head.description shouldBe "Auditing bag failed"
                 }
               }
             }
@@ -203,12 +209,12 @@ class BagAuditorFeatureTest
                   ingestUpdates.size shouldBe 2
 
                   val ingestStart = ingestUpdates.head
-                  ingestStart.events.head.description shouldBe "Locating bag root started"
+                  ingestStart.events.head.description shouldBe "Auditing bag started"
 
                   val ingestFailed =
                     ingestUpdates.tail.head.asInstanceOf[IngestStatusUpdate]
                   ingestFailed.status shouldBe Ingest.Failed
-                  ingestFailed.events.head.description shouldBe "Locating bag root failed"
+                  ingestFailed.events.head.description shouldBe "Auditing bag failed"
               }
             }
           }

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/fixtures/BagAuditorFixtures.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/fixtures/BagAuditorFixtures.scala
@@ -37,8 +37,8 @@ trait BagAuditorFixtures
     outgoingTopic: Topic
   )(testWith: TestWith[BagAuditorWorker, R]): R =
     withActorSystem { implicit actorSystem =>
-      withIngestUpdater("locating bag root", ingestTopic) { ingestUpdater =>
-        withOutgoingPublisher("locating bag root", outgoingTopic) {
+      withIngestUpdater("auditing bag", ingestTopic) { ingestUpdater =>
+        withOutgoingPublisher("auditing bag", outgoingTopic) {
           outgoingPublisher =>
             withMonitoringClient { implicit monitoringClient =>
               val worker = new BagAuditorWorker(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/parsers/BagInfoParser.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/parsers/BagInfoParser.scala
@@ -12,7 +12,6 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.error.{
   InvalidBagInfo
 }
 
-import scala.concurrent.Future
 import scala.util.Try
 
 object BagInfoKeys {
@@ -30,13 +29,10 @@ object BagInfoParser {
   private val payloadOxumRegex =
     s"""${BagInfoKeys.payloadOxum}\\s*:\\s*([0-9]+)\\.([0-9]+)\\s*""".r
 
-  def create(inputStream: InputStream): Future[BagInfo] = {
-    Future.fromTry(
-      validate(inputStream).toEither.left
-        .map(e => new RuntimeException(e.toString))
-        .toTry
-    )
-  }
+  def create(inputStream: InputStream): Try[BagInfo] =
+    validate(inputStream).toEither.left
+      .map(e => new RuntimeException(e.toString))
+      .toTry
 
   private def validate(inputStream: InputStream) = {
     val bagInfoLines = scala.io.Source

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/config/builders/IngestUpdaterBuilder.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/config/builders/IngestUpdaterBuilder.scala
@@ -4,8 +4,10 @@ import com.typesafe.config.Config
 import uk.ac.wellcome.messaging.typesafe.SNSBuilder
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 
+import scala.concurrent.ExecutionContext
+
 object IngestUpdaterBuilder {
-  def build(config: Config, operationName: String): IngestUpdater =
+  def build(config: Config, operationName: String)(implicit ec: ExecutionContext): IngestUpdater =
     new IngestUpdater(
       stepName = operationName,
       snsWriter = SNSBuilder.buildSNSWriter(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/config/builders/IngestUpdaterBuilder.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/config/builders/IngestUpdaterBuilder.scala
@@ -7,7 +7,8 @@ import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import scala.concurrent.ExecutionContext
 
 object IngestUpdaterBuilder {
-  def build(config: Config, operationName: String)(implicit ec: ExecutionContext): IngestUpdater =
+  def build(config: Config, operationName: String)(
+    implicit ec: ExecutionContext): IngestUpdater =
     new IngestUpdater(
       stepName = operationName,
       snsWriter = SNSBuilder.buildSNSWriter(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdater.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdater.scala
@@ -13,7 +13,8 @@ import scala.concurrent.{ExecutionContext, Future}
 class IngestUpdater(
   stepName: String,
   snsWriter: SNSWriter
-)(implicit ec: ExecutionContext) extends Logging {
+)(implicit ec: ExecutionContext)
+    extends Logging {
 
   def start(ingestId: IngestID): Future[Unit] =
     send(
@@ -64,26 +65,38 @@ class IngestUpdater(
         )
     }
 
-    snsWriter.writeMessage[IngestUpdate](
-      update,
-      subject = s"Sent by ${this.getClass.getSimpleName}"
-    ).map { _ => () }
+    snsWriter
+      .writeMessage[IngestUpdate](
+        update,
+        subject = s"Sent by ${this.getClass.getSimpleName}"
+      )
+      .map { _ =>
+        ()
+      }
   }
 
   def sendEvent(ingestId: IngestID, messages: Seq[String]): Future[Unit] = {
     val update: IngestUpdate = IngestEventUpdate(
       id = ingestId,
-      events = messages.map { m: String => IngestEvent(eventDescription(m)) }
+      events = messages.map { m: String =>
+        IngestEvent(eventDescription(m))
+      }
     )
 
-    snsWriter.writeMessage[IngestUpdate](
-      update, subject = s"Sent by ${this.getClass.getSimpleName}"
-    ).map { _ => () }
+    snsWriter
+      .writeMessage[IngestUpdate](
+        update,
+        subject = s"Sent by ${this.getClass.getSimpleName}"
+      )
+      .map { _ =>
+        ()
+      }
   }
 
   val descriptionMaxLength = 250
-  private def eventDescription(main: String,
-                               maybeInformation: Option[String] = None): String = {
+  private def eventDescription(
+    main: String,
+    maybeInformation: Option[String] = None): String = {
     val separator: String = " - "
     truncate(
       Seq(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdater.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdater.scala
@@ -73,7 +73,7 @@ class IngestUpdater(
   def sendEvent(ingestId: IngestID, messages: Seq[String]): Future[Unit] = {
     val update: IngestUpdate = IngestEventUpdate(
       id = ingestId,
-      events = messages.map { IngestEvent(_) }
+      events = messages.map { m: String => IngestEvent(eventDescription(m)) }
     )
 
     snsWriter.writeMessage[IngestUpdate](
@@ -83,7 +83,7 @@ class IngestUpdater(
 
   val descriptionMaxLength = 250
   private def eventDescription(main: String,
-                               maybeInformation: Option[String]): String = {
+                               maybeInformation: Option[String] = None): String = {
     val separator: String = " - "
     truncate(
       Seq(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdater.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdater.scala
@@ -5,12 +5,7 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.SNSWriter
 import uk.ac.wellcome.platform.archive.common.IngestID
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  Ingest,
-  IngestEvent,
-  IngestStatusUpdate,
-  IngestUpdate
-}
+import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models._
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -72,6 +67,17 @@ class IngestUpdater(
     snsWriter.writeMessage[IngestUpdate](
       update,
       subject = s"Sent by ${this.getClass.getSimpleName}"
+    ).map { _ => () }
+  }
+
+  def sendEvent(ingestId: IngestID, messages: Seq[String]): Future[Unit] = {
+    val update: IngestUpdate = IngestEventUpdate(
+      id = ingestId,
+      events = messages.map { IngestEvent(_) }
+    )
+
+    snsWriter.writeMessage[IngestUpdate](
+      update, subject = s"Sent by ${this.getClass.getSimpleName}"
     ).map { _ => () }
   }
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
@@ -62,9 +62,11 @@ class StorageManifestService(
         .toObjectLocation(bagRootLocation)
         .toInputStream
 
-      bagInfo <- BagInfoParser.create(
-        bagInfoInputStream
-      )
+      bagInfo <- Future.fromTry {
+        BagInfoParser.create(
+          bagInfoInputStream
+        )
+      }
     } yield bagInfo
 
   def createFileManifest(

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/OperationFixtures.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/OperationFixtures.scala
@@ -7,6 +7,8 @@ import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services.OutgoingPublisher
 
+import scala.concurrent.ExecutionContext.Implicits.global
+
 trait OperationFixtures extends SNS with MetricsSenderFixture {
   def withIngestUpdater[R](stepName: String, topic: Topic)(
     testWith: TestWith[IngestUpdater, R]): R =


### PR DESCRIPTION
A standalone piece spun out of #205 to make it smaller and so easier to review, and I took the models from #204 to avoid icky merge conflicts later.

You now get the following messages from the auditor:

```json
    {
      "createdDate": "2019-05-15T16:26:47.885084Z",
      "description": "Auditing bag started",
      "type": "IngestEvent"
    },
    {
      "createdDate": "2019-05-15T16:26:48.823683Z",
      "description": "Detected bag root as wellcomecollection-storage-staging-ingests/unpacked/alex-testing/6ddaad8a-03ff-4cab-af67-e758a214ae5f",
      "type": "IngestEvent"
    },
    {
      "createdDate": "2019-05-15T16:26:48.823692Z",
      "description": "Detected bag identifier as b1000290x",
      "type": "IngestEvent"
    },
    {
      "createdDate": "2019-05-15T16:26:48.823697Z",
      "description": "Assigned bag version 2",
      "type": "IngestEvent"
    },
    {
      "createdDate": "2019-05-15T16:26:48.858095Z",
      "description": "Auditing bag succeeded",
      "type": "IngestEvent"
    },
```