### PR TITLE
Use the new storage/messaging libraries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ SBT_APPS = notifier \
            bag_verifier \
            bag_unpacker \
            bag_auditor
-
+SBT_NO_DOCKER_APPS =
 
 SBT_DOCKER_LIBRARIES    = common ingests_common
 SBT_NO_DOCKER_LIBRARIES = bags_common display

--- a/api/Makefile
+++ b/api/Makefile
@@ -4,8 +4,8 @@ PROJECT_ID = storage
 
 STACK_ROOT 	= api
 
-SBT_APPS = ingests_api
-SBT_NO_DOCKER_APPS = bags_api
+SBT_APPS = 
+SBT_NO_DOCKER_APPS = bags_api ingests_api
 
 
 SBT_DOCKER_LIBRARIES    =

--- a/api/Makefile
+++ b/api/Makefile
@@ -4,7 +4,7 @@ PROJECT_ID = storage
 
 STACK_ROOT 	= api
 
-SBT_APPS = 
+SBT_APPS =
 SBT_NO_DOCKER_APPS = bags_api ingests_api
 
 

--- a/api/Makefile
+++ b/api/Makefile
@@ -4,8 +4,8 @@ PROJECT_ID = storage
 
 STACK_ROOT 	= api
 
-SBT_APPS = ingests_api \
-           bags_api
+SBT_APPS = ingests_api
+SBT_NO_DOCKER_APPS = bags_api
 
 
 SBT_DOCKER_LIBRARIES    =

--- a/api/bags_api/docker-compose.yml
+++ b/api/bags_api/docker-compose.yml
@@ -1,8 +1,0 @@
-dynamodb:
-  image: peopleperhour/dynamodb
-  ports:
-    - "45678:8000"
-s3:
-  image: scality/s3server:mem-latest
-  ports:
-  - "33333:8000"

--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Main.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Main.scala
@@ -26,7 +26,7 @@ object Main extends WellcomeTypesafeApp {
       AkkaBuilder.buildActorMaterializer()
 
     val vhs = new StorageManifestVHS(
-      underlying = VHSBuilder.buildVHS[StorageManifest, EmptyMetadata](config)
+      underlying = VHSBuilder.buildVHS[String, StorageManifest, EmptyMetadata](config)
     )
 
     val httpMetrics = new HttpMetrics(

--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Main.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Main.scala
@@ -27,7 +27,8 @@ object Main extends WellcomeTypesafeApp {
       AkkaBuilder.buildActorMaterializer()
 
     val vhs = new StorageManifestVHS(
-      underlying = VHSBuilder.buildVHS[String, StorageManifest, EmptyMetadata](config)
+      underlying =
+        VHSBuilder.buildVHS[String, StorageManifest, EmptyMetadata](config)
     )
 
     val httpMetrics = new HttpMetrics(

--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Main.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Main.scala
@@ -6,6 +6,7 @@ import com.typesafe.config.Config
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.monitoring.typesafe.MetricsBuilder
 import uk.ac.wellcome.platform.archive.common.config.builders._
+import uk.ac.wellcome.platform.archive.common.dynamo._
 import uk.ac.wellcome.platform.archive.common.http.HttpMetrics
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
 import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestVHS

--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Router.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Router.scala
@@ -16,7 +16,7 @@ import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestVHS
 import uk.ac.wellcome.platform.storage.bags.api.models.DisplayBag
 
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, Future}
 
 class Router(vhs: StorageManifestVHS, contextURL: URL)(
   implicit val ec: ExecutionContext) {
@@ -34,7 +34,7 @@ class Router(vhs: StorageManifestVHS, contextURL: URL)(
         )
 
         get {
-          onSuccess(vhs.getRecord(bagId)) {
+          onSuccess(Future.fromTry { vhs.getRecord(bagId) }) {
             case Some(storageManifest) =>
               complete(DisplayBag(storageManifest, contextURL))
             case None =>

--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Router.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Router.scala
@@ -7,8 +7,14 @@ import akka.http.scaladsl.server.Route
 import grizzled.slf4j.Logging
 import io.circe.Printer
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, ExternalIdentifier}
-import uk.ac.wellcome.platform.archive.common.http.models.{InternalServerErrorResponse, UserErrorResponse}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagId,
+  ExternalIdentifier
+}
+import uk.ac.wellcome.platform.archive.common.http.models.{
+  InternalServerErrorResponse,
+  UserErrorResponse
+}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestVHS
 import uk.ac.wellcome.platform.storage.bags.api.models.DisplayBag
@@ -17,7 +23,8 @@ import scala.concurrent.ExecutionContext
 import scala.util.{Failure, Success}
 
 class Router(vhs: StorageManifestVHS, contextURL: URL)(
-  implicit val ec: ExecutionContext) extends Logging {
+  implicit val ec: ExecutionContext)
+    extends Logging {
 
   def routes: Route = {
     import akka.http.scaladsl.server.Directives._
@@ -48,7 +55,8 @@ class Router(vhs: StorageManifestVHS, contextURL: URL)(
             case Failure(t) =>
               error(s"Error looking up storage manifest $bagId", t)
               complete(
-                StatusCodes.InternalServerError -> InternalServerErrorResponse(contextURL)
+                StatusCodes.InternalServerError -> InternalServerErrorResponse(
+                  contextURL)
               )
           }
         }

--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Router.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Router.scala
@@ -48,10 +48,7 @@ class Router(vhs: StorageManifestVHS, contextURL: URL)(
             case Failure(t) =>
               error(s"Error looking up storage manifest $bagId", t)
               complete(
-                StatusCodes.InternalServerError -> InternalServerErrorResponse(
-                  context = contextURL,
-                  statusCode = StatusCodes.InternalServerError
-                )
+                StatusCodes.InternalServerError -> InternalServerErrorResponse(contextURL)
               )
           }
         }

--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
@@ -8,7 +8,11 @@ import io.circe.parser._
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.utils.JsonAssertions
-import uk.ac.wellcome.platform.archive.common.generators.{BagIdGenerators, BagInfoGenerators, StorageManifestGenerators}
+import uk.ac.wellcome.platform.archive.common.generators.{
+  BagIdGenerators,
+  BagInfoGenerators,
+  StorageManifestGenerators
+}
 import uk.ac.wellcome.platform.archive.common.http.HttpMetricResults
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
 import uk.ac.wellcome.platform.archive.display.fixtures.DisplayJsonHelpers
@@ -54,10 +58,8 @@ class BagsApiFeatureTest
                  |  "locations": [
                  |    ${asList(storageManifest.locations, location)}
                  |  ],
-                 |  "createdDate": "${
-                DateTimeFormatter.ISO_INSTANT.format(
-                  storageManifest.createdDate)
-              }",
+                 |  "createdDate": "${DateTimeFormatter.ISO_INSTANT.format(
+                   storageManifest.createdDate)}",
                  |  "type": "Bag"
                  |}
                """.stripMargin

--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
@@ -8,7 +8,11 @@ import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
-import uk.ac.wellcome.platform.archive.common.fixtures.{HttpFixtures, RandomThings, StorageManifestVHSFixture}
+import uk.ac.wellcome.platform.archive.common.fixtures.{
+  HttpFixtures,
+  RandomThings,
+  StorageManifestVHSFixture
+}
 import uk.ac.wellcome.platform.archive.common.http.HttpMetrics
 import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestVHS
 import uk.ac.wellcome.platform.storage.bags.api.BagsApi

--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
@@ -7,16 +7,14 @@ import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
-import uk.ac.wellcome.platform.archive.common.fixtures.{
-  HttpFixtures,
-  RandomThings,
-  StorageManifestVHSFixture
-}
+import uk.ac.wellcome.platform.archive.common.fixtures.{HttpFixtures, RandomThings, StorageManifestVHSFixture}
 import uk.ac.wellcome.platform.archive.common.http.HttpMetrics
+import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
 import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestVHS
 import uk.ac.wellcome.platform.storage.bags.api.BagsApi
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
+import uk.ac.wellcome.storage.vhs.{EmptyMetadata, VersionedHybridStore}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -56,21 +54,19 @@ trait BagsApiFixture
     }
 
   def withConfiguredApp[R](
-    testWith: TestWith[(StorageManifestVHS, MetricsSender, String), R]): R =
-    withLocalS3Bucket { bucket =>
-      withLocalDynamoDbTable { table =>
-        withStorageManifestVHS(table, bucket) { vhs =>
-          withMockMetricsSender { metricsSender =>
-            withApp(metricsSender, vhs) { _ =>
-              testWith((vhs, metricsSender, httpServerConfig.externalBaseURL))
-            }
-          }
-        }
+    testWith: TestWith[(StorageManifestVHS, MetricsSender, String), R]): R = {
+    val vhs = createStorageManifestVHS()
+
+    withMockMetricsSender { metricsSender =>
+      withApp(metricsSender, vhs) { _ =>
+        testWith((vhs, metricsSender, httpServerConfig.externalBaseURL))
       }
     }
+  }
 
   def withBrokenApp[R](
     testWith: TestWith[(StorageManifestVHS, MetricsSender, String), R]): R = {
+
     val bucket = Bucket("does-not-exist")
     val table = Table("does-not-exist", index = "does-not-exist")
     withStorageManifestVHS(table, bucket) { vhs =>

--- a/api/ingests_api/docker-compose.yml
+++ b/api/ingests_api/docker-compose.yml
@@ -1,8 +1,0 @@
-dynamodb:
-  image: peopleperhour/dynamodb
-  ports:
-    - "45678:8000"
-sns:
-  image: wellcome/fake-sns
-  ports:
-  - "9292:9292"

--- a/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestStarter.scala
+++ b/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestStarter.scala
@@ -4,13 +4,13 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sns.SNSWriter
 import uk.ac.wellcome.platform.archive.common.IngestRequestPayload
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
-import uk.ac.wellcome.platform.archive.common.ingests.monitor.IngestTracker
+import uk.ac.wellcome.platform.archive.common.ingests.monitor.DynamoIngestTracker
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class IngestStarter(
-  ingestTracker: IngestTracker,
-  unpackerSnsWriter: SNSWriter
+                     ingestTracker: DynamoIngestTracker,
+                     unpackerSnsWriter: SNSWriter
 )(implicit ec: ExecutionContext) {
   def initialise(ingest: Ingest): Future[Ingest] =
     for {

--- a/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApi.scala
+++ b/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApi.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.platform.archive.common.http.{
   HttpMetrics,
   WellcomeHttpApp
 }
-import uk.ac.wellcome.platform.archive.common.ingests.monitor.IngestTracker
+import uk.ac.wellcome.platform.archive.common.ingests.monitor.DynamoIngestTracker
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 import uk.ac.wellcome.typesafe.Runnable
 
@@ -29,7 +29,7 @@ class IngestsApi(
   mat: ActorMaterializer,
   ec: ExecutionContext)
     extends Runnable {
-  val ingestTracker = new IngestTracker(
+  val ingestTracker = new DynamoIngestTracker(
     dynamoDbClient = dynamoClient,
     dynamoConfig = dynamoConfig
   )

--- a/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApi.scala
+++ b/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApi.scala
@@ -7,7 +7,10 @@ import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
 import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.platform.archive.common.config.models.HTTPServerConfig
-import uk.ac.wellcome.platform.archive.common.http.{HttpMetrics, WellcomeHttpApp}
+import uk.ac.wellcome.platform.archive.common.http.{
+  HttpMetrics,
+  WellcomeHttpApp
+}
 import uk.ac.wellcome.platform.archive.common.ingests.monitor.IngestTracker
 import uk.ac.wellcome.typesafe.Runnable
 

--- a/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApi.scala
+++ b/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApi.scala
@@ -5,23 +5,17 @@ import java.net.URL
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.stream.ActorMaterializer
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
-import uk.ac.wellcome.messaging.sns.SNSWriter
+import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.platform.archive.common.config.models.HTTPServerConfig
-import uk.ac.wellcome.platform.archive.common.http.{
-  HttpMetrics,
-  WellcomeHttpApp
-}
-import uk.ac.wellcome.platform.archive.common.ingests.monitor.DynamoIngestTracker
-import uk.ac.wellcome.storage.dynamo.DynamoConfig
+import uk.ac.wellcome.platform.archive.common.http.{HttpMetrics, WellcomeHttpApp}
+import uk.ac.wellcome.platform.archive.common.ingests.monitor.IngestTracker
 import uk.ac.wellcome.typesafe.Runnable
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class IngestsApi(
-  dynamoClient: AmazonDynamoDB,
-  dynamoConfig: DynamoConfig,
-  unpackerSnsWriter: SNSWriter,
+class IngestsApi[Destination](
+  ingestTracker: IngestTracker,
+  unpackerMessageSender: MessageSender[Destination],
   httpMetrics: HttpMetrics,
   httpServerConfig: HTTPServerConfig,
   contextURL: URL
@@ -29,16 +23,11 @@ class IngestsApi(
   mat: ActorMaterializer,
   ec: ExecutionContext)
     extends Runnable {
-  val ingestTracker = new DynamoIngestTracker(
-    dynamoDbClient = dynamoClient,
-    dynamoConfig = dynamoConfig
-  )
-
   val router = new Router(
     ingestTracker = ingestTracker,
-    ingestStarter = new IngestStarter(
+    ingestStarter = new IngestStarter[Destination](
       ingestTracker = ingestTracker,
-      unpackerSnsWriter = unpackerSnsWriter
+      unpackerMessageSender = unpackerMessageSender
     ),
     httpServerConfig = httpServerConfig,
     contextURL = contextURL

--- a/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/Main.scala
+++ b/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/Main.scala
@@ -36,7 +36,9 @@ object Main extends WellcomeTypesafeApp {
     new IngestsApi(
       ingestTracker = ingestTracker,
       unpackerMessageSender = SNSBuilder.buildSNSMessageSender(
-        config, namespace = "unpacker", subject = "Sent from the ingests API"
+        config,
+        namespace = "unpacker",
+        subject = "Sent from the ingests API"
       ),
       httpMetrics = httpMetrics,
       httpServerConfig = HTTPServerBuilder.buildHTTPServerConfig(config),

--- a/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/Router.scala
+++ b/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/Router.scala
@@ -20,7 +20,7 @@ import uk.ac.wellcome.platform.archive.common.http.models.{
   UserErrorResponse
 }
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
-import uk.ac.wellcome.platform.archive.common.ingests.monitor.IngestTracker
+import uk.ac.wellcome.platform.archive.common.ingests.monitor.DynamoIngestTracker
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.platform.archive.display.{
   DisplayIngestMinimal,
@@ -28,7 +28,7 @@ import uk.ac.wellcome.platform.archive.display.{
   ResponseDisplayIngest
 }
 
-class Router(ingestTracker: IngestTracker,
+class Router(ingestTracker: DynamoIngestTracker,
              ingestStarter: IngestStarter,
              httpServerConfig: HTTPServerConfig,
              contextURL: URL)

--- a/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/Router.scala
+++ b/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/Router.scala
@@ -9,13 +9,23 @@ import akka.http.scaladsl.server._
 import grizzled.slf4j.Logging
 import io.circe.Printer
 import uk.ac.wellcome.platform.archive.common.IngestID
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, ExternalIdentifier}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagId,
+  ExternalIdentifier
+}
 import uk.ac.wellcome.platform.archive.common.config.models.HTTPServerConfig
-import uk.ac.wellcome.platform.archive.common.http.models.{InternalServerErrorResponse, UserErrorResponse}
+import uk.ac.wellcome.platform.archive.common.http.models.{
+  InternalServerErrorResponse,
+  UserErrorResponse
+}
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
 import uk.ac.wellcome.platform.archive.common.ingests.monitor.IngestTracker
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.platform.archive.display.{DisplayIngestMinimal, RequestDisplayIngest, ResponseDisplayIngest}
+import uk.ac.wellcome.platform.archive.display.{
+  DisplayIngestMinimal,
+  RequestDisplayIngest,
+  ResponseDisplayIngest
+}
 
 import scala.util.{Failure, Success}
 
@@ -39,7 +49,10 @@ class Router[IngestStarterDestination](
           ingestStarter.initialise(requestDisplayIngest.toIngest) match {
             case Success(ingest) =>
               respondWithHeaders(List(createLocationHeader(ingest))) {
-                complete(StatusCodes.Created -> ResponseDisplayIngest(ingest, contextURL))
+                complete(
+                  StatusCodes.Created -> ResponseDisplayIngest(
+                    ingest,
+                    contextURL))
               }
             case Failure(err) =>
               error(s"Error initialising the ingest: $err")
@@ -52,17 +65,18 @@ class Router[IngestStarterDestination](
       } ~ path(JavaUUID) { id: UUID =>
         get {
           ingestTracker.get(IngestID(id)) match {
-            case Success(result) => result match {
-              case Some(ingest) =>
-                complete(ResponseDisplayIngest(ingest, contextURL))
-              case None =>
-                complete(
-                  StatusCodes.NotFound -> UserErrorResponse(
-                    context = contextURL,
-                    statusCode = StatusCodes.NotFound,
-                    description = s"Ingest $id not found"
-                  ))
-            }
+            case Success(result) =>
+              result match {
+                case Some(ingest) =>
+                  complete(ResponseDisplayIngest(ingest, contextURL))
+                case None =>
+                  complete(
+                    StatusCodes.NotFound -> UserErrorResponse(
+                      context = contextURL,
+                      statusCode = StatusCodes.NotFound,
+                      description = s"Ingest $id not found"
+                    ))
+              }
             case Failure(err) =>
               error(s"Error looking up ingest $id: $err")
               complete(

--- a/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/Router.scala
+++ b/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/Router.scala
@@ -4,34 +4,26 @@ import java.net.URL
 import java.util.UUID
 
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.headers.Location
 import akka.http.scaladsl.server._
 import grizzled.slf4j.Logging
 import io.circe.Printer
 import uk.ac.wellcome.platform.archive.common.IngestID
-import uk.ac.wellcome.platform.archive.common.bagit.models.{
-  BagId,
-  ExternalIdentifier
-}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, ExternalIdentifier}
 import uk.ac.wellcome.platform.archive.common.config.models.HTTPServerConfig
-import uk.ac.wellcome.platform.archive.common.http.models.{
-  InternalServerErrorResponse,
-  UserErrorResponse
-}
+import uk.ac.wellcome.platform.archive.common.http.models.{InternalServerErrorResponse, UserErrorResponse}
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
-import uk.ac.wellcome.platform.archive.common.ingests.monitor.DynamoIngestTracker
+import uk.ac.wellcome.platform.archive.common.ingests.monitor.IngestTracker
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.platform.archive.display.{
-  DisplayIngestMinimal,
-  RequestDisplayIngest,
-  ResponseDisplayIngest
-}
+import uk.ac.wellcome.platform.archive.display.{DisplayIngestMinimal, RequestDisplayIngest, ResponseDisplayIngest}
 
-class Router(ingestTracker: DynamoIngestTracker,
-             ingestStarter: IngestStarter,
-             httpServerConfig: HTTPServerConfig,
-             contextURL: URL)
+import scala.util.{Failure, Success}
+
+class Router[IngestStarterDestination](
+  ingestTracker: IngestTracker,
+  ingestStarter: IngestStarter[IngestStarterDestination],
+  httpServerConfig: HTTPServerConfig,
+  contextURL: URL)
     extends Logging {
 
   import akka.http.scaladsl.server.Directives._
@@ -44,25 +36,39 @@ class Router(ingestTracker: DynamoIngestTracker,
     pathPrefix("ingests") {
       post {
         entity(as[RequestDisplayIngest]) { requestDisplayIngest =>
-          onSuccess(ingestStarter.initialise(requestDisplayIngest.toIngest)) {
-            ingest =>
+          ingestStarter.initialise(requestDisplayIngest.toIngest) match {
+            case Success(ingest) =>
               respondWithHeaders(List(createLocationHeader(ingest))) {
-                complete(Created -> ResponseDisplayIngest(ingest, contextURL))
+                complete(StatusCodes.Created -> ResponseDisplayIngest(ingest, contextURL))
               }
+            case Failure(err) =>
+              error(s"Error initialising the ingest: $err")
+              complete(
+                StatusCodes.InternalServerError ->
+                  InternalServerErrorResponse(contextURL)
+              )
           }
         }
       } ~ path(JavaUUID) { id: UUID =>
         get {
-          onSuccess(ingestTracker.get(IngestID(id))) {
-            case Some(ingest) =>
-              complete(ResponseDisplayIngest(ingest, contextURL))
-            case None =>
+          ingestTracker.get(IngestID(id)) match {
+            case Success(result) => result match {
+              case Some(ingest) =>
+                complete(ResponseDisplayIngest(ingest, contextURL))
+              case None =>
+                complete(
+                  StatusCodes.NotFound -> UserErrorResponse(
+                    context = contextURL,
+                    statusCode = StatusCodes.NotFound,
+                    description = s"Ingest $id not found"
+                  ))
+            }
+            case Failure(err) =>
+              error(s"Error looking up ingest $id: $err")
               complete(
-                NotFound -> UserErrorResponse(
-                  context = contextURL,
-                  statusCode = StatusCodes.NotFound,
-                  description = s"Ingest $id not found"
-                ))
+                StatusCodes.InternalServerError ->
+                  InternalServerErrorResponse(contextURL)
+              )
           }
         }
       } ~ path("find-by-bag-id" / Segment) { combinedId: String =>
@@ -85,21 +91,19 @@ class Router(ingestTracker: DynamoIngestTracker,
     }
 
   private def findIngest(bagId: BagId) = {
-    val results = ingestTracker.findByBagId(bagId)
-    if (results.nonEmpty && results.forall(_.isRight)) {
-      complete(OK -> results.collect {
-        case Right(ingest) => DisplayIngestMinimal(ingest)
-      })
-    } else if (results.isEmpty) {
-      complete(NotFound -> List[DisplayIngestMinimal]())
-    } else {
-      info(s"""errors fetching ingests for $bagId: ${results.mkString(" ")}""")
-      complete(
-        InternalServerError -> InternalServerErrorResponse(
-          context = contextURL,
-          statusCode = InternalServerError
+    ingestTracker.findByBagId(bagId) match {
+      case Success(results) =>
+        if (results.nonEmpty) {
+          complete(StatusCodes.OK -> results.map { DisplayIngestMinimal(_) })
+        } else {
+          complete(StatusCodes.NotFound -> List[DisplayIngestMinimal]())
+        }
+      case Failure(err) =>
+        error(s"Error fetching ingests for $bagId: $err")
+        complete(
+          StatusCodes.InternalServerError ->
+            InternalServerErrorResponse(contextURL)
         )
-      )
     }
   }
 

--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestStarterTest.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestStarterTest.scala
@@ -31,9 +31,7 @@ class IngestStarterTest
     tracker.ingests shouldBe Map(ingest.id -> ingest)
 
     val expectedPayload = IngestRequestPayload(ingest)
-    sender.messages
-      .map { _.body }
-      .map { fromJson[IngestRequestPayload](_).get } shouldBe Seq(expectedPayload)
+    sender.getMessages[IngestRequestPayload]() shouldBe Seq(expectedPayload)
   }
 
   it("returns a failed future if saving to the tracker fails") {

--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestStarterTest.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestStarterTest.scala
@@ -38,7 +38,8 @@ class IngestStarterTest
     val sender = createMessageSender
 
     val tracker = new MemoryIngestTracker() {
-      override def initialise(ingest: Ingest): Try[Ingest] = Failure(new Throwable("BOOM!"))
+      override def initialise(ingest: Ingest): Try[Ingest] =
+        Failure(new Throwable("BOOM!"))
     }
 
     val starter = createIngestStarter(sender, tracker)
@@ -54,7 +55,8 @@ class IngestStarterTest
       destination = randomAlphanumeric(),
       subject = randomAlphanumeric()
     ) {
-      override def sendT[T](t: T)(implicit encoder: Encoder[T]): Try[Unit] = Failure(new Throwable("BOOM!"))
+      override def sendT[T](t: T)(implicit encoder: Encoder[T]): Try[Unit] =
+        Failure(new Throwable("BOOM!"))
     }
 
     val tracker = createIngestTracker

--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestStarterTest.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestStarterTest.scala
@@ -1,100 +1,70 @@
 package uk.ac.wellcome.platform.storage.ingests.api
 
-import org.scalatest.concurrent.ScalaFutures
+import io.circe.Encoder
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.storage.dynamo._
-import uk.ac.wellcome.messaging.fixtures.SNS
-import uk.ac.wellcome.messaging.fixtures.SNS.Topic
+import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.common.IngestRequestPayload
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
-import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestTrackerFixture
-import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
+import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
+import uk.ac.wellcome.platform.archive.common.ingests.monitor.MemoryIngestTracker
+import uk.ac.wellcome.platform.storage.ingests.api.fixtures.IngestsStarterFixtures
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.{Failure, Success, Try}
 
 class IngestStarterTest
     extends FunSpec
-    with IngestTrackerFixture
-    with SNS
+    with Matchers
     with IngestGenerators
-    with ScalaFutures
-    with Matchers {
+    with IngestsStarterFixtures {
 
-  val ingest = createIngest
+  val ingest: Ingest = createIngest
 
   it("saves an Ingest and sends a notification") {
-    withLocalSnsTopic { unpackerTopic =>
-      withIngestTrackerTable { table =>
-        withIngestStarter(table, unpackerTopic) { ingestStarter =>
-          whenReady(ingestStarter.initialise(ingest)) { p =>
-            p shouldBe ingest
+    val sender = createMessageSender
+    val tracker = createIngestTracker
 
-            assertTableOnlyHasItem(ingest, table)
+    val starter = createIngestStarter(sender, tracker)
 
-            eventually {
-              val expectedPayload = IngestRequestPayload(ingest)
+    starter.initialise(ingest) shouldBe Success(ingest)
 
-              assertSnsReceivesOnly(expectedPayload, unpackerTopic)
-            }
-          }
+    tracker.ingests shouldBe Map(ingest.id -> ingest)
 
-        }
-      }
-    }
+    val expectedPayload = IngestRequestPayload(ingest)
+    sender.messages
+      .map { _.body }
+      .map { fromJson[IngestRequestPayload](_).get } shouldBe Seq(expectedPayload)
   }
 
-  it("returns a failed future if saving to DynamoDB fails") {
-    withLocalSnsTopic { unpackerTopic =>
-      val fakeTable = Table("does-not-exist", index = "does-not-exist")
+  it("returns a failed future if saving to the tracker fails") {
+    val sender = createMessageSender
 
-      withIngestStarter(
-        fakeTable,
-        unpackerTopic
-      ) { ingestStarter =>
-        val future = ingestStarter.initialise(ingest)
-
-        whenReady(future.failed) { _ =>
-          assertSnsReceivesNothing(unpackerTopic)
-        }
-      }
+    val tracker = new MemoryIngestTracker() {
+      override def initialise(ingest: Ingest): Try[Ingest] = Failure(new Throwable("BOOM!"))
     }
 
+    val starter = createIngestStarter(sender, tracker)
+
+    starter.initialise(ingest) shouldBe a[Failure[_]]
+
+    tracker.ingests shouldBe empty
+    sender.messages shouldBe empty
   }
 
-  it("returns a failed future if publishing to SNS fails") {
-    withIngestTrackerTable { table =>
-      val fakeUnpackerTopic = Topic("does-not-exist")
-
-      withIngestStarter(
-        table,
-        fakeUnpackerTopic
-      ) { ingestStarter =>
-        val future = ingestStarter.initialise(ingest)
-
-        whenReady(future.failed) { _ =>
-          assertTableOnlyHasItem(ingest, table)
-        }
-      }
+  it("returns a failed future if sending the onward message fails") {
+    val sender = new MemoryMessageSender(
+      destination = randomAlphanumeric(),
+      subject = randomAlphanumeric()
+    ) {
+      override def sendT[T](t: T)(implicit encoder: Encoder[T]): Try[Unit] = Failure(new Throwable("BOOM!"))
     }
+
+    val tracker = createIngestTracker
+
+    val starter = createIngestStarter(sender, tracker)
+
+    starter.initialise(ingest) shouldBe a[Failure[_]]
+
+    sender.messages shouldBe empty
   }
-
-  private def withIngestStarter[R](
-    table: Table,
-    unpackerTopic: Topic
-  )(
-    testWith: TestWith[IngestStarter, R]
-  ): R =
-    withSNSWriter(unpackerTopic) { unpackerSnsWriter =>
-      withIngestTracker(table) { ingestTracker =>
-        val ingestStarter = new IngestStarter(
-          ingestTracker = ingestTracker,
-          unpackerSnsWriter = unpackerSnsWriter
-        )
-
-        testWith(ingestStarter)
-      }
-    }
-
 }

--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
@@ -291,9 +291,7 @@ class IngestsApiFeatureTest
                     ingestTracker.ingests shouldBe Map(expectedIngest.id -> expectedIngest)
 
                     val expectedPayload = IngestRequestPayload(expectedIngest)
-                    unpackerMessageSender.messages
-                      .map { _.body }
-                      .map { fromJson[IngestRequestPayload](_).get } shouldBe Seq(expectedPayload)
+                    unpackerMessageSender.getMessages[IngestRequestPayload]() shouldBe Seq(expectedPayload)
                 }
               }
 

--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
@@ -78,54 +78,52 @@ class IngestsApiFeatureTest
 
             ingestTracker.initialise(ingest)
 
-            whenGetRequestReady(s"$baseUrl/ingests/${ingest.id}") {
-              result =>
-                result.status shouldBe StatusCodes.OK
+            whenGetRequestReady(s"$baseUrl/ingests/${ingest.id}") { result =>
+              result.status shouldBe StatusCodes.OK
 
-                withStringEntity(result.entity) { jsonString =>
-                  val json = parse(jsonString).right.get
-                  root.`@context`.string
-                    .getOption(json)
-                    .get shouldBe "http://api.wellcomecollection.org/storage/v1/context.json"
-                  root.id.string
-                    .getOption(json)
-                    .get shouldBe ingest.id.toString
+              withStringEntity(result.entity) { jsonString =>
+                val json = parse(jsonString).right.get
+                root.`@context`.string
+                  .getOption(json)
+                  .get shouldBe "http://api.wellcomecollection.org/storage/v1/context.json"
+                root.id.string
+                  .getOption(json)
+                  .get shouldBe ingest.id.toString
 
-                  assertJsonStringsAreEqual(
-                    root.sourceLocation.json.getOption(json).get.noSpaces,
-                    expectedSourceLocationJson)
+                assertJsonStringsAreEqual(
+                  root.sourceLocation.json.getOption(json).get.noSpaces,
+                  expectedSourceLocationJson)
 
-                  assertJsonStringsAreEqual(
-                    root.callback.json.getOption(json).get.noSpaces,
-                    expectedCallbackJson)
-                  assertJsonStringsAreEqual(
-                    root.ingestType.json.getOption(json).get.noSpaces,
-                    expectedIngestTypeJson)
-                  assertJsonStringsAreEqual(
-                    root.space.json.getOption(json).get.noSpaces,
-                    expectedSpaceJson)
-                  assertJsonStringsAreEqual(
-                    root.status.json.getOption(json).get.noSpaces,
-                    expectedStatusJson)
-                  assertJsonStringsAreEqual(
-                    root.events.json.getOption(json).get.noSpaces,
-                    "[]")
+                assertJsonStringsAreEqual(
+                  root.callback.json.getOption(json).get.noSpaces,
+                  expectedCallbackJson)
+                assertJsonStringsAreEqual(
+                  root.ingestType.json.getOption(json).get.noSpaces,
+                  expectedIngestTypeJson)
+                assertJsonStringsAreEqual(
+                  root.space.json.getOption(json).get.noSpaces,
+                  expectedSpaceJson)
+                assertJsonStringsAreEqual(
+                  root.status.json.getOption(json).get.noSpaces,
+                  expectedStatusJson)
+                assertJsonStringsAreEqual(
+                  root.events.json.getOption(json).get.noSpaces,
+                  "[]")
 
-                  root.`type`.string.getOption(json).get shouldBe "Ingest"
+                root.`type`.string.getOption(json).get shouldBe "Ingest"
 
-                  assertRecent(
-                    Instant.parse(
-                      root.createdDate.string.getOption(json).get),
-                    25)
-                  assertRecent(
-                    Instant.parse(
-                      root.lastModifiedDate.string.getOption(json).get),
-                    25)
-                }
+                assertRecent(
+                  Instant.parse(root.createdDate.string.getOption(json).get),
+                  25)
+                assertRecent(
+                  Instant.parse(
+                    root.lastModifiedDate.string.getOption(json).get),
+                  25)
+              }
 
-                assertMetricSent(
-                  metricsSender,
-                  result = HttpMetricResults.Success)
+              assertMetricSent(
+                metricsSender,
+                result = HttpMetricResults.Success)
             }
           }
       }
@@ -137,17 +135,16 @@ class IngestsApiFeatureTest
           withMaterializer { implicit materialiser =>
             val ingest = createIngestWith(callback = None)
             ingestTracker.initialise(ingest)
-            whenGetRequestReady(s"$baseUrl/ingests/${ingest.id}") {
-              result =>
-                result.status shouldBe StatusCodes.OK
-                withStringEntity(result.entity) { jsonString =>
-                  val infoJson = parse(jsonString).right.get
-                  infoJson.findAllByKey("callback") shouldBe empty
-                }
+            whenGetRequestReady(s"$baseUrl/ingests/${ingest.id}") { result =>
+              result.status shouldBe StatusCodes.OK
+              withStringEntity(result.entity) { jsonString =>
+                val infoJson = parse(jsonString).right.get
+                infoJson.findAllByKey("callback") shouldBe empty
+              }
 
-                assertMetricSent(
-                  metricsSender,
-                  result = HttpMetricResults.Success)
+              assertMetricSent(
+                metricsSender,
+                result = HttpMetricResults.Success)
             }
           }
       }
@@ -288,10 +285,13 @@ class IngestsApiFeatureTest
                       events = Nil
                     )
 
-                    ingestTracker.ingests shouldBe Map(expectedIngest.id -> expectedIngest)
+                    ingestTracker.ingests shouldBe Map(
+                      expectedIngest.id -> expectedIngest)
 
                     val expectedPayload = IngestRequestPayload(expectedIngest)
-                    unpackerMessageSender.getMessages[IngestRequestPayload]() shouldBe Seq(expectedPayload)
+                    unpackerMessageSender
+                      .getMessages[IngestRequestPayload]() shouldBe Seq(
+                      expectedPayload)
                 }
               }
 
@@ -676,13 +676,15 @@ class IngestsApiFeatureTest
             ingestTracker.initialise(ingest)
             val bagId = createBagId
 
-            val storedIngest = ingestTracker.update(
-              IngestStatusUpdate(
-                id = ingest.id,
-                status = Ingest.Accepted,
-                affectedBag = Some(bagId)
+            val storedIngest = ingestTracker
+              .update(
+                IngestStatusUpdate(
+                  id = ingest.id,
+                  status = Ingest.Accepted,
+                  affectedBag = Some(bagId)
+                )
               )
-            ).get
+              .get
 
             val bagIngest = BagIngest(
               id = ingest.id,

--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/fixtures/IngestsApiFixture.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/fixtures/IngestsApiFixture.scala
@@ -2,28 +2,27 @@ package uk.ac.wellcome.platform.storage.ingests.api.fixtures
 
 import java.net.URL
 
+import org.scalatest.Matchers
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.messaging.fixtures.SNS.Topic
-import uk.ac.wellcome.messaging.fixtures.Messaging
+import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.monitoring.MetricsSender
-import uk.ac.wellcome.platform.archive.common.fixtures.{
-  HttpFixtures,
-  RandomThings
-}
+import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
+import uk.ac.wellcome.platform.archive.common.IngestID
+import uk.ac.wellcome.platform.archive.common.fixtures.HttpFixtures
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
 import uk.ac.wellcome.platform.archive.common.http.HttpMetrics
-import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestTrackerFixture
+import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
+import uk.ac.wellcome.platform.archive.common.ingests.monitor.MemoryIngestTracker
 import uk.ac.wellcome.platform.storage.ingests.api.IngestsApi
-import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
 
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.{Failure, Try}
 
 trait IngestsApiFixture
-    extends RandomThings
-    with IngestTrackerFixture
-    with IngestGenerators
+    extends IngestGenerators
     with HttpFixtures
-    with Messaging {
+    with IngestsStarterFixtures
+    with MetricsSenderFixture { this: Matchers =>
 
   val contextURL = new URL(
     "http://api.wellcomecollection.org/storage/v1/context.json")
@@ -31,10 +30,9 @@ trait IngestsApiFixture
   val metricsName = "IngestsApiFixture"
 
   private def withApp[R](
-    table: Table,
-    unpackerTopic: Topic,
-    metricsSender: MetricsSender)(testWith: TestWith[IngestsApi, R]): R =
-    withSNSWriter(unpackerTopic) { unpackerSnsWriter =>
+    ingestTracker: MemoryIngestTracker,
+    unpackerMessageSender: MemoryMessageSender,
+    metricsSender: MetricsSender)(testWith: TestWith[IngestsApi[String], R]): R =
       withActorSystem { implicit actorSystem =>
         withMaterializer(actorSystem) { implicit materializer =>
           val httpMetrics = new HttpMetrics(
@@ -43,9 +41,8 @@ trait IngestsApiFixture
           )
 
           val ingestsApi = new IngestsApi(
-            dynamoClient = dynamoDbClient,
-            dynamoConfig = createDynamoConfigWith(table),
-            unpackerSnsWriter = unpackerSnsWriter,
+            ingestTracker = ingestTracker,
+            unpackerMessageSender = unpackerMessageSender,
             httpMetrics = httpMetrics,
             httpServerConfig = httpServerConfig,
             contextURL = contextURL
@@ -56,38 +53,33 @@ trait IngestsApiFixture
           testWith(ingestsApi)
         }
       }
-    }
 
   def withBrokenApp[R](
-    testWith: TestWith[(Table, Topic, MetricsSender, String), R]): R =
-    withLocalSnsTopic { unpackerTopic =>
-      val table = Table("does-not-exist", index = "does-not-exist")
-      withMockMetricsSender { metricsSender =>
-        withApp(table, unpackerTopic, metricsSender) { _ =>
-          testWith(
-            (
-              table,
-              unpackerTopic,
-              metricsSender,
-              httpServerConfig.externalBaseURL))
-        }
-      }
+    testWith: TestWith[(MemoryIngestTracker, MemoryMessageSender, MetricsSender, String), R]): R = {
+    val brokenTracker = new MemoryIngestTracker() {
+      override def get(id: IngestID): Try[Option[Ingest]] = Failure(new Throwable("BOOM! get()"))
+
+      override def initialise(ingest: Ingest): Try[Ingest] = Failure(new Throwable("BOOM! initialise()"))
     }
 
-  def withConfiguredApp[R](
-    testWith: TestWith[(Table, Topic, MetricsSender, String), R]): R =
-    withLocalSnsTopic { unpackerTopic =>
-      withIngestTrackerTable { table =>
-        withMockMetricsSender { metricsSender =>
-          withApp(table, unpackerTopic, metricsSender) { _ =>
-            testWith(
-              (
-                table,
-                unpackerTopic,
-                metricsSender,
-                httpServerConfig.externalBaseURL))
-          }
-        }
+    val messageSender = createMessageSender
+
+    withMockMetricsSender { metricsSender =>
+      withApp(brokenTracker, messageSender, metricsSender) { _ =>
+        testWith((brokenTracker, messageSender, metricsSender, httpServerConfig.externalBaseURL))
       }
     }
+  }
+
+  def withConfiguredApp[R](
+    testWith: TestWith[(MemoryIngestTracker, MemoryMessageSender, MetricsSender, String), R]): R = {
+    val tracker = createIngestTracker
+    val messageSender = createMessageSender
+
+    withMockMetricsSender { metricsSender =>
+      withApp(tracker, messageSender, metricsSender) { _ =>
+        testWith((tracker, messageSender, metricsSender, httpServerConfig.externalBaseURL))
+      }
+    }
+  }
 }

--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/fixtures/IngestsStarterFixtures.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/fixtures/IngestsStarterFixtures.scala
@@ -1,0 +1,25 @@
+package uk.ac.wellcome.platform.storage.ingests.api.fixtures
+
+import uk.ac.wellcome.messaging.MessageSender
+import uk.ac.wellcome.messaging.memory.MemoryMessageSender
+import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
+import uk.ac.wellcome.platform.archive.common.ingests.monitor.{IngestTracker, MemoryIngestTracker}
+import uk.ac.wellcome.platform.storage.ingests.api.IngestStarter
+
+trait IngestsStarterFixtures extends RandomThings {
+  def createMessageSender =
+    new MemoryMessageSender(
+      destination = randomAlphanumeric(),
+      subject = randomAlphanumeric()
+    )
+
+  def createIngestTracker = new MemoryIngestTracker()
+
+  def createIngestStarter(
+                           sender: MessageSender[String] = createMessageSender,
+                           tracker: IngestTracker = createIngestTracker
+                         ): IngestStarter[String] = new IngestStarter[String](
+    ingestTracker = tracker,
+    unpackerMessageSender = sender
+  )
+}

--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/fixtures/IngestsStarterFixtures.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/fixtures/IngestsStarterFixtures.scala
@@ -3,7 +3,10 @@ package uk.ac.wellcome.platform.storage.ingests.api.fixtures
 import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
-import uk.ac.wellcome.platform.archive.common.ingests.monitor.{IngestTracker, MemoryIngestTracker}
+import uk.ac.wellcome.platform.archive.common.ingests.monitor.{
+  IngestTracker,
+  MemoryIngestTracker
+}
 import uk.ac.wellcome.platform.storage.ingests.api.IngestStarter
 
 trait IngestsStarterFixtures extends RandomThings {
@@ -16,9 +19,9 @@ trait IngestsStarterFixtures extends RandomThings {
   def createIngestTracker = new MemoryIngestTracker()
 
   def createIngestStarter(
-                           sender: MessageSender[String] = createMessageSender,
-                           tracker: IngestTracker = createIngestTracker
-                         ): IngestStarter[String] = new IngestStarter[String](
+    sender: MessageSender[String] = createMessageSender,
+    tracker: IngestTracker = createIngestTracker
+  ): IngestStarter[String] = new IngestStarter[String](
     ingestTracker = tracker,
     unpackerMessageSender = sender
   )

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
@@ -16,7 +16,7 @@ import uk.ac.wellcome.platform.archive.common.storage.models.{
 }
 import uk.ac.wellcome.platform.storage.bagauditor.models._
 import uk.ac.wellcome.platform.archive.common.storage.services.S3BagLocator
-import uk.ac.wellcome.platform.archive.common.storage.services.S3StreamableInstances._
+import uk.ac.wellcome.platform.archive.common.storage.services.StreamableInstances._
 import uk.ac.wellcome.platform.storage.bagauditor.versioning.VersionPicker
 import uk.ac.wellcome.storage.ObjectLocation
 

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
@@ -19,11 +19,14 @@ import uk.ac.wellcome.platform.archive.common.storage.services.S3BagLocator
 import uk.ac.wellcome.platform.archive.common.storage.services.StreamableInstances._
 import uk.ac.wellcome.platform.storage.bagauditor.versioning.VersionPicker
 import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.s3.S3StorageBackend
 
 import scala.util.{Failure, Success, Try}
 
 class BagAuditor(versionPicker: VersionPicker)(implicit s3Client: AmazonS3) {
   val s3BagLocator = new S3BagLocator(s3Client)
+
+  implicit val s3Backend: S3StorageBackend = new S3StorageBackend(s3Client)
 
   type IngestStep = Try[IngestStepResult[AuditSummary]]
 

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
@@ -4,39 +4,26 @@ import akka.actor.ActorSystem
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.sqsworker.alpakka.{
-  AlpakkaSQSWorker,
-  AlpakkaSQSWorkerConfig
-}
+import uk.ac.wellcome.messaging.sqsworker.alpakka.{AlpakkaSQSWorker, AlpakkaSQSWorkerConfig}
 import uk.ac.wellcome.messaging.worker.models.Result
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
-import uk.ac.wellcome.platform.archive.common.{
-  BagInformationPayload,
-  UnpackedBagPayload
-}
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services._
-import uk.ac.wellcome.platform.archive.common.storage.models.{
-  IngestStepResult,
-  IngestStepSucceeded,
-  IngestStepWorker
-}
-import uk.ac.wellcome.platform.storage.bagauditor.models.{
-  AuditSuccessSummary,
-  AuditSummary
-}
+import uk.ac.wellcome.platform.archive.common.storage.models.{IngestStepResult, IngestStepSucceeded, IngestStepWorker}
+import uk.ac.wellcome.platform.archive.common.{BagInformationPayload, UnpackedBagPayload}
+import uk.ac.wellcome.platform.storage.bagauditor.models.{AuditSuccessSummary, AuditSummary}
 import uk.ac.wellcome.typesafe.Runnable
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
+import scala.util.{Success, Try}
 
-class BagAuditorWorker(
+class BagAuditorWorker[IngestUpdaterDestination, OutgoingPublisherDestination](
   alpakkaSQSWorkerConfig: AlpakkaSQSWorkerConfig,
   bagAuditor: BagAuditor,
-  ingestUpdater: IngestUpdater,
-  outgoingPublisher: OutgoingPublisher
+  ingestUpdater: IngestUpdater[IngestUpdaterDestination],
+  outgoingPublisher: OutgoingPublisher[OutgoingPublisherDestination]
 )(implicit
   actorSystem: ActorSystem,
-  ec: ExecutionContext,
   mc: MonitoringClient,
   sc: AmazonSQSAsync)
     extends Runnable
@@ -44,22 +31,20 @@ class BagAuditorWorker(
     with IngestStepWorker {
   private val worker =
     AlpakkaSQSWorker[UnpackedBagPayload, AuditSummary](alpakkaSQSWorkerConfig) {
-      processMessage
+      payload => Future.fromTry { processMessage(payload) }
     }
 
   def processMessage(
-    payload: UnpackedBagPayload): Future[Result[AuditSummary]] =
+    payload: UnpackedBagPayload): Try[Result[AuditSummary]] =
     for {
       _ <- ingestUpdater.start(ingestId = payload.ingestId)
 
-      auditStep <- Future.fromTry {
-        bagAuditor.getAuditSummary(
-          ingestId = payload.ingestId,
-          ingestDate = payload.ingestDate,
-          unpackLocation = payload.unpackedBagLocation,
-          storageSpace = payload.storageSpace
-        )
-      }
+      auditStep <- bagAuditor.getAuditSummary(
+        ingestId = payload.ingestId,
+        ingestDate = payload.ingestDate,
+        unpackLocation = payload.unpackedBagLocation,
+        storageSpace = payload.storageSpace
+      )
 
       _ <- sendIngestInformation(payload)(auditStep)
       _ <- ingestUpdater.send(payload.ingestId, auditStep)
@@ -67,7 +52,7 @@ class BagAuditorWorker(
     } yield toResult(auditStep)
 
   private def sendIngestInformation(payload: UnpackedBagPayload)(
-    step: IngestStepResult[AuditSummary]): Future[Unit] =
+    step: IngestStepResult[AuditSummary]): Try[Unit] =
     step match {
       case IngestStepSucceeded(summary: AuditSuccessSummary) =>
         ingestUpdater.sendEvent(
@@ -78,11 +63,11 @@ class BagAuditorWorker(
             s"Assigned bag version ${summary.audit.version}"
           )
         )
-      case _ => Future.successful(())
+      case _ => Success(())
     }
 
   private def sendSuccessful(payload: UnpackedBagPayload)(
-    step: IngestStepResult[AuditSummary]): Future[Unit] =
+    step: IngestStepResult[AuditSummary]): Try[Unit] =
     step match {
       case IngestStepSucceeded(summary: AuditSuccessSummary) =>
         outgoingPublisher.sendIfSuccessful(
@@ -95,7 +80,7 @@ class BagAuditorWorker(
             version = summary.audit.version
           )
         )
-      case _ => Future.successful(())
+      case _ => Success(())
     }
 
   override def run(): Future[Any] = worker.start

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
@@ -4,14 +4,27 @@ import akka.actor.ActorSystem
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.sqsworker.alpakka.{AlpakkaSQSWorker, AlpakkaSQSWorkerConfig}
+import uk.ac.wellcome.messaging.sqsworker.alpakka.{
+  AlpakkaSQSWorker,
+  AlpakkaSQSWorkerConfig
+}
 import uk.ac.wellcome.messaging.worker.models.Result
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services._
-import uk.ac.wellcome.platform.archive.common.storage.models.{IngestStepResult, IngestStepSucceeded, IngestStepWorker}
-import uk.ac.wellcome.platform.archive.common.{BagInformationPayload, UnpackedBagPayload}
-import uk.ac.wellcome.platform.storage.bagauditor.models.{AuditSuccessSummary, AuditSummary}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  IngestStepResult,
+  IngestStepSucceeded,
+  IngestStepWorker
+}
+import uk.ac.wellcome.platform.archive.common.{
+  BagInformationPayload,
+  UnpackedBagPayload
+}
+import uk.ac.wellcome.platform.storage.bagauditor.models.{
+  AuditSuccessSummary,
+  AuditSummary
+}
 import uk.ac.wellcome.typesafe.Runnable
 
 import scala.concurrent.Future
@@ -31,11 +44,11 @@ class BagAuditorWorker[IngestsDestination, OutgoingDestination](
     with IngestStepWorker {
   private val worker =
     AlpakkaSQSWorker[UnpackedBagPayload, AuditSummary](alpakkaSQSWorkerConfig) {
-      payload => Future.fromTry { processMessage(payload) }
+      payload =>
+        Future.fromTry { processMessage(payload) }
     }
 
-  def processMessage(
-    payload: UnpackedBagPayload): Try[Result[AuditSummary]] =
+  def processMessage(payload: UnpackedBagPayload): Try[Result[AuditSummary]] =
     for {
       _ <- ingestUpdater.start(ingestId = payload.ingestId)
 

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
@@ -17,11 +17,11 @@ import uk.ac.wellcome.typesafe.Runnable
 import scala.concurrent.Future
 import scala.util.{Success, Try}
 
-class BagAuditorWorker[IngestUpdaterDestination, OutgoingPublisherDestination](
+class BagAuditorWorker[IngestsDestination, OutgoingDestination](
   alpakkaSQSWorkerConfig: AlpakkaSQSWorkerConfig,
   bagAuditor: BagAuditor,
-  ingestUpdater: IngestUpdater[IngestUpdaterDestination],
-  outgoingPublisher: OutgoingPublisher[OutgoingPublisherDestination]
+  ingestUpdater: IngestUpdater[IngestsDestination],
+  outgoingPublisher: OutgoingPublisher[OutgoingDestination]
 )(implicit
   actorSystem: ActorSystem,
   mc: MonitoringClient,

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
@@ -41,9 +41,7 @@ class BagAuditorFeatureTest
               eventually {
                 assertQueueEmpty(queue)
 
-                outgoing.messages
-                  .map { _.body }
-                  .map { fromJson[BagInformationPayload](_).get } shouldBe Seq(expectedPayload)
+                outgoing.getMessages[BagInformationPayload]() shouldBe Seq(expectedPayload)
 
                 assertReceivesIngestEvents(ingests)(
                   payload.ingestId,
@@ -91,9 +89,7 @@ class BagAuditorFeatureTest
               eventually {
                 assertQueueEmpty(queue)
 
-                outgoing.messages
-                  .map { _.body }
-                  .map { fromJson[BagInformationPayload](_).get } shouldBe Seq(expectedPayload)
+                outgoing.getMessages[BagInformationPayload]() shouldBe Seq(expectedPayload)
 
                 assertReceivesIngestEvents(ingests)(
                   payload.ingestId,

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
@@ -7,7 +7,6 @@ import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
 import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestStatusUpdate}
 import uk.ac.wellcome.platform.storage.bagauditor.fixtures.BagAuditorFixtures
-import uk.ac.wellcome.storage.s3.S3StorageBackend
 
 class BagAuditorFeatureTest
     extends FunSpec
@@ -15,12 +14,10 @@ class BagAuditorFeatureTest
     with IngestUpdateAssertions
     with PayloadGenerators {
 
-  val s3Backend: S3StorageBackend = new S3StorageBackend(s3Client)
-
   it("detects a bag in the root of the bagLocation") {
     withLocalS3Bucket { bucket =>
       val bagInfo = createBagInfo
-      withBag(s3Backend, namespace = bucket.name, bagInfo = bagInfo) {
+      withBag(storageBackend, namespace = bucket.name, bagInfo = bagInfo) {
         case (bagRootLocation, storageSpace) =>
           val payload = createUnpackedBagPayloadWith(
             unpackedBagLocation = bagRootLocation,
@@ -68,7 +65,7 @@ class BagAuditorFeatureTest
   it("detects a bag in a subdirectory of the bagLocation") {
     withLocalS3Bucket { bucket =>
       val bagInfo = createBagInfo
-      withBag(s3Backend, namespace = bucket.name, bagInfo = bagInfo, bagRootDirectory = Some("subdir")) {
+      withBag(storageBackend, namespace = bucket.name, bagInfo = bagInfo, bagRootDirectory = Some("subdir")) {
         case (unpackedBagLocation, storageSpace) =>
           val bagRootLocation = unpackedBagLocation.join("subdir")
 
@@ -117,7 +114,7 @@ class BagAuditorFeatureTest
 
   it("errors if the bag is nested too deep") {
     withLocalS3Bucket { bucket =>
-      withBag(s3Backend, namespace = bucket.name, bagRootDirectory = Some("subdir1/subdir2/subdir3")) {
+      withBag(storageBackend, namespace = bucket.name, bagRootDirectory = Some("subdir1/subdir2/subdir3")) {
         case (unpackedBagLocation, _) =>
           val payload = createUnpackedBagPayloadWith(unpackedBagLocation)
 

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
@@ -5,7 +5,10 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.common.BagInformationPayload
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestStatusUpdate}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  Ingest,
+  IngestStatusUpdate
+}
 import uk.ac.wellcome.platform.storage.bagauditor.fixtures.BagAuditorFixtures
 
 class BagAuditorFeatureTest
@@ -41,7 +44,8 @@ class BagAuditorFeatureTest
               eventually {
                 assertQueueEmpty(queue)
 
-                outgoing.getMessages[BagInformationPayload]() shouldBe Seq(expectedPayload)
+                outgoing.getMessages[BagInformationPayload]() shouldBe Seq(
+                  expectedPayload)
 
                 assertReceivesIngestEvents(ingests)(
                   payload.ingestId,
@@ -63,7 +67,11 @@ class BagAuditorFeatureTest
   it("detects a bag in a subdirectory of the bagLocation") {
     withLocalS3Bucket { bucket =>
       val bagInfo = createBagInfo
-      withBag(storageBackend, namespace = bucket.name, bagInfo = bagInfo, bagRootDirectory = Some("subdir")) {
+      withBag(
+        storageBackend,
+        namespace = bucket.name,
+        bagInfo = bagInfo,
+        bagRootDirectory = Some("subdir")) {
         case (unpackedBagLocation, storageSpace) =>
           val bagRootLocation = unpackedBagLocation.join("subdir")
 
@@ -89,7 +97,8 @@ class BagAuditorFeatureTest
               eventually {
                 assertQueueEmpty(queue)
 
-                outgoing.getMessages[BagInformationPayload]() shouldBe Seq(expectedPayload)
+                outgoing.getMessages[BagInformationPayload]() shouldBe Seq(
+                  expectedPayload)
 
                 assertReceivesIngestEvents(ingests)(
                   payload.ingestId,
@@ -110,7 +119,10 @@ class BagAuditorFeatureTest
 
   it("errors if the bag is nested too deep") {
     withLocalS3Bucket { bucket =>
-      withBag(storageBackend, namespace = bucket.name, bagRootDirectory = Some("subdir1/subdir2/subdir3")) {
+      withBag(
+        storageBackend,
+        namespace = bucket.name,
+        bagRootDirectory = Some("subdir1/subdir2/subdir3")) {
         case (unpackedBagLocation, _) =>
           val payload = createUnpackedBagPayloadWith(unpackedBagLocation)
 
@@ -126,17 +138,17 @@ class BagAuditorFeatureTest
 
                 outgoing.messages shouldBe empty
 
-                assertReceivesIngestUpdates(ingests)(
-                  payload.ingestId) { ingestUpdates =>
-                  ingestUpdates.size shouldBe 2
+                assertReceivesIngestUpdates(ingests)(payload.ingestId) {
+                  ingestUpdates =>
+                    ingestUpdates.size shouldBe 2
 
-                  val ingestStart = ingestUpdates.head
-                  ingestStart.events.head.description shouldBe "Auditing bag started"
+                    val ingestStart = ingestUpdates.head
+                    ingestStart.events.head.description shouldBe "Auditing bag started"
 
-                  val ingestFailed =
-                    ingestUpdates.tail.head.asInstanceOf[IngestStatusUpdate]
-                  ingestFailed.status shouldBe Ingest.Failed
-                  ingestFailed.events.head.description shouldBe "Auditing bag failed"
+                    val ingestFailed =
+                      ingestUpdates.tail.head.asInstanceOf[IngestStatusUpdate]
+                    ingestFailed.status shouldBe Ingest.Failed
+                    ingestFailed.events.head.description shouldBe "Auditing bag failed"
                 }
               }
             }

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/fixtures/BagAuditorFixtures.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/fixtures/BagAuditorFixtures.scala
@@ -4,10 +4,18 @@ import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
-import uk.ac.wellcome.platform.archive.common.fixtures.{BagLocationFixtures, MonitoringClientFixture, OperationFixtures, RandomThings}
+import uk.ac.wellcome.platform.archive.common.fixtures.{
+  BagLocationFixtures,
+  MonitoringClientFixture,
+  OperationFixtures,
+  RandomThings
+}
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services.OutgoingPublisher
-import uk.ac.wellcome.platform.storage.bagauditor.services.{BagAuditor, BagAuditorWorker}
+import uk.ac.wellcome.platform.storage.bagauditor.services.{
+  BagAuditor,
+  BagAuditorWorker
+}
 import uk.ac.wellcome.platform.storage.bagauditor.versioning.VersionPicker
 import uk.ac.wellcome.storage.fixtures.S3
 

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/fixtures/BagAuditorFixtures.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/fixtures/BagAuditorFixtures.scala
@@ -1,23 +1,15 @@
 package uk.ac.wellcome.platform.storage.bagauditor.fixtures
 
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.messaging.fixtures.SNS.Topic
+import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
-import uk.ac.wellcome.platform.archive.common.fixtures.{
-  BagLocationFixtures,
-  MonitoringClientFixture,
-  OperationFixtures,
-  RandomThings
-}
-import uk.ac.wellcome.platform.storage.bagauditor.services.{
-  BagAuditor,
-  BagAuditorWorker
-}
+import uk.ac.wellcome.platform.archive.common.fixtures.{BagLocationFixtures, MonitoringClientFixture, OperationFixtures, RandomThings}
+import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
+import uk.ac.wellcome.platform.archive.common.operation.services.OutgoingPublisher
+import uk.ac.wellcome.platform.storage.bagauditor.services.{BagAuditor, BagAuditorWorker}
 import uk.ac.wellcome.platform.storage.bagauditor.versioning.VersionPicker
 import uk.ac.wellcome.storage.fixtures.S3
-
-import scala.concurrent.ExecutionContext.Implicits.global
 
 trait BagAuditorFixtures
     extends S3
@@ -49,27 +41,32 @@ trait BagAuditorFixtures
 
   def withAuditorWorker[R](
     queue: Queue = defaultQueue,
-    ingestTopic: Topic,
-    outgoingTopic: Topic
-  )(testWith: TestWith[BagAuditorWorker, R]): R =
+    ingestsMessageSender: MessageSender[String],
+    outgoingMessageSender: MessageSender[String]
+  )(testWith: TestWith[BagAuditorWorker[String, String], R]): R =
     withActorSystem { implicit actorSystem =>
-      withIngestUpdater("auditing bag", ingestTopic) { ingestUpdater =>
-        withOutgoingPublisher("auditing bag", outgoingTopic) {
-          outgoingPublisher =>
-            withMonitoringClient { implicit monitoringClient =>
-              withBagAuditor { bagAuditor =>
-                val worker = new BagAuditorWorker(
-                  alpakkaSQSWorkerConfig = createAlpakkaSQSWorkerConfig(queue),
-                  bagAuditor = bagAuditor,
-                  ingestUpdater = ingestUpdater,
-                  outgoingPublisher = outgoingPublisher
-                )
+      val ingestUpdater = new IngestUpdater[String](
+        stepName = "auditing bag",
+        messageSender = ingestsMessageSender
+      )
 
-                worker.run()
+      val outgoingPublisher = new OutgoingPublisher[String](
+        operationName = "auditing bag",
+        messageSender = outgoingMessageSender
+      )
 
-                testWith(worker)
-              }
-            }
+      withMonitoringClient { implicit monitoringClient =>
+        withBagAuditor { bagAuditor =>
+          val worker = new BagAuditorWorker(
+            alpakkaSQSWorkerConfig = createAlpakkaSQSWorkerConfig(queue),
+            bagAuditor = bagAuditor,
+            ingestUpdater = ingestUpdater,
+            outgoingPublisher = outgoingPublisher
+          )
+
+          worker.run()
+
+          testWith(worker)
         }
       }
     }

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/fixtures/VersionPickerFixtures.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/fixtures/VersionPickerFixtures.scala
@@ -3,20 +3,16 @@ package uk.ac.wellcome.platform.storage.bagauditor.fixtures
 import java.util.UUID
 
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.archive.common.versioning.{
-  IngestVersionManager,
-  IngestVersionManagerDao,
-  MemoryIngestVersionManagerDao
-}
+import uk.ac.wellcome.platform.archive.common.versioning.{IngestVersionManager, IngestVersionManagerDao, MemoryIngestVersionManagerDao}
 import uk.ac.wellcome.platform.storage.bagauditor.versioning.VersionPicker
 import uk.ac.wellcome.storage.{LockDao, LockingService}
-import uk.ac.wellcome.storage.fixtures.InMemoryLockDao
+import uk.ac.wellcome.storage.memory.MemoryLockDao
 
 import scala.util.Try
 
 trait VersionPickerFixtures {
   def withVersionPicker[R](testWith: TestWith[VersionPicker, R]): R =
-    withVersionPicker(new InMemoryLockDao()) { picker =>
+    withVersionPicker(new MemoryLockDao[String, UUID] {}) { picker =>
       testWith(picker)
     }
 

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/fixtures/VersionPickerFixtures.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/fixtures/VersionPickerFixtures.scala
@@ -3,7 +3,11 @@ package uk.ac.wellcome.platform.storage.bagauditor.fixtures
 import java.util.UUID
 
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.archive.common.versioning.{IngestVersionManager, IngestVersionManagerDao, MemoryIngestVersionManagerDao}
+import uk.ac.wellcome.platform.archive.common.versioning.{
+  IngestVersionManager,
+  IngestVersionManagerDao,
+  MemoryIngestVersionManagerDao
+}
 import uk.ac.wellcome.platform.storage.bagauditor.versioning.VersionPicker
 import uk.ac.wellcome.storage.{LockDao, LockingService}
 import uk.ac.wellcome.storage.memory.MemoryLockDao

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorTest.scala
@@ -6,7 +6,10 @@ import org.scalatest.{FunSpec, Matchers, TryValues}
 import uk.ac.wellcome.platform.archive.common.fixtures.BagLocationFixtures
 import uk.ac.wellcome.platform.archive.common.storage.models.IngestFailed
 import uk.ac.wellcome.platform.storage.bagauditor.fixtures.BagAuditorFixtures
-import uk.ac.wellcome.platform.storage.bagauditor.models.{AuditFailureSummary, AuditSuccessSummary}
+import uk.ac.wellcome.platform.storage.bagauditor.models.{
+  AuditFailureSummary,
+  AuditSuccessSummary
+}
 
 class BagAuditorTest
     extends FunSpec
@@ -42,7 +45,10 @@ class BagAuditorTest
 
   it("errors if it cannot find the bag root") {
     withLocalS3Bucket { bucket =>
-      withBag(storageBackend, namespace = bucket.name, bagRootDirectory = Some("1/2/3")) {
+      withBag(
+        storageBackend,
+        namespace = bucket.name,
+        bagRootDirectory = Some("1/2/3")) {
         case (_, storageSpace) =>
           withBagAuditor { bagAuditor =>
             val maybeAudit = bagAuditor.getAuditSummary(

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorTest.scala
@@ -7,7 +7,6 @@ import uk.ac.wellcome.platform.archive.common.fixtures.BagLocationFixtures
 import uk.ac.wellcome.platform.archive.common.storage.models.IngestFailed
 import uk.ac.wellcome.platform.storage.bagauditor.fixtures.BagAuditorFixtures
 import uk.ac.wellcome.platform.storage.bagauditor.models.{AuditFailureSummary, AuditSuccessSummary}
-import uk.ac.wellcome.storage.s3.S3StorageBackend
 
 class BagAuditorTest
     extends FunSpec
@@ -16,12 +15,10 @@ class BagAuditorTest
     with BagLocationFixtures
     with BagAuditorFixtures {
 
-  val s3Backend: S3StorageBackend = new S3StorageBackend(s3Client)
-
   it("gets the audit information for a valid bag") {
     withLocalS3Bucket { bucket =>
       val bagInfo = createBagInfo
-      withBag(s3Backend, namespace = bucket.name, bagInfo = bagInfo) {
+      withBag(storageBackend, namespace = bucket.name, bagInfo = bagInfo) {
         case (bagRootLocation, storageSpace) =>
           withBagAuditor { bagAuditor =>
             val maybeAudit = bagAuditor.getAuditSummary(
@@ -45,7 +42,7 @@ class BagAuditorTest
 
   it("errors if it cannot find the bag root") {
     withLocalS3Bucket { bucket =>
-      withBag(s3Backend, namespace = bucket.name, bagRootDirectory = Some("1/2/3")) {
+      withBag(storageBackend, namespace = bucket.name, bagRootDirectory = Some("1/2/3")) {
         case (_, storageSpace) =>
           withBagAuditor { bagAuditor =>
             val maybeAudit = bagAuditor.getAuditSummary(
@@ -66,7 +63,7 @@ class BagAuditorTest
 
   it("errors if it cannot find the bag identifier") {
     withLocalS3Bucket { bucket =>
-      withBag(s3Backend, namespace = bucket.name) {
+      withBag(storageBackend, namespace = bucket.name) {
         case (bagRootLocation, storageSpace) =>
           withBagAuditor { bagAuditor =>
             val bagInfoLocation = bagRootLocation.join("bag-info.txt")

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/versioning/VersionPickerTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/versioning/VersionPickerTest.scala
@@ -6,7 +6,7 @@ import java.util.UUID
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.common.generators.ExternalIdentifierGenerators
 import uk.ac.wellcome.platform.storage.bagauditor.fixtures.VersionPickerFixtures
-import uk.ac.wellcome.storage.fixtures.InMemoryLockDao
+import uk.ac.wellcome.storage.memory.MemoryLockDao
 import uk.ac.wellcome.storage.{LockDao, LockFailure, UnlockFailure}
 
 import scala.util.{Failure, Success}
@@ -104,7 +104,7 @@ class VersionPickerTest
   }
 
   it("locks around the ingest ID and external identifiers") {
-    val lockDao = new InMemoryLockDao()
+    val lockDao = new MemoryLockDao[String, UUID] {}
 
     withVersionPicker(lockDao) { picker =>
       val ingestId = createIngestID

--- a/bag_register/docker-compose.yml
+++ b/bag_register/docker-compose.yml
@@ -1,7 +1,3 @@
-sns:
-  image: wellcome/fake-sns
-  ports:
-    - "9292:9292"
 sqs:
   image: s12v/elasticmq
   ports:
@@ -11,7 +7,3 @@ s3:
   image: scality/s3server:mem-latest
   ports:
     - "33333:8000"
-dynamodb:
-  image: peopleperhour/dynamodb
-  ports:
-    - "45678:8000"

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/Main.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/Main.scala
@@ -6,13 +6,27 @@ import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.typesafe.config.Config
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.typesafe.{AlpakkaSqsWorkerConfigBuilder, CloudwatchMonitoringClientBuilder, SQSBuilder}
+import uk.ac.wellcome.messaging.typesafe.{
+  AlpakkaSqsWorkerConfigBuilder,
+  CloudwatchMonitoringClientBuilder,
+  SQSBuilder
+}
 import uk.ac.wellcome.messaging.worker.monitoring.CloudwatchMonitoringClient
-import uk.ac.wellcome.platform.archive.bag_register.services.{BagRegisterWorker, Register}
-import uk.ac.wellcome.platform.archive.common.config.builders.{IngestUpdaterBuilder, OperationNameBuilder, OutgoingPublisherBuilder}
+import uk.ac.wellcome.platform.archive.bag_register.services.{
+  BagRegisterWorker,
+  Register
+}
+import uk.ac.wellcome.platform.archive.common.config.builders.{
+  IngestUpdaterBuilder,
+  OperationNameBuilder,
+  OutgoingPublisherBuilder
+}
 import uk.ac.wellcome.platform.archive.common.dynamo._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
-import uk.ac.wellcome.platform.archive.common.storage.services.{StorageManifestService, StorageManifestVHS}
+import uk.ac.wellcome.platform.archive.common.storage.services.{
+  StorageManifestService,
+  StorageManifestVHS
+}
 import uk.ac.wellcome.storage.StorageBackend
 import uk.ac.wellcome.storage.s3.S3StorageBackend
 import uk.ac.wellcome.storage.typesafe.{S3Builder, VHSBuilder}
@@ -39,12 +53,14 @@ object Main extends WellcomeTypesafeApp {
     implicit val sqsClient: AmazonSQSAsync =
       SQSBuilder.buildSQSAsyncClient(config)
 
-    implicit val s3StorageBackend: StorageBackend = new S3StorageBackend(s3Client)
+    implicit val s3StorageBackend: StorageBackend =
+      new S3StorageBackend(s3Client)
 
     val storageManifestService = new StorageManifestService()
 
     val storageManifestVHS = new StorageManifestVHS(
-      underlying = VHSBuilder.buildVHS[String, StorageManifest, EmptyMetadata](config)
+      underlying =
+        VHSBuilder.buildVHS[String, StorageManifest, EmptyMetadata](config)
     )
 
     val operationName = OperationNameBuilder

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/Main.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/Main.scala
@@ -6,26 +6,15 @@ import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.typesafe.config.Config
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.typesafe.{
-  AlpakkaSqsWorkerConfigBuilder,
-  CloudwatchMonitoringClientBuilder,
-  SQSBuilder
-}
+import uk.ac.wellcome.messaging.typesafe.{AlpakkaSqsWorkerConfigBuilder, CloudwatchMonitoringClientBuilder, SQSBuilder}
 import uk.ac.wellcome.messaging.worker.monitoring.CloudwatchMonitoringClient
-import uk.ac.wellcome.platform.archive.bag_register.services.{
-  BagRegisterWorker,
-  Register
-}
-import uk.ac.wellcome.platform.archive.common.config.builders.{
-  IngestUpdaterBuilder,
-  OperationNameBuilder,
-  OutgoingPublisherBuilder
-}
+import uk.ac.wellcome.platform.archive.bag_register.services.{BagRegisterWorker, Register}
+import uk.ac.wellcome.platform.archive.common.config.builders.{IngestUpdaterBuilder, OperationNameBuilder, OutgoingPublisherBuilder}
+import uk.ac.wellcome.platform.archive.common.dynamo._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
-import uk.ac.wellcome.platform.archive.common.storage.services.{
-  StorageManifestService,
-  StorageManifestVHS
-}
+import uk.ac.wellcome.platform.archive.common.storage.services.{StorageManifestService, StorageManifestVHS}
+import uk.ac.wellcome.storage.StorageBackend
+import uk.ac.wellcome.storage.s3.S3StorageBackend
 import uk.ac.wellcome.storage.typesafe.{S3Builder, VHSBuilder}
 import uk.ac.wellcome.storage.vhs.EmptyMetadata
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
@@ -50,10 +39,12 @@ object Main extends WellcomeTypesafeApp {
     implicit val sqsClient: AmazonSQSAsync =
       SQSBuilder.buildSQSAsyncClient(config)
 
+    implicit val s3StorageBackend: StorageBackend = new S3StorageBackend(s3Client)
+
     val storageManifestService = new StorageManifestService()
 
     val storageManifestVHS = new StorageManifestVHS(
-      underlying = VHSBuilder.buildVHS[StorageManifest, EmptyMetadata](config)
+      underlying = VHSBuilder.buildVHS[String, StorageManifest, EmptyMetadata](config)
     )
 
     val operationName = OperationNameBuilder

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorker.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorker.scala
@@ -4,10 +4,7 @@ import akka.actor.ActorSystem
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.sqsworker.alpakka.{
-  AlpakkaSQSWorker,
-  AlpakkaSQSWorkerConfig
-}
+import uk.ac.wellcome.messaging.sqsworker.alpakka.{AlpakkaSQSWorker, AlpakkaSQSWorkerConfig}
 import uk.ac.wellcome.messaging.worker.models.Result
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
 import uk.ac.wellcome.platform.archive.bag_register.models.RegistrationSummary
@@ -17,16 +14,16 @@ import uk.ac.wellcome.platform.archive.common.operation.services.OutgoingPublish
 import uk.ac.wellcome.platform.archive.common.storage.models.IngestStepWorker
 import uk.ac.wellcome.typesafe.Runnable
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
+import scala.util.Try
 
-class BagRegisterWorker(
+class BagRegisterWorker[IngestsDestination, OutgoingDestination](
   alpakkaSQSWorkerConfig: AlpakkaSQSWorkerConfig,
-  ingestUpdater: IngestUpdater,
-  outgoingPublisher: OutgoingPublisher,
+  ingestUpdater: IngestUpdater[IngestsDestination],
+  outgoingPublisher: OutgoingPublisher[OutgoingDestination],
   register: Register
 )(implicit
   actorSystem: ActorSystem,
-  ec: ExecutionContext,
   mc: MonitoringClient,
   sc: AmazonSQSAsync)
     extends Runnable
@@ -36,11 +33,11 @@ class BagRegisterWorker(
   private val worker =
     AlpakkaSQSWorker[BagInformationPayload, RegistrationSummary](
       alpakkaSQSWorkerConfig) {
-      processMessage
+      payload => Future.fromTry { processMessage(payload) }
     }
 
   def processMessage(
-    payload: BagInformationPayload): Future[Result[RegistrationSummary]] =
+    payload: BagInformationPayload): Try[Result[RegistrationSummary]] =
     for {
       _ <- ingestUpdater.start(payload.ingestId)
 

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorker.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorker.scala
@@ -4,7 +4,10 @@ import akka.actor.ActorSystem
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.sqsworker.alpakka.{AlpakkaSQSWorker, AlpakkaSQSWorkerConfig}
+import uk.ac.wellcome.messaging.sqsworker.alpakka.{
+  AlpakkaSQSWorker,
+  AlpakkaSQSWorkerConfig
+}
 import uk.ac.wellcome.messaging.worker.models.Result
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
 import uk.ac.wellcome.platform.archive.bag_register.models.RegistrationSummary
@@ -32,8 +35,8 @@ class BagRegisterWorker[IngestsDestination, OutgoingDestination](
 
   private val worker =
     AlpakkaSQSWorker[BagInformationPayload, RegistrationSummary](
-      alpakkaSQSWorkerConfig) {
-      payload => Future.fromTry { processMessage(payload) }
+      alpakkaSQSWorkerConfig) { payload =>
+      Future.fromTry { processMessage(payload) }
     }
 
   def processMessage(

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/Register.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/Register.scala
@@ -3,8 +3,16 @@ package uk.ac.wellcome.platform.archive.bag_register.services
 import java.time.Instant
 
 import uk.ac.wellcome.platform.archive.bag_register.models.RegistrationSummary
-import uk.ac.wellcome.platform.archive.common.storage.models.{IngestCompleted, IngestFailed, IngestStepResult, StorageSpace}
-import uk.ac.wellcome.platform.archive.common.storage.services.{StorageManifestService, StorageManifestVHS}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  IngestCompleted,
+  IngestFailed,
+  IngestStepResult,
+  StorageSpace
+}
+import uk.ac.wellcome.platform.archive.common.storage.services.{
+  StorageManifestService,
+  StorageManifestVHS
+}
 import uk.ac.wellcome.storage.ObjectLocation
 
 import scala.util.{Failure, Success, Try}
@@ -35,11 +43,11 @@ class Register(
 
       completedRegistration <- storageManifestVHS
         .updateRecord(manifest)(_ => manifest) match {
-          case Success(_) =>
-            Success(IngestCompleted(registrationWithBagId.complete))
-          case Failure(e) =>
-            Success(IngestFailed(registrationWithBagId.complete, e))
-        }
+        case Success(_) =>
+          Success(IngestCompleted(registrationWithBagId.complete))
+        case Failure(e) =>
+          Success(IngestFailed(registrationWithBagId.complete, e))
+      }
 
     } yield completedRegistration
   }

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/BagRegisterFeatureTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/BagRegisterFeatureTest.scala
@@ -8,8 +8,15 @@ import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.platform.archive.bag_register.fixtures.BagRegisterFixtures
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
 import uk.ac.wellcome.platform.archive.common.fixtures.BagLocationFixtures
-import uk.ac.wellcome.platform.archive.common.generators.{BagInfoGenerators, IngestOperationGenerators, PayloadGenerators}
-import uk.ac.wellcome.platform.archive.common.ingests.models.{InfrequentAccessStorageProvider, StorageLocation}
+import uk.ac.wellcome.platform.archive.common.generators.{
+  BagInfoGenerators,
+  IngestOperationGenerators,
+  PayloadGenerators
+}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  InfrequentAccessStorageProvider,
+  StorageLocation
+}
 import uk.ac.wellcome.storage.memory.MemoryStorageBackend
 
 class BagRegisterFeatureTest

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
@@ -5,15 +5,29 @@ import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
-import uk.ac.wellcome.platform.archive.bag_register.services.{BagRegisterWorker, Register}
+import uk.ac.wellcome.platform.archive.bag_register.services.{
+  BagRegisterWorker,
+  Register
+}
 import uk.ac.wellcome.platform.archive.common.IngestID
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
-import uk.ac.wellcome.platform.archive.common.fixtures.{MonitoringClientFixture, OperationFixtures, RandomThings, StorageManifestVHSFixture}
+import uk.ac.wellcome.platform.archive.common.fixtures.{
+  MonitoringClientFixture,
+  OperationFixtures,
+  RandomThings,
+  StorageManifestVHSFixture
+}
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestStatusUpdate}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  Ingest,
+  IngestStatusUpdate
+}
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services.OutgoingPublisher
-import uk.ac.wellcome.platform.archive.common.storage.services.{StorageManifestService, StorageManifestVHS}
+import uk.ac.wellcome.platform.archive.common.storage.services.{
+  StorageManifestService,
+  StorageManifestVHS
+}
 import uk.ac.wellcome.storage.StorageBackend
 import uk.ac.wellcome.storage.memory.MemoryStorageBackend
 
@@ -25,13 +39,16 @@ trait BagRegisterFixtures
     with MonitoringClientFixture
     with IngestUpdateAssertions {
 
-  type Fixtures = (BagRegisterWorker[String, String], StorageManifestVHS, MemoryMessageSender, MemoryMessageSender, QueuePair)
+  type Fixtures = (BagRegisterWorker[String, String],
+                   StorageManifestVHS,
+                   MemoryMessageSender,
+                   MemoryMessageSender,
+                   QueuePair)
 
   def withBagRegisterWorker[R](
     storageBackend: StorageBackend = new MemoryStorageBackend(),
     vhs: StorageManifestVHS = createStorageManifestVHS()
-  )(
-    testWith: TestWith[Fixtures, R]): R =
+  )(testWith: TestWith[Fixtures, R]): R =
     withActorSystem { implicit actorSystem =>
       withMonitoringClient { implicit monitoringClient =>
         val ingests = createMessageSender
@@ -70,8 +87,8 @@ trait BagRegisterFixtures
       }
     }
 
-  def assertBagRegisterSucceeded(ingests: MemoryMessageSender)(ingestId: IngestID,
-                                 bagId: BagId): Assertion =
+  def assertBagRegisterSucceeded(
+    ingests: MemoryMessageSender)(ingestId: IngestID, bagId: BagId): Assertion =
     assertReceivesIngestUpdates(ingests)(ingestId) { ingestUpdates =>
       ingestUpdates.size shouldBe 2
 
@@ -85,8 +102,8 @@ trait BagRegisterFixtures
       ingestCompleted.events.head.description shouldBe "Register succeeded (completed)"
     }
 
-  def assertBagRegisterFailed(ingests: MemoryMessageSender)(ingestId: IngestID,
-                              bagId: BagId): Assertion =
+  def assertBagRegisterFailed(
+    ingests: MemoryMessageSender)(ingestId: IngestID, bagId: BagId): Assertion =
     assertReceivesIngestUpdates(ingests)(ingestId) { ingestUpdates =>
       ingestUpdates.size shouldBe 2
 

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
@@ -2,31 +2,19 @@ package uk.ac.wellcome.platform.archive.bag_register.fixtures
 
 import org.scalatest.Assertion
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.messaging.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
-import uk.ac.wellcome.platform.archive.bag_register.services.{
-  BagRegisterWorker,
-  Register
-}
+import uk.ac.wellcome.messaging.memory.MemoryMessageSender
+import uk.ac.wellcome.platform.archive.bag_register.services.{BagRegisterWorker, Register}
 import uk.ac.wellcome.platform.archive.common.IngestID
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
-import uk.ac.wellcome.platform.archive.common.fixtures.{
-  MonitoringClientFixture,
-  OperationFixtures,
-  RandomThings,
-  StorageManifestVHSFixture
-}
+import uk.ac.wellcome.platform.archive.common.fixtures.{MonitoringClientFixture, OperationFixtures, RandomThings, StorageManifestVHSFixture}
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  Ingest,
-  IngestStatusUpdate
-}
-import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestService
-import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
-import uk.ac.wellcome.storage.fixtures.S3.Bucket
-
-import scala.concurrent.ExecutionContext.Implicits.global
+import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestStatusUpdate}
+import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
+import uk.ac.wellcome.platform.archive.common.operation.services.OutgoingPublisher
+import uk.ac.wellcome.platform.archive.common.storage.services.{StorageManifestService, StorageManifestVHS}
+import uk.ac.wellcome.storage.fixtures.S3
 
 trait BagRegisterFixtures
     extends RandomThings
@@ -34,73 +22,63 @@ trait BagRegisterFixtures
     with OperationFixtures
     with StorageManifestVHSFixture
     with MonitoringClientFixture
-    with IngestUpdateAssertions {
+    with IngestUpdateAssertions
+    with S3 {
 
-  type Fixtures = (BagRegisterWorker, Table, Bucket, Topic, Topic, QueuePair)
+  type Fixtures = (BagRegisterWorker[String, String], StorageManifestVHS, MemoryMessageSender, MemoryMessageSender, QueuePair)
 
-  def withBagRegisterWorkerAndBucket[R](userBucket: Bucket)(
+  def withBagRegisterWorker[R](
+    storageManifestVHS: StorageManifestVHS = createStorageManifestVHS()
+  )(
     testWith: TestWith[Fixtures, R]): R =
     withActorSystem { implicit actorSystem =>
       withMonitoringClient { implicit monitoringClient =>
-        withLocalDynamoDbTable { table =>
-          withLocalSnsTopic { ingestTopic =>
-            withLocalSnsTopic { outgoingTopic =>
-              withLocalSqsQueueAndDlq { queuePair =>
-                withLocalS3Bucket { bucket =>
-                  withStorageManifestVHS(table, userBucket) {
-                    storageManifestVHS =>
-                      val storageManifestService =
-                        new StorageManifestService()
+        val ingests = createMessageSender
+        val outgoing = createMessageSender
 
-                      val register = new Register(
-                        storageManifestService,
-                        storageManifestVHS
-                      )
-                      withIngestUpdater("register", ingestTopic) {
-                        ingestUpdater =>
-                          withOutgoingPublisher("register", outgoingTopic) {
-                            outgoingPublisher =>
-                              val service = new BagRegisterWorker(
-                                alpakkaSQSWorkerConfig =
-                                  createAlpakkaSQSWorkerConfig(queuePair.queue),
-                                ingestUpdater = ingestUpdater,
-                                outgoingPublisher = outgoingPublisher,
-                                register = register
-                              )
+        withLocalSqsQueueAndDlq { queuePair =>
+          val storageManifestService =
+            new StorageManifestService()
 
-                              service.run()
+          val register = new Register(
+            storageManifestService = storageManifestService,
+            storageManifestVHS = storageManifestVHS
+          )
 
-                              testWith(
-                                (
-                                  service,
-                                  table,
-                                  bucket,
-                                  ingestTopic,
-                                  outgoingTopic,
-                                  queuePair)
-                              )
-                          }
-                      }
-                  }
-                }
-              }
-            }
-          }
+          val ingestUpdater = new IngestUpdater[String](
+            stepName = "register",
+            messageSender = ingests
+          )
+          val outgoingPublisher = new OutgoingPublisher[String](
+            operationName = "register",
+            messageSender = outgoing
+          )
+
+          val service = new BagRegisterWorker(
+            alpakkaSQSWorkerConfig =
+              createAlpakkaSQSWorkerConfig(queuePair.queue),
+            ingestUpdater = ingestUpdater,
+            outgoingPublisher = outgoingPublisher,
+            register = register
+          )
+
+          service.run()
+
+          testWith(
+            (
+              service,
+              storageManifestVHS,
+              ingests,
+              outgoing,
+              queuePair)
+          )
         }
       }
     }
 
-  def withBagRegisterWorker[R](testWith: TestWith[Fixtures, R]): R =
-    withLocalS3Bucket { bucket =>
-      withBagRegisterWorkerAndBucket(bucket) { fixtures =>
-        testWith(fixtures)
-      }
-    }
-
-  def assertBagRegisterSucceeded(ingestId: IngestID,
-                                 ingestTopic: Topic,
+  def assertBagRegisterSucceeded(ingests: MemoryMessageSender)(ingestId: IngestID,
                                  bagId: BagId): Assertion =
-    assertTopicReceivesIngestUpdates(ingestId, ingestTopic) { ingestUpdates =>
+    assertReceivesIngestUpdates(ingests)(ingestId) { ingestUpdates =>
       ingestUpdates.size shouldBe 2
 
       val ingestStart = ingestUpdates.head
@@ -113,10 +91,9 @@ trait BagRegisterFixtures
       ingestCompleted.events.head.description shouldBe "Register succeeded (completed)"
     }
 
-  def assertBagRegisterFailed(ingestId: IngestID,
-                              ingestTopic: Topic,
+  def assertBagRegisterFailed(ingests: MemoryMessageSender)(ingestId: IngestID,
                               bagId: BagId): Assertion =
-    assertTopicReceivesIngestUpdates(ingestId, ingestTopic) { ingestUpdates =>
+    assertReceivesIngestUpdates(ingests)(ingestId) { ingestUpdates =>
       ingestUpdates.size shouldBe 2
 
       val ingestStart = ingestUpdates.head

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
@@ -6,8 +6,14 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.bag_register.fixtures.BagRegisterFixtures
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
 import uk.ac.wellcome.platform.archive.common.fixtures.BagLocationFixtures
-import uk.ac.wellcome.platform.archive.common.generators.{BagInfoGenerators, PayloadGenerators}
-import uk.ac.wellcome.platform.archive.common.ingests.models.{InfrequentAccessStorageProvider, StorageLocation}
+import uk.ac.wellcome.platform.archive.common.generators.{
+  BagInfoGenerators,
+  PayloadGenerators
+}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  InfrequentAccessStorageProvider,
+  StorageLocation
+}
 import uk.ac.wellcome.storage.memory.MemoryStorageBackend
 
 import scala.util.Success

--- a/bag_replicator/docker-compose.yml
+++ b/bag_replicator/docker-compose.yml
@@ -3,10 +3,6 @@ sqs:
   ports:
     - "9324:9324"
     - "4789:9324"
-sns:
-  image: wellcome/fake-sns
-  ports:
-    - "9292:9292"
 s3:
   image: "zenko/cloudserver:8.1.8"
   environment:

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/Main.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/Main.scala
@@ -5,13 +5,24 @@ import akka.stream.ActorMaterializer
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.typesafe.config.Config
-import uk.ac.wellcome.messaging.typesafe.{AlpakkaSqsWorkerConfigBuilder, CloudwatchMonitoringClientBuilder, SQSBuilder}
+import uk.ac.wellcome.messaging.typesafe.{
+  AlpakkaSqsWorkerConfigBuilder,
+  CloudwatchMonitoringClientBuilder,
+  SQSBuilder
+}
 import uk.ac.wellcome.messaging.worker.models.Result
 import uk.ac.wellcome.messaging.worker.monitoring.CloudwatchMonitoringClient
 import uk.ac.wellcome.platform.archive.bagreplicator.config.ReplicatorDestinationConfig
 import uk.ac.wellcome.platform.archive.bagreplicator.models.ReplicationSummary
-import uk.ac.wellcome.platform.archive.bagreplicator.services.{BagReplicator, BagReplicatorWorker}
-import uk.ac.wellcome.platform.archive.common.config.builders.{IngestUpdaterBuilder, OperationNameBuilder, OutgoingPublisherBuilder}
+import uk.ac.wellcome.platform.archive.bagreplicator.services.{
+  BagReplicator,
+  BagReplicatorWorker
+}
+import uk.ac.wellcome.platform.archive.common.config.builders.{
+  IngestUpdaterBuilder,
+  OperationNameBuilder,
+  OutgoingPublisherBuilder
+}
 import uk.ac.wellcome.storage.typesafe.{LockingBuilder, S3Builder}
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/Main.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/Main.scala
@@ -5,29 +5,19 @@ import akka.stream.ActorMaterializer
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.typesafe.config.Config
-import uk.ac.wellcome.messaging.typesafe.{
-  AlpakkaSqsWorkerConfigBuilder,
-  CloudwatchMonitoringClientBuilder,
-  SQSBuilder
-}
+import uk.ac.wellcome.messaging.typesafe.{AlpakkaSqsWorkerConfigBuilder, CloudwatchMonitoringClientBuilder, SQSBuilder}
 import uk.ac.wellcome.messaging.worker.models.Result
 import uk.ac.wellcome.messaging.worker.monitoring.CloudwatchMonitoringClient
 import uk.ac.wellcome.platform.archive.bagreplicator.config.ReplicatorDestinationConfig
 import uk.ac.wellcome.platform.archive.bagreplicator.models.ReplicationSummary
-import uk.ac.wellcome.platform.archive.bagreplicator.services.{
-  BagReplicator,
-  BagReplicatorWorker
-}
-import uk.ac.wellcome.platform.archive.common.config.builders.{
-  IngestUpdaterBuilder,
-  OperationNameBuilder,
-  OutgoingPublisherBuilder
-}
+import uk.ac.wellcome.platform.archive.bagreplicator.services.{BagReplicator, BagReplicatorWorker}
+import uk.ac.wellcome.platform.archive.common.config.builders.{IngestUpdaterBuilder, OperationNameBuilder, OutgoingPublisherBuilder}
 import uk.ac.wellcome.storage.typesafe.{LockingBuilder, S3Builder}
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 
-import scala.concurrent.{ExecutionContextExecutor, Future}
+import scala.concurrent.ExecutionContextExecutor
+import scala.util.Try
 
 object Main extends WellcomeTypesafeApp {
   runWithConfig { config: Config =>
@@ -49,7 +39,7 @@ object Main extends WellcomeTypesafeApp {
       .getName(config, default = "replicating")
 
     val lockingService = LockingBuilder
-      .buildDynamoLockingService[Result[ReplicationSummary], Future](config)
+      .buildDynamoLockingService[Result[ReplicationSummary], Try](config)
 
     new BagReplicatorWorker(
       alpakkaSQSWorkerConfig = AlpakkaSqsWorkerConfigBuilder.build(config),

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicator.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicator.scala
@@ -4,7 +4,12 @@ import java.time.Instant
 
 import com.amazonaws.services.s3.AmazonS3
 import uk.ac.wellcome.platform.archive.bagreplicator.models.ReplicationSummary
-import uk.ac.wellcome.platform.archive.common.storage.models.{IngestFailed, IngestStepResult, IngestStepSucceeded, StorageSpace}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  IngestFailed,
+  IngestStepResult,
+  IngestStepSucceeded,
+  StorageSpace
+}
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.s3.S3PrefixCopier
 
@@ -13,10 +18,10 @@ import scala.util.{Failure, Success, Try}
 class BagReplicator(implicit s3Client: AmazonS3) {
   val s3PrefixCopier = S3PrefixCopier(s3Client)
 
-  def replicate(bagRootLocation: ObjectLocation,
-                storageSpace: StorageSpace,
-                destination: ObjectLocation)
-    : Try[IngestStepResult[ReplicationSummary]] = {
+  def replicate(
+    bagRootLocation: ObjectLocation,
+    storageSpace: StorageSpace,
+    destination: ObjectLocation): Try[IngestStepResult[ReplicationSummary]] = {
     val replicationSummary = ReplicationSummary(
       startTime = Instant.now(),
       bagRootLocation = bagRootLocation,

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicator.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicator.scala
@@ -4,25 +4,19 @@ import java.time.Instant
 
 import com.amazonaws.services.s3.AmazonS3
 import uk.ac.wellcome.platform.archive.bagreplicator.models.ReplicationSummary
-import uk.ac.wellcome.platform.archive.common.storage.models.{
-  IngestFailed,
-  IngestStepResult,
-  IngestStepSucceeded,
-  StorageSpace
-}
+import uk.ac.wellcome.platform.archive.common.storage.models.{IngestFailed, IngestStepResult, IngestStepSucceeded, StorageSpace}
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.s3.S3PrefixCopier
 
-import scala.concurrent.{ExecutionContext, Future}
-import scala.util.{Failure, Success}
+import scala.util.{Failure, Success, Try}
 
-class BagReplicator(implicit s3Client: AmazonS3, ec: ExecutionContext) {
+class BagReplicator(implicit s3Client: AmazonS3) {
   val s3PrefixCopier = S3PrefixCopier(s3Client)
 
   def replicate(bagRootLocation: ObjectLocation,
                 storageSpace: StorageSpace,
                 destination: ObjectLocation)
-    : Future[IngestStepResult[ReplicationSummary]] = {
+    : Try[IngestStepResult[ReplicationSummary]] = {
     val replicationSummary = ReplicationSummary(
       startTime = Instant.now(),
       bagRootLocation = bagRootLocation,
@@ -37,7 +31,7 @@ class BagReplicator(implicit s3Client: AmazonS3, ec: ExecutionContext) {
           dstLocationPrefix = destination
         )
 
-    copyResult.transform {
+    copyResult match {
       case Success(_) =>
         Success(
           IngestStepSucceeded(

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
@@ -9,7 +9,10 @@ import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.amazonaws.services.sqs.model.{Message => SQSMessage}
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.sqsworker.alpakka.{AlpakkaSQSWorker, AlpakkaSQSWorkerConfig}
+import uk.ac.wellcome.messaging.sqsworker.alpakka.{
+  AlpakkaSQSWorker,
+  AlpakkaSQSWorkerConfig
+}
 import uk.ac.wellcome.messaging.worker.models.{NonDeterministicFailure, Result}
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
 import uk.ac.wellcome.platform.archive.bagreplicator.config.ReplicatorDestinationConfig
@@ -44,7 +47,8 @@ class BagReplicatorWorker[IngestsDestination, OutgoingDestination](
     new AlpakkaSQSWorker[
       BagInformationPayload,
       ReplicationSummary,
-      MonitoringClient](alpakkaSQSWorkerConfig)(payload => Future.fromTry(processMessage(payload))) {
+      MonitoringClient](alpakkaSQSWorkerConfig)(payload =>
+      Future.fromTry(processMessage(payload))) {
 
       // TODO: This is hard-coded, read it from config!
       override val retryAction = (message: SQSMessage) =>
@@ -73,9 +77,8 @@ class BagReplicatorWorker[IngestsDestination, OutgoingDestination](
       result <- replicate(payload, destination)
     } yield result
 
-  def replicate(
-    payload: BagInformationPayload,
-    destination: ObjectLocation): Try[Result[ReplicationSummary]] =
+  def replicate(payload: BagInformationPayload,
+                destination: ObjectLocation): Try[Result[ReplicationSummary]] =
     lockingService
       .withLock(destination.toString) {
         for {

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
@@ -54,9 +54,7 @@ class BagReplicatorFeatureTest
                     bagRootLocation = expectedDst
                   )
 
-                  outgoing.messages
-                    .map { _.body }
-                    .map { fromJson[BagInformationPayload](_).get } shouldBe Seq(expectedPayload)
+                  outgoing.getMessages[BagInformationPayload]() shouldBe Seq(expectedPayload)
 
                   verifyBagCopied(
                     src = srcBagRootLocation,

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
@@ -28,7 +28,11 @@ class BagReplicatorFeatureTest
         val outgoing = createMessageSender
 
         withLocalSqsQueue { queue =>
-          withBagReplicatorWorker(queue, ingests, outgoing, config = destination) { _ =>
+          withBagReplicatorWorker(
+            queue,
+            ingests,
+            outgoing,
+            config = destination) { _ =>
             withBag(storageBackend, namespace = ingestsBucket.name) {
               case (srcBagRootLocation, _) =>
                 val payload = createBagInformationPayloadWith(
@@ -54,7 +58,8 @@ class BagReplicatorFeatureTest
                     bagRootLocation = expectedDst
                   )
 
-                  outgoing.getMessages[BagInformationPayload]() shouldBe Seq(expectedPayload)
+                  outgoing.getMessages[BagInformationPayload]() shouldBe Seq(
+                    expectedPayload)
 
                   verifyBagCopied(
                     src = srcBagRootLocation,

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
@@ -2,10 +2,10 @@ package uk.ac.wellcome.platform.archive.bagreplicator
 
 import java.nio.file.Paths
 
-import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.bagreplicator.fixtures.BagReplicatorFixtures
+import uk.ac.wellcome.platform.archive.common.BagInformationPayload
 import uk.ac.wellcome.platform.archive.common.fixtures.BagLocationFixtures
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
@@ -14,7 +14,6 @@ import uk.ac.wellcome.storage.ObjectLocation
 class BagReplicatorFeatureTest
     extends FunSpec
     with Matchers
-    with ScalaFutures
     with BagLocationFixtures
     with BagReplicatorFixtures
     with IngestUpdateAssertions
@@ -25,57 +24,53 @@ class BagReplicatorFeatureTest
       withLocalS3Bucket { archiveBucket =>
         val destination = createReplicatorDestinationConfigWith(archiveBucket)
 
+        val ingests = createMessageSender
+        val outgoing = createMessageSender
+
         withLocalSqsQueue { queue =>
-          withLocalSnsTopic { ingestTopic =>
-            withLocalSnsTopic { outgoingTopic =>
-              withBagReplicatorWorker(
-                queue,
-                ingestTopic = ingestTopic,
-                outgoingTopic = outgoingTopic,
-                config = destination) { _ =>
-                withBag(ingestsBucket) {
-                  case (srcBagRootLocation, _) =>
-                    val payload = createBagInformationPayloadWith(
-                      bagRootLocation = srcBagRootLocation
+          withBagReplicatorWorker(queue, ingests, outgoing, config = destination) { _ =>
+            withBag(storageBackend, namespace = ingestsBucket.name) {
+              case (srcBagRootLocation, _) =>
+                val payload = createBagInformationPayloadWith(
+                  bagRootLocation = srcBagRootLocation
+                )
+
+                sendNotificationToSQS(queue, payload)
+
+                eventually {
+                  val expectedDst = ObjectLocation(
+                    namespace = destination.namespace,
+                    key = Paths
+                      .get(
+                        destination.rootPath.getOrElse(""),
+                        payload.storageSpace.toString,
+                        payload.externalIdentifier.toString,
+                        s"v${payload.version}"
+                      )
+                      .toString
+                  )
+
+                  val expectedPayload = payload.copy(
+                    bagRootLocation = expectedDst
+                  )
+
+                  outgoing.messages
+                    .map { _.body }
+                    .map { fromJson[BagInformationPayload](_).get } shouldBe Seq(expectedPayload)
+
+                  verifyBagCopied(
+                    src = srcBagRootLocation,
+                    dst = expectedDst
+                  )
+
+                  assertReceivesIngestEvents(ingests)(
+                    payload.ingestId,
+                    expectedDescriptions = Seq(
+                      "Replicating started",
+                      "Replicating succeeded"
                     )
-
-                    sendNotificationToSQS(queue, payload)
-
-                    eventually {
-                      val expectedDst = ObjectLocation(
-                        namespace = destination.namespace,
-                        key = Paths
-                          .get(
-                            destination.rootPath.getOrElse(""),
-                            payload.storageSpace.toString,
-                            payload.externalIdentifier.toString,
-                            s"v${payload.version}"
-                          )
-                          .toString
-                      )
-
-                      val expectedPayload = payload.copy(
-                        bagRootLocation = expectedDst
-                      )
-
-                      assertSnsReceivesOnly(expectedPayload, outgoingTopic)
-
-                      verifyBagCopied(
-                        src = srcBagRootLocation,
-                        dst = expectedDst
-                      )
-
-                      assertTopicReceivesIngestEvents(
-                        payload.ingestId,
-                        ingestTopic,
-                        expectedDescriptions = Seq(
-                          "Replicating started",
-                          "Replicating succeeded"
-                        )
-                      )
-                    }
+                  )
                 }
-              }
             }
           }
         }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
@@ -13,8 +13,15 @@ import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.messaging.worker.models.Result
 import uk.ac.wellcome.platform.archive.bagreplicator.config.ReplicatorDestinationConfig
 import uk.ac.wellcome.platform.archive.bagreplicator.models.ReplicationSummary
-import uk.ac.wellcome.platform.archive.bagreplicator.services.{BagReplicator, BagReplicatorWorker}
-import uk.ac.wellcome.platform.archive.common.fixtures.{BagLocationFixtures, MonitoringClientFixture, OperationFixtures}
+import uk.ac.wellcome.platform.archive.bagreplicator.services.{
+  BagReplicator,
+  BagReplicatorWorker
+}
+import uk.ac.wellcome.platform.archive.common.fixtures.{
+  BagLocationFixtures,
+  MonitoringClientFixture,
+  OperationFixtures
+}
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services.OutgoingPublisher
 import uk.ac.wellcome.storage.fixtures.LockingServiceFixtures
@@ -69,8 +76,9 @@ trait BagReplicatorFixtures
       subject = randomAlphanumeric()
     )
 
-    withBagReplicatorWorker(defaultQueue, messageSender, messageSender, config) { worker =>
-      testWith(worker)
+    withBagReplicatorWorker(defaultQueue, messageSender, messageSender, config) {
+      worker =>
+        testWith(worker)
     }
   }
 
@@ -80,18 +88,17 @@ trait BagReplicatorFixtures
     testWith: TestWith[BagReplicatorWorker[String, String], R]
   ): R = {
     val config = createReplicatorDestinationConfigWith(bucket)
-    withBagReplicatorWorker(defaultQueue, ingests, outgoing, config) {
-      worker =>
-        testWith(worker)
+    withBagReplicatorWorker(defaultQueue, ingests, outgoing, config) { worker =>
+      testWith(worker)
     }
   }
 
-  def withBagReplicatorWorker[R](
-    queue: Queue,
-    ingests: MessageSender[String],
-    outgoing: MessageSender[String],
-    config: ReplicatorDestinationConfig,
-    lockServiceDao: LockDao[String, UUID] = new MemoryLockDao[String, UUID] {})(
+  def withBagReplicatorWorker[R](queue: Queue,
+                                 ingests: MessageSender[String],
+                                 outgoing: MessageSender[String],
+                                 config: ReplicatorDestinationConfig,
+                                 lockServiceDao: LockDao[String, UUID] =
+                                   new MemoryLockDao[String, UUID] {})(
     testWith: TestWith[BagReplicatorWorker[String, String], R]): R =
     withActorSystem { implicit actorSystem =>
       val ingestUpdater = new IngestUpdater[String](

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
@@ -5,29 +5,25 @@ import java.util.UUID
 import com.amazonaws.services.s3.model.S3ObjectSummary
 import org.scalatest.Assertion
 import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.fixtures.Messaging
-import uk.ac.wellcome.messaging.fixtures.SNS.Topic
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
+import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.messaging.worker.models.Result
 import uk.ac.wellcome.platform.archive.bagreplicator.config.ReplicatorDestinationConfig
 import uk.ac.wellcome.platform.archive.bagreplicator.models.ReplicationSummary
-import uk.ac.wellcome.platform.archive.bagreplicator.services.{
-  BagReplicator,
-  BagReplicatorWorker
-}
-import uk.ac.wellcome.platform.archive.common.fixtures.{
-  BagLocationFixtures,
-  MonitoringClientFixture,
-  OperationFixtures
-}
-import uk.ac.wellcome.storage.{LockDao, LockingService, ObjectLocation}
-import uk.ac.wellcome.storage.fixtures.{InMemoryLockDao, LockingServiceFixtures}
+import uk.ac.wellcome.platform.archive.bagreplicator.services.{BagReplicator, BagReplicatorWorker}
+import uk.ac.wellcome.platform.archive.common.fixtures.{BagLocationFixtures, MonitoringClientFixture, OperationFixtures}
+import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
+import uk.ac.wellcome.platform.archive.common.operation.services.OutgoingPublisher
+import uk.ac.wellcome.storage.fixtures.LockingServiceFixtures
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
+import uk.ac.wellcome.storage.memory.MemoryLockDao
+import uk.ac.wellcome.storage.{LockDao, LockingService, ObjectLocation}
 
 import scala.collection.JavaConverters._
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.util.Try
 
 trait BagReplicatorFixtures
     extends Messaging
@@ -42,28 +38,28 @@ trait BagReplicatorFixtures
     arn = "arn::default_q"
   )
 
-  def withBagReplicatorWorker[R](ingestTopic: Topic, outgoingTopic: Topic)(
-    testWith: TestWith[BagReplicatorWorker, R]
+  def withBagReplicatorWorker[R](ingests: MemoryMessageSender, outgoing: MemoryMessageSender)(
+    testWith: TestWith[BagReplicatorWorker[String, String], R]
   ): R =
     withLocalS3Bucket { bucket =>
       val config = createReplicatorDestinationConfigWith(bucket)
-      withBagReplicatorWorker(defaultQueue, ingestTopic, outgoingTopic, config) {
+      withBagReplicatorWorker(defaultQueue, ingests, outgoing, config) {
         worker =>
           testWith(worker)
       }
     }
 
-  def withBagReplicatorWorker[R](ingestTopic: Topic,
-                                 outgoingTopic: Topic,
+  def withBagReplicatorWorker[R](ingests: MemoryMessageSender,
+                                 outgoing: MemoryMessageSender,
                                  lockServiceDao: LockDao[String, UUID])(
-    testWith: TestWith[BagReplicatorWorker, R]
+    testWith: TestWith[BagReplicatorWorker[String, String], R]
   ): R =
     withLocalS3Bucket { bucket =>
       val config = createReplicatorDestinationConfigWith(bucket)
       withBagReplicatorWorker(
         defaultQueue,
-        ingestTopic,
-        outgoingTopic,
+        ingests,
+        outgoing,
         config,
         lockServiceDao) { worker =>
         testWith(worker)
@@ -71,15 +67,15 @@ trait BagReplicatorFixtures
     }
 
   def withBagReplicatorWorker[R](lockServiceDao: LockDao[String, UUID])(
-    testWith: TestWith[BagReplicatorWorker, R]
+    testWith: TestWith[BagReplicatorWorker[String, String], R]
   ): R =
     withLocalS3Bucket { bucket =>
       val config = createReplicatorDestinationConfigWith(bucket)
       withLocalSnsTopic { topic =>
         withBagReplicatorWorker(
           defaultQueue,
-          topic,
-          topic,
+          createMessageSender,
+          createMessageSender,
           config,
           lockServiceDao) { worker =>
           testWith(worker)
@@ -88,7 +84,7 @@ trait BagReplicatorFixtures
     }
 
   def withBagReplicatorWorker[R](bucket: Bucket)(
-    testWith: TestWith[BagReplicatorWorker, R]): R = {
+    testWith: TestWith[BagReplicatorWorker[String, String], R]): R = {
     val config = createReplicatorDestinationConfigWith(bucket)
     withBagReplicatorWorker(config) { worker =>
       testWith(worker)
@@ -97,61 +93,71 @@ trait BagReplicatorFixtures
 
   def withBagReplicatorWorker[R](
     config: ReplicatorDestinationConfig
-  )(testWith: TestWith[BagReplicatorWorker, R]): R =
-    withLocalSnsTopic { topic =>
-      withBagReplicatorWorker(defaultQueue, topic, topic, config) { worker =>
-        testWith(worker)
-      }
-    }
+  )(testWith: TestWith[BagReplicatorWorker[String, String], R]): R = {
+    val messageSender = new MemoryMessageSender(
+      destination = randomAlphanumeric(),
+      subject = randomAlphanumeric()
+    )
 
-  def withBagReplicatorWorker[R](ingestTopic: Topic,
-                                 outgoingTopic: Topic,
+    withBagReplicatorWorker(defaultQueue, messageSender, messageSender, config) { worker =>
+      testWith(worker)
+    }
+  }
+
+  def withBagReplicatorWorker[R](ingests: MessageSender[String],
+                                 outgoing: MessageSender[String],
                                  bucket: Bucket)(
-    testWith: TestWith[BagReplicatorWorker, R]
+    testWith: TestWith[BagReplicatorWorker[String, String], R]
   ): R = {
     val config = createReplicatorDestinationConfigWith(bucket)
-    withBagReplicatorWorker(defaultQueue, ingestTopic, outgoingTopic, config) {
+    withBagReplicatorWorker(defaultQueue, ingests, outgoing, config) {
       worker =>
         testWith(worker)
     }
   }
 
-  def withBagReplicatorWorker[R](queue: Queue,
-                                 ingestTopic: Topic,
-                                 outgoingTopic: Topic,
-                                 config: ReplicatorDestinationConfig,
-                                 lockServiceDao: LockDao[String, UUID] =
-                                   new InMemoryLockDao())(
-    testWith: TestWith[BagReplicatorWorker, R]): R =
+  def withBagReplicatorWorker[R](
+    queue: Queue,
+    ingests: MessageSender[String],
+    outgoing: MessageSender[String],
+    config: ReplicatorDestinationConfig,
+    lockServiceDao: LockDao[String, UUID] = new MemoryLockDao[String, UUID] {})(
+    testWith: TestWith[BagReplicatorWorker[String, String], R]): R =
     withActorSystem { implicit actorSystem =>
-      withIngestUpdater("replicating", ingestTopic) { ingestUpdater =>
-        withOutgoingPublisher("replicating", outgoingTopic) {
-          outgoingPublisher =>
-            withMonitoringClient { implicit monitoringClient =>
-              val lockingService = new LockingService[
-                Result[ReplicationSummary],
-                Future,
-                LockDao[String, UUID]] {
-                override implicit val lockDao: LockDao[String, UUID] =
-                  lockServiceDao
-                override protected def createContextId(): lockDao.ContextId =
-                  UUID.randomUUID()
-              }
+      val ingestUpdater = new IngestUpdater[String](
+        stepName = "replicating",
+        messageSender = ingests
+      )
 
-              val service = new BagReplicatorWorker(
-                alpakkaSQSWorkerConfig = createAlpakkaSQSWorkerConfig(queue),
-                bagReplicator = new BagReplicator(),
-                ingestUpdater = ingestUpdater,
-                outgoingPublisher = outgoingPublisher,
-                lockingService = lockingService,
-                replicatorDestinationConfig = config
-              )
+      val outgoingPublisher = new OutgoingPublisher[String](
+        operationName = "replicating",
+        messageSender = outgoing
+      )
 
-              service.run()
+      withMonitoringClient { implicit monitoringClient =>
+        val lockingService = new LockingService[
+          Result[ReplicationSummary],
+          Try,
+          LockDao[String, UUID]] {
+          override implicit val lockDao: LockDao[String, UUID] =
+            lockServiceDao
 
-              testWith(service)
-            }
+          override protected def createContextId(): lockDao.ContextId =
+            UUID.randomUUID()
         }
+
+        val service = new BagReplicatorWorker(
+          alpakkaSQSWorkerConfig = createAlpakkaSQSWorkerConfig(queue),
+          bagReplicator = new BagReplicator(),
+          ingestUpdater = ingestUpdater,
+          outgoingPublisher = outgoingPublisher,
+          lockingService = lockingService,
+          replicatorDestinationConfig = config
+        )
+
+        service.run()
+
+        testWith(service)
       }
     }
 

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
@@ -71,15 +71,13 @@ trait BagReplicatorFixtures
   ): R =
     withLocalS3Bucket { bucket =>
       val config = createReplicatorDestinationConfigWith(bucket)
-      withLocalSnsTopic { topic =>
-        withBagReplicatorWorker(
-          defaultQueue,
-          createMessageSender,
-          createMessageSender,
-          config,
-          lockServiceDao) { worker =>
-          testWith(worker)
-        }
+      withBagReplicatorWorker(
+        defaultQueue,
+        createMessageSender,
+        createMessageSender,
+        config,
+        lockServiceDao) { worker =>
+        testWith(worker)
       }
     }
 

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
@@ -38,34 +38,6 @@ trait BagReplicatorFixtures
     arn = "arn::default_q"
   )
 
-  def withBagReplicatorWorker[R](ingests: MemoryMessageSender, outgoing: MemoryMessageSender)(
-    testWith: TestWith[BagReplicatorWorker[String, String], R]
-  ): R =
-    withLocalS3Bucket { bucket =>
-      val config = createReplicatorDestinationConfigWith(bucket)
-      withBagReplicatorWorker(defaultQueue, ingests, outgoing, config) {
-        worker =>
-          testWith(worker)
-      }
-    }
-
-  def withBagReplicatorWorker[R](ingests: MemoryMessageSender,
-                                 outgoing: MemoryMessageSender,
-                                 lockServiceDao: LockDao[String, UUID])(
-    testWith: TestWith[BagReplicatorWorker[String, String], R]
-  ): R =
-    withLocalS3Bucket { bucket =>
-      val config = createReplicatorDestinationConfigWith(bucket)
-      withBagReplicatorWorker(
-        defaultQueue,
-        ingests,
-        outgoing,
-        config,
-        lockServiceDao) { worker =>
-        testWith(worker)
-      }
-    }
-
   def withBagReplicatorWorker[R](lockServiceDao: LockDao[String, UUID])(
     testWith: TestWith[BagReplicatorWorker[String, String], R]
   ): R =

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
@@ -223,19 +223,13 @@ class BagReplicatorWorkerTest
   it("only allows one worker to process a destination") {
     val lockServiceDao = new MemoryLockDao[String, UUID] {}
 
-    val ingests = createMessageSender
-    val outgoing = createMessageSender
-
     withLocalS3Bucket { bucket =>
       // We have to create a large bag to slow down the replicators, or the
       // first process finishes and releases the lock before the later
       // processes have started.
       withBag(storageBackend, namespace = bucket.name, dataFileCount = 250) {
         case (bagRootLocation, _) =>
-          withBagReplicatorWorker(
-            ingests = ingests,
-            outgoing = outgoing,
-            lockServiceDao = lockServiceDao) { worker =>
+          withBagReplicatorWorker(lockServiceDao = lockServiceDao) { worker =>
             val payload = createBagInformationPayloadWith(
               bagRootLocation = bagRootLocation
             )

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
@@ -47,7 +47,7 @@ class BagReplicatorWorkerTest
 
               service.processMessage(payload) shouldBe a[Success[_]]
 
-              val result = outgoing.getMessages[BagInformationPayload]()
+              val result = outgoing.getMessages[BagInformationPayload]().head
 
               result.ingestId shouldBe payload.ingestId
 

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
@@ -47,10 +47,7 @@ class BagReplicatorWorkerTest
 
               service.processMessage(payload) shouldBe a[Success[_]]
 
-              val result = outgoing.messages
-                .map { _.body }
-                .map { fromJson[BagInformationPayload](_).get }
-                .head
+              val result = outgoing.getMessages[BagInformationPayload]()
 
               result.ingestId shouldBe payload.ingestId
 

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
@@ -255,16 +255,17 @@ class BagReplicatorWorkerTest
             // It returns a Try, but we can't just use Future.fromTry because
             // that returns a completed Future -- so we'd be running the processes
             // in sequence.
-            val futures: Future[Seq[Result[ReplicationSummary]]] = Future.sequence(
-              (1 to 5).map { i =>
-                Future(i).map { _ =>
-                  worker.processMessage(payload) match {
-                    case Success(result) => result
-                    case Failure(err) => throw err
+            val futures: Future[Seq[Result[ReplicationSummary]]] =
+              Future.sequence(
+                (1 to 5).map { i =>
+                  Future(i).map { _ =>
+                    worker.processMessage(payload) match {
+                      case Success(result) => result
+                      case Failure(err)    => throw err
+                    }
                   }
                 }
-              }
-            )
+              )
 
             whenReady(futures) { result =>
               result.count { _.isInstanceOf[Successful[_]] } shouldBe 1

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
@@ -6,7 +6,11 @@ import java.util.UUID
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.worker.models.{NonDeterministicFailure, Result, Successful}
+import uk.ac.wellcome.messaging.worker.models.{
+  NonDeterministicFailure,
+  Result,
+  Successful
+}
 import uk.ac.wellcome.platform.archive.bagreplicator.fixtures.BagReplicatorFixtures
 import uk.ac.wellcome.platform.archive.bagreplicator.models.ReplicationSummary
 import uk.ac.wellcome.platform.archive.common.BagInformationPayload
@@ -37,7 +41,9 @@ class BagReplicatorWorkerTest
     withLocalS3Bucket { ingestsBucket =>
       withLocalS3Bucket { archiveBucket =>
         withBagReplicatorWorker(
-          ingests = ingests, outgoing = outgoing, bucket = archiveBucket) { service =>
+          ingests = ingests,
+          outgoing = outgoing,
+          bucket = archiveBucket) { service =>
           withBag(storageBackend, namespace = ingestsBucket.name) {
             case (srcBagRootLocation, storageSpace) =>
               val payload = createBagInformationPayloadWith(
@@ -100,7 +106,10 @@ class BagReplicatorWorkerTest
           val config = createReplicatorDestinationConfigWith(archiveBucket)
           withBagReplicatorWorker(config) { worker =>
             val bagInfo = createBagInfo
-            withBag(storageBackend, namespace = ingestsBucket.name, bagInfo = bagInfo) {
+            withBag(
+              storageBackend,
+              namespace = ingestsBucket.name,
+              bagInfo = bagInfo) {
               case (bagRootLocation, _) =>
                 val payload = createBagInformationPayloadWith(
                   bagRootLocation = bagRootLocation
@@ -265,7 +274,9 @@ class BagReplicatorWorkerTest
         case (bagRootLocation, _) =>
           withLocalSqsQueue { queue =>
             withBagReplicatorWorker(
-              queue, ingests, outgoing,
+              queue,
+              ingests,
+              outgoing,
               config = createReplicatorDestinationConfigWith(bucket),
               lockServiceDao = neverAllowLockDao) { _ =>
               val payload = createBagInformationPayloadWith(

--- a/bag_unpacker/docker-compose.yml
+++ b/bag_unpacker/docker-compose.yml
@@ -3,10 +3,6 @@ sqs:
   ports:
     - "9324:9324"
     - "4789:9324"
-sns:
-  image: wellcome/fake-sns
-  ports:
-    - "9292:9292"
 s3:
   image: scality/s3server:mem-latest
   ports:

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
@@ -3,7 +3,10 @@ package uk.ac.wellcome.platform.archive.bagunpacker.services
 import akka.actor.ActorSystem
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.sqsworker.alpakka.{AlpakkaSQSWorker, AlpakkaSQSWorkerConfig}
+import uk.ac.wellcome.messaging.sqsworker.alpakka.{
+  AlpakkaSQSWorker,
+  AlpakkaSQSWorkerConfig
+}
 import uk.ac.wellcome.messaging.worker.models.Result
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
 import uk.ac.wellcome.platform.archive.bagunpacker.builders.BagLocationBuilder
@@ -12,26 +15,29 @@ import uk.ac.wellcome.platform.archive.bagunpacker.models.UnpackSummary
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services._
 import uk.ac.wellcome.platform.archive.common.storage.models.IngestStepWorker
-import uk.ac.wellcome.platform.archive.common.{IngestRequestPayload, UnpackedBagPayload}
+import uk.ac.wellcome.platform.archive.common.{
+  IngestRequestPayload,
+  UnpackedBagPayload
+}
 import uk.ac.wellcome.typesafe.Runnable
 
 import scala.concurrent.Future
 import scala.util.Try
 
-case class BagUnpackerWorker[IngestsDestination, OutgoingDestination](alpakkaSQSWorkerConfig: AlpakkaSQSWorkerConfig,
-                             bagUnpackerWorkerConfig: BagUnpackerWorkerConfig,
-                             ingestUpdater: IngestUpdater[IngestsDestination],
-                             outgoingPublisher: OutgoingPublisher[OutgoingDestination],
-                             unpacker: Unpacker)(
-  implicit actorSystem: ActorSystem,
-  mc: MonitoringClient,
-  sc: AmazonSQSAsync)
+case class BagUnpackerWorker[IngestsDestination, OutgoingDestination](
+  alpakkaSQSWorkerConfig: AlpakkaSQSWorkerConfig,
+  bagUnpackerWorkerConfig: BagUnpackerWorkerConfig,
+  ingestUpdater: IngestUpdater[IngestsDestination],
+  outgoingPublisher: OutgoingPublisher[OutgoingDestination],
+  unpacker: Unpacker)(implicit actorSystem: ActorSystem,
+                      mc: MonitoringClient,
+                      sc: AmazonSQSAsync)
     extends Runnable
     with IngestStepWorker {
   private val worker =
     AlpakkaSQSWorker[IngestRequestPayload, UnpackSummary](
-      alpakkaSQSWorkerConfig) {
-      payload => Future.fromTry { processMessage(payload) }
+      alpakkaSQSWorkerConfig) { payload =>
+      Future.fromTry { processMessage(payload) }
     }
 
   def processMessage(

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
@@ -7,10 +7,17 @@ import java.time.Instant
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.AmazonS3Exception
 import org.apache.commons.compress.archivers.ArchiveEntry
-import uk.ac.wellcome.platform.archive.bagunpacker.exceptions.{ArchiveLocationException, UnpackerArchiveEntryUploadException}
+import uk.ac.wellcome.platform.archive.bagunpacker.exceptions.{
+  ArchiveLocationException,
+  UnpackerArchiveEntryUploadException
+}
 import uk.ac.wellcome.platform.archive.bagunpacker.models.UnpackSummary
 import uk.ac.wellcome.platform.archive.bagunpacker.storage.Archive
-import uk.ac.wellcome.platform.archive.common.storage.models.{IngestFailed, IngestStepResult, IngestStepSucceeded}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  IngestFailed,
+  IngestStepResult,
+  IngestStepSucceeded
+}
 import uk.ac.wellcome.platform.archive.common.storage.services.StreamableInstances._
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.s3.S3StorageBackend
@@ -19,7 +26,8 @@ import scala.util.{Failure, Success, Try}
 
 case class Unpacker(s3Uploader: S3Uploader)(implicit s3Client: AmazonS3) {
 
-  implicit val s3StorageBackend: S3StorageBackend = new S3StorageBackend(s3Client)
+  implicit val s3StorageBackend: S3StorageBackend = new S3StorageBackend(
+    s3Client)
 
   def unpack(
     requestId: String,

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
@@ -18,7 +18,7 @@ import uk.ac.wellcome.platform.archive.common.storage.models.{
   IngestStepResult,
   IngestStepSucceeded
 }
-import uk.ac.wellcome.platform.archive.common.storage.services.S3StreamableInstances._
+import uk.ac.wellcome.platform.archive.common.storage.services.StreamableInstances._
 import uk.ac.wellcome.storage.ObjectLocation
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/storage/Archive.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/storage/Archive.scala
@@ -3,16 +3,11 @@ package uk.ac.wellcome.platform.archive.bagunpacker.storage
 import java.io.{BufferedInputStream, InputStream}
 
 import grizzled.slf4j.Logging
-import org.apache.commons.compress.archivers.{
-  ArchiveEntry,
-  ArchiveInputStream,
-  ArchiveStreamFactory
-}
+import org.apache.commons.compress.archivers.{ArchiveEntry, ArchiveInputStream, ArchiveStreamFactory}
 import org.apache.commons.compress.compressors.CompressorStreamFactory
 import org.apache.commons.io.input.CloseShieldInputStream
 
 import scala.annotation.tailrec
-import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
 object Archive extends Logging {
@@ -20,8 +15,7 @@ object Archive extends Logging {
     inputStream: InputStream
   )(init: T)(
     f: (T, InputStream, ArchiveEntry) => T
-  )(implicit ec: ExecutionContext): Future[T] = Future {
-
+  ): Try[T] = Try {
     val archiveReader = new ArchiveReader[T](inputStream)
 
     @tailrec

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/storage/Archive.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/storage/Archive.scala
@@ -3,7 +3,11 @@ package uk.ac.wellcome.platform.archive.bagunpacker.storage
 import java.io.{BufferedInputStream, InputStream}
 
 import grizzled.slf4j.Logging
-import org.apache.commons.compress.archivers.{ArchiveEntry, ArchiveInputStream, ArchiveStreamFactory}
+import org.apache.commons.compress.archivers.{
+  ArchiveEntry,
+  ArchiveInputStream,
+  ArchiveStreamFactory
+}
 import org.apache.commons.compress.compressors.CompressorStreamFactory
 import org.apache.commons.io.input.CloseShieldInputStream
 

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
@@ -5,11 +5,17 @@ import java.nio.file.Paths
 import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.platform.archive.bagunpacker.fixtures.{BagUnpackerFixtures, CompressFixture}
+import uk.ac.wellcome.platform.archive.bagunpacker.fixtures.{
+  BagUnpackerFixtures,
+  CompressFixture
+}
 import uk.ac.wellcome.platform.archive.common.UnpackedBagPayload
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestStatusUpdate}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  Ingest,
+  IngestStatusUpdate
+}
 
 class UnpackerFeatureTest
     extends FunSpec
@@ -43,7 +49,8 @@ class UnpackerFeatureTest
               )
             )
 
-            outgoing.getMessages[UnpackedBagPayload]() shouldBe Seq(expectedPayload)
+            outgoing.getMessages[UnpackedBagPayload]() shouldBe Seq(
+              expectedPayload)
 
             assertReceivesIngestEvents(ingests)(
               ingestRequestPayload.ingestId,

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
@@ -2,27 +2,18 @@ package uk.ac.wellcome.platform.archive.bagunpacker
 
 import java.nio.file.Paths
 
-import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
+import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.platform.archive.bagunpacker.fixtures.{
-  BagUnpackerFixtures,
-  CompressFixture
-}
+import uk.ac.wellcome.platform.archive.bagunpacker.fixtures.{BagUnpackerFixtures, CompressFixture}
 import uk.ac.wellcome.platform.archive.common.UnpackedBagPayload
-import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  Ingest,
-  IngestStatusUpdate
-}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestStatusUpdate}
 
 class UnpackerFeatureTest
     extends FunSpec
     with Matchers
-    with ScalaFutures
-    with RandomThings
     with BagUnpackerFixtures
     with IntegrationPatience
     with CompressFixture
@@ -32,7 +23,7 @@ class UnpackerFeatureTest
   it("receives and processes a notification") {
     val (archiveFile, _, _) = createTgzArchiveWithRandomFiles()
     withBagUnpackerApp {
-      case (_, srcBucket, queue, ingestTopic, outgoingTopic) =>
+      case (_, srcBucket, queue, ingests, outgoing) =>
         withArchive(srcBucket, archiveFile) { archiveLocation =>
           val ingestRequestPayload =
             createIngestRequestPayloadWith(archiveLocation)
@@ -52,11 +43,12 @@ class UnpackerFeatureTest
               )
             )
 
-            assertSnsReceivesOnly(expectedPayload, outgoingTopic)
+            outgoing.messages
+              .map { _.body }
+              .map { fromJson[UnpackedBagPayload](_).get } shouldBe Seq(expectedPayload)
 
-            assertTopicReceivesIngestEvents(
+            assertReceivesIngestEvents(ingests)(
               ingestRequestPayload.ingestId,
-              ingestTopic,
               expectedDescriptions = Seq(
                 "Unpacker started",
                 "Unpacker succeeded"
@@ -69,14 +61,14 @@ class UnpackerFeatureTest
 
   it("sends a failed Ingest update if it cannot read the bag") {
     withBagUnpackerApp {
-      case (_, _, queue, ingestTopic, outgoingTopic) =>
+      case (_, _, queue, ingests, outgoing) =>
         val payload = createIngestRequestPayload
         sendNotificationToSQS(queue, payload)
 
         eventually {
-          assertSnsReceivesNothing(outgoingTopic)
+          outgoing.messages shouldBe empty
 
-          assertTopicReceivesIngestUpdates(payload.ingestId, ingestTopic) {
+          assertReceivesIngestUpdates(ingests)(payload.ingestId) {
             ingestUpdates =>
               ingestUpdates.size shouldBe 2
 

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
@@ -43,9 +43,7 @@ class UnpackerFeatureTest
               )
             )
 
-            outgoing.messages
-              .map { _.body }
-              .map { fromJson[UnpackedBagPayload](_).get } shouldBe Seq(expectedPayload)
+            outgoing.getMessages[UnpackedBagPayload]() shouldBe Seq(expectedPayload)
 
             assertReceivesIngestEvents(ingests)(
               ingestRequestPayload.ingestId,

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/BagUnpackerFixtures.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/BagUnpackerFixtures.scala
@@ -1,85 +1,78 @@
 package uk.ac.wellcome.platform.archive.bagunpacker.fixtures
 
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.messaging.fixtures.Messaging
-import uk.ac.wellcome.messaging.fixtures.SNS.Topic
+import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
+import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.bagunpacker.config.models.BagUnpackerWorkerConfig
-import uk.ac.wellcome.platform.archive.bagunpacker.services.{
-  BagUnpackerWorker,
-  S3Uploader,
-  Unpacker
-}
-import uk.ac.wellcome.platform.archive.common.fixtures.{
-  BagLocationFixtures,
-  MonitoringClientFixture,
-  OperationFixtures,
-  RandomThings
-}
+import uk.ac.wellcome.platform.archive.bagunpacker.services.{BagUnpackerWorker, S3Uploader, Unpacker}
+import uk.ac.wellcome.platform.archive.common.fixtures.{BagLocationFixtures, MonitoringClientFixture, OperationFixtures}
+import uk.ac.wellcome.storage.fixtures.S3
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
 
-import scala.concurrent.ExecutionContext.Implicits.global
-
 trait BagUnpackerFixtures
-    extends RandomThings
-    with Messaging
-    with BagLocationFixtures
+    extends BagLocationFixtures
     with OperationFixtures
     with AlpakkaSQSWorkerFixtures
-    with MonitoringClientFixture {
+    with MonitoringClientFixture
+    with S3 {
 
   def withBagUnpackerWorker[R](
     queue: Queue,
-    ingestTopic: Topic,
-    outgoingTopic: Topic,
+    ingests: MessageSender[String],
+    outgoing: MessageSender[String],
     dstBucket: Bucket
-  )(testWith: TestWith[BagUnpackerWorker, R]): R =
+  )(testWith: TestWith[BagUnpackerWorker[String, String], R]): R =
     withActorSystem { implicit actorSystem =>
-      withIngestUpdater("unpacker", ingestTopic) { ingestUpdater =>
-        withOutgoingPublisher("unpacker", outgoingTopic) { ongoingPublisher =>
-          withMonitoringClient { implicit monitoringClient =>
-            val bagUnpackerWorker = BagUnpackerWorker(
-              alpakkaSQSWorkerConfig = createAlpakkaSQSWorkerConfig(queue),
-              bagUnpackerWorkerConfig = BagUnpackerWorkerConfig(dstBucket.name),
-              ingestUpdater = ingestUpdater,
-              outgoingPublisher = ongoingPublisher,
-              unpacker = Unpacker(new S3Uploader())
-            )
+      val ingestUpdater = createIngestUpdater(
+        stepName = "unpacker",
+        messageSender = ingests
+      )
 
-            bagUnpackerWorker.run()
+      val outgoingPublisher = createOutgoingPublisher(
+        operationName = "unpacker",
+        messageSender = outgoing
+      )
 
-            testWith(bagUnpackerWorker)
-          }
-        }
+      withMonitoringClient { implicit monitoringClient =>
+        val bagUnpackerWorker = BagUnpackerWorker(
+          alpakkaSQSWorkerConfig = createAlpakkaSQSWorkerConfig(queue),
+          bagUnpackerWorkerConfig = BagUnpackerWorkerConfig(dstBucket.name),
+          ingestUpdater = ingestUpdater,
+          outgoingPublisher = outgoingPublisher,
+          unpacker = Unpacker(new S3Uploader())
+        )
+
+        bagUnpackerWorker.run()
+
+        testWith(bagUnpackerWorker)
       }
     }
 
   def withBagUnpackerApp[R](
-    testWith: TestWith[(BagUnpackerWorker, Bucket, Queue, Topic, Topic), R])
+    testWith: TestWith[(BagUnpackerWorker[String, String], Bucket, Queue, MemoryMessageSender, MemoryMessageSender), R])
     : R =
     withLocalS3Bucket { sourceBucket =>
       withLocalSqsQueue { queue =>
-        withLocalSnsTopic { ingestTopic =>
-          withLocalSnsTopic { outgoingTopic =>
-            withBagUnpackerWorker(
+        val ingests = createMessageSender
+        val outgoing = createMessageSender
+        withBagUnpackerWorker(
+          queue,
+          ingests,
+          outgoing,
+          sourceBucket
+        )({ bagUnpackerProcess =>
+          testWith(
+            (
+              bagUnpackerProcess,
+              sourceBucket,
               queue,
-              ingestTopic,
-              outgoingTopic,
-              sourceBucket
-            )({ bagUnpackerProcess =>
-              testWith(
-                (
-                  bagUnpackerProcess,
-                  sourceBucket,
-                  queue,
-                  ingestTopic,
-                  outgoingTopic
-                )
-              )
-            })
-          }
-        }
+              ingests,
+              outgoing
+            )
+          )
+        })
       }
     }
 }

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/BagUnpackerFixtures.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/BagUnpackerFixtures.scala
@@ -6,8 +6,16 @@ import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.bagunpacker.config.models.BagUnpackerWorkerConfig
-import uk.ac.wellcome.platform.archive.bagunpacker.services.{BagUnpackerWorker, S3Uploader, Unpacker}
-import uk.ac.wellcome.platform.archive.common.fixtures.{BagLocationFixtures, MonitoringClientFixture, OperationFixtures}
+import uk.ac.wellcome.platform.archive.bagunpacker.services.{
+  BagUnpackerWorker,
+  S3Uploader,
+  Unpacker
+}
+import uk.ac.wellcome.platform.archive.common.fixtures.{
+  BagLocationFixtures,
+  MonitoringClientFixture,
+  OperationFixtures
+}
 import uk.ac.wellcome.storage.fixtures.S3
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
 
@@ -51,8 +59,12 @@ trait BagUnpackerFixtures
     }
 
   def withBagUnpackerApp[R](
-    testWith: TestWith[(BagUnpackerWorker[String, String], Bucket, Queue, MemoryMessageSender, MemoryMessageSender), R])
-    : R =
+    testWith: TestWith[(BagUnpackerWorker[String, String],
+                        Bucket,
+                        Queue,
+                        MemoryMessageSender,
+                        MemoryMessageSender),
+                       R]): R =
     withLocalS3Bucket { sourceBucket =>
       withLocalSqsQueue { queue =>
         val ingests = createMessageSender

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTest.scala
@@ -4,36 +4,24 @@ import java.io.{File, FileInputStream}
 import java.nio.file.Paths
 
 import org.apache.commons.io.IOUtils
-import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.platform.archive.bagunpacker.exceptions.{
-  ArchiveLocationException,
-  UnpackerArchiveEntryUploadException
-}
+import uk.ac.wellcome.platform.archive.bagunpacker.exceptions.{ArchiveLocationException, UnpackerArchiveEntryUploadException}
 import uk.ac.wellcome.platform.archive.bagunpacker.fixtures.CompressFixture
 import uk.ac.wellcome.platform.archive.bagunpacker.models.UnpackSummary
-import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
-import uk.ac.wellcome.platform.archive.common.storage.models.{
-  IngestFailed,
-  IngestStepSucceeded
-}
+import uk.ac.wellcome.platform.archive.common.storage.models.{IngestFailed, IngestStepSucceeded}
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.fixtures.S3
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.{Failure, Success}
 
 class UnpackerTest
     extends FunSpec
     with Matchers
-    with ScalaFutures
     with CompressFixture
-    with RandomThings
     with S3 {
 
-  val unpacker = Unpacker(
-    s3Uploader = new S3Uploader()
-  )
+  val unpacker = Unpacker(s3Uploader = new S3Uploader())
 
   it("unpacks a tgz archive") {
     withLocalS3Bucket { srcBucket =>
@@ -44,22 +32,23 @@ class UnpackerTest
           val dstLocation =
             ObjectLocation(dstBucket.name, dstKey)
 
-          val summaryResult = unpacker
+          val result = unpacker
             .unpack(
               randomUUID.toString,
               testArchive,
               dstLocation
             )
 
-          whenReady(summaryResult) { unpacked =>
-            unpacked shouldBe a[IngestStepSucceeded[_]]
+          result shouldBe a[Success[_]]
+          val unpacked = result.get
 
-            val summary = unpacked.summary
-            summary.fileCount shouldBe filesInArchive.size
-            summary.bytesUnpacked shouldBe totalBytes(filesInArchive)
+          unpacked shouldBe a[IngestStepSucceeded[_]]
 
-            assertBucketContentsMatchFiles(dstBucket, dstKey, filesInArchive)
-          }
+          val summary = unpacked.summary
+          summary.fileCount shouldBe filesInArchive.size
+          summary.bytesUnpacked shouldBe totalBytes(filesInArchive)
+
+          assertBucketContentsMatchFiles(dstBucket, dstKey, filesInArchive)
         }
       }
     }
@@ -75,22 +64,22 @@ class UnpackerTest
             ))
         withArchive(srcBucket, archiveFile) { testArchive =>
           val dstKey = "unpacked"
-          val summaryResult = unpacker
+          val result = unpacker
             .unpack(
               randomUUID.toString,
               testArchive,
               ObjectLocation(dstBucket.name, dstKey)
             )
 
-          whenReady(summaryResult) { unpacked =>
-            unpacked shouldBe a[IngestStepSucceeded[_]]
+          result shouldBe a[Success[_]]
+          val unpacked = result.get
+          unpacked shouldBe a[IngestStepSucceeded[_]]
 
-            val summary = unpacked.summary
-            summary.fileCount shouldBe filesInArchive.size
-            summary.bytesUnpacked shouldBe totalBytes(filesInArchive)
+          val summary = unpacked.summary
+          summary.fileCount shouldBe filesInArchive.size
+          summary.bytesUnpacked shouldBe totalBytes(filesInArchive)
 
-            assertBucketContentsMatchFiles(dstBucket, dstKey, filesInArchive)
-          }
+          assertBucketContentsMatchFiles(dstBucket, dstKey, filesInArchive)
         }
       }
     }
@@ -98,23 +87,23 @@ class UnpackerTest
 
   it("returns an IngestFailed if it cannot open the input stream") {
     val srcLocation = createObjectLocation
-    val future =
+    val result =
       unpacker.unpack(
         randomUUID.toString,
         srcLocation = srcLocation,
         dstLocation = createObjectLocation
       )
 
-    whenReady(future) { result =>
-      result shouldBe a[IngestFailed[_]]
-      result.summary.fileCount shouldBe 0
-      result.summary.bytesUnpacked shouldBe 0
-      val actualResult = result.asInstanceOf[IngestFailed[UnpackSummary]]
-      actualResult.e shouldBe a[ArchiveLocationException]
-      actualResult.e.getMessage should
-        startWith(
-          s"Error getting input stream for s3://$srcLocation: The specified bucket does not exist.")
-    }
+    result shouldBe a[Failure[_]]
+    val failure = result.get
+    failure shouldBe a[IngestFailed[_]]
+    failure.summary.fileCount shouldBe 0
+    failure.summary.bytesUnpacked shouldBe 0
+    val actualResult = failure.asInstanceOf[IngestFailed[UnpackSummary]]
+    actualResult.e shouldBe a[ArchiveLocationException]
+    actualResult.e.getMessage should
+      startWith(
+        s"Error getting input stream for s3://$srcLocation: The specified bucket does not exist.")
   }
 
   it("returns an IngestFailed if it cannot write to the destination") {
@@ -122,21 +111,21 @@ class UnpackerTest
       val (archiveFile, _, _) = createTgzArchiveWithRandomFiles()
       withArchive(srcBucket, archiveFile) { testArchive =>
         val dstLocation = createObjectLocation
-        val future =
+        val result =
           unpacker.unpack(
             randomUUID.toString,
             srcLocation = testArchive,
             dstLocation = dstLocation
           )
 
-        whenReady(future) { result =>
-          result shouldBe a[IngestFailed[_]]
-          result.summary.fileCount shouldBe 0
-          result.summary.bytesUnpacked shouldBe 0
-          val actualResult = result.asInstanceOf[IngestFailed[UnpackSummary]]
-          actualResult.e shouldBe a[UnpackerArchiveEntryUploadException]
-          actualResult.e.getMessage should startWith("upload failed")
-        }
+        result shouldBe a[Failure[_]]
+        val failure = result.get
+        failure shouldBe a[IngestFailed[_]]
+        failure.summary.fileCount shouldBe 0
+        failure.summary.bytesUnpacked shouldBe 0
+        val actualResult = result.asInstanceOf[IngestFailed[UnpackSummary]]
+        actualResult.e shouldBe a[UnpackerArchiveEntryUploadException]
+        actualResult.e.getMessage should startWith("upload failed")
       }
     }
   }

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTest.scala
@@ -5,21 +5,23 @@ import java.nio.file.Paths
 
 import org.apache.commons.io.IOUtils
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.platform.archive.bagunpacker.exceptions.{ArchiveLocationException, UnpackerArchiveEntryUploadException}
+import uk.ac.wellcome.platform.archive.bagunpacker.exceptions.{
+  ArchiveLocationException,
+  UnpackerArchiveEntryUploadException
+}
 import uk.ac.wellcome.platform.archive.bagunpacker.fixtures.CompressFixture
 import uk.ac.wellcome.platform.archive.bagunpacker.models.UnpackSummary
-import uk.ac.wellcome.platform.archive.common.storage.models.{IngestFailed, IngestStepSucceeded}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  IngestFailed,
+  IngestStepSucceeded
+}
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.fixtures.S3
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
 
 import scala.util.Success
 
-class UnpackerTest
-    extends FunSpec
-    with Matchers
-    with CompressFixture
-    with S3 {
+class UnpackerTest extends FunSpec with Matchers with CompressFixture with S3 {
 
   val unpacker = Unpacker(s3Uploader = new S3Uploader())
 

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTest.scala
@@ -13,7 +13,7 @@ import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.fixtures.S3
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
 
-import scala.util.{Failure, Success}
+import scala.util.Success
 
 class UnpackerTest
     extends FunSpec
@@ -94,7 +94,7 @@ class UnpackerTest
         dstLocation = createObjectLocation
       )
 
-    result shouldBe a[Failure[_]]
+    result shouldBe a[Success[_]]
     val failure = result.get
     failure shouldBe a[IngestFailed[_]]
     failure.summary.fileCount shouldBe 0
@@ -118,12 +118,12 @@ class UnpackerTest
             dstLocation = dstLocation
           )
 
-        result shouldBe a[Failure[_]]
+        result shouldBe a[Success[_]]
         val failure = result.get
         failure shouldBe a[IngestFailed[_]]
         failure.summary.fileCount shouldBe 0
         failure.summary.bytesUnpacked shouldBe 0
-        val actualResult = result.asInstanceOf[IngestFailed[UnpackSummary]]
+        val actualResult = failure.asInstanceOf[IngestFailed[UnpackSummary]]
         actualResult.e shouldBe a[UnpackerArchiveEntryUploadException]
         actualResult.e.getMessage should startWith("upload failed")
       }

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/storage/ArchiveTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/storage/ArchiveTest.scala
@@ -4,18 +4,15 @@ import java.io.{File, FileInputStream, FileOutputStream, InputStream}
 
 import org.apache.commons.compress.archivers.ArchiveEntry
 import org.apache.commons.compress.utils.IOUtils
-import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.bagunpacker.fixtures.CompressFixture
 import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
-import scala.concurrent.ExecutionContext.Implicits.global
 
-import scala.concurrent.Future
+import scala.util.{Success, Try}
 
 class ArchiveTest
     extends FunSpec
     with Matchers
-    with ScalaFutures
     with CompressFixture
     with RandomThings {
 
@@ -39,42 +36,43 @@ class ArchiveTest
       entries + entry
     }
 
-    val unpack: Future[Set[ArchiveEntry]] =
+    val result: Try[Set[ArchiveEntry]] =
       Archive.unpack(
         inputStream
       )(
         Set.empty[ArchiveEntry]
       )(fold)
 
-    whenReady(unpack) { unpacked =>
-      unpacked.diff(expectedEntries) shouldBe Set.empty
+    result shouldBe a[Success[_]]
+    val unpacked = result.get
 
-      val expectedFiles = files
-        .map(file => relativeToTmpDir(file) -> file)
-        .toMap
+    unpacked.diff(expectedEntries) shouldBe Set.empty
 
-      val actualFiles = unpacked
-        .map(entry => entry.getName -> new File(tmp, entry.getName))
-        .toMap
+    val expectedFiles = files
+      .map(file => relativeToTmpDir(file) -> file)
+      .toMap
 
-      expectedFiles.foreach {
-        case (key, expectedFile) => {
-          val maybeActualFile = actualFiles.get(key)
-          maybeActualFile shouldBe a[Some[_]]
+    val actualFiles = unpacked
+      .map(entry => entry.getName -> new File(tmp, entry.getName))
+      .toMap
 
-          val actualFile = maybeActualFile.get
+    expectedFiles.foreach {
+      case (key, expectedFile) => {
+        val maybeActualFile = actualFiles.get(key)
+        maybeActualFile shouldBe a[Some[_]]
 
-          actualFile.exists() shouldBe true
+        val actualFile = maybeActualFile.get
 
-          val actualFis = new FileInputStream(actualFile)
-          val actualBytes = IOUtils.toByteArray(actualFis)
+        actualFile.exists() shouldBe true
 
-          val expectedFis = new FileInputStream(expectedFile)
-          val expectedBytes = IOUtils.toByteArray(expectedFis)
+        val actualFis = new FileInputStream(actualFile)
+        val actualBytes = IOUtils.toByteArray(actualFis)
 
-          actualBytes.length shouldBe expectedBytes.length
-          actualBytes shouldEqual expectedBytes
-        }
+        val expectedFis = new FileInputStream(expectedFile)
+        val expectedBytes = IOUtils.toByteArray(expectedFis)
+
+        actualBytes.length shouldBe expectedBytes.length
+        actualBytes shouldEqual expectedBytes
       }
     }
   }

--- a/bag_verifier/docker-compose.yml
+++ b/bag_verifier/docker-compose.yml
@@ -3,10 +3,6 @@ sqs:
   ports:
     - "9324:9324"
     - "4789:9324"
-sns:
-  image: wellcome/fake-sns
-  ports:
-    - "9292:9292"
 s3:
   image: "zenko/cloudserver:8.1.8"
   environment:

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/Main.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/Main.scala
@@ -5,11 +5,23 @@ import akka.stream.ActorMaterializer
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.typesafe.config.Config
-import uk.ac.wellcome.messaging.typesafe.{AlpakkaSqsWorkerConfigBuilder, CloudwatchMonitoringClientBuilder, SQSBuilder}
+import uk.ac.wellcome.messaging.typesafe.{
+  AlpakkaSqsWorkerConfigBuilder,
+  CloudwatchMonitoringClientBuilder,
+  SQSBuilder
+}
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
-import uk.ac.wellcome.platform.archive.bagverifier.services.{BagVerifier, BagVerifierWorker, S3ObjectVerifier}
+import uk.ac.wellcome.platform.archive.bagverifier.services.{
+  BagVerifier,
+  BagVerifierWorker,
+  S3ObjectVerifier
+}
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagService
-import uk.ac.wellcome.platform.archive.common.config.builders.{IngestUpdaterBuilder, OperationNameBuilder, OutgoingPublisherBuilder}
+import uk.ac.wellcome.platform.archive.common.config.builders.{
+  IngestUpdaterBuilder,
+  OperationNameBuilder,
+  OutgoingPublisherBuilder
+}
 import uk.ac.wellcome.storage.StorageBackend
 import uk.ac.wellcome.storage.s3.S3StorageBackend
 import uk.ac.wellcome.storage.typesafe.S3Builder
@@ -35,7 +47,8 @@ object Main extends WellcomeTypesafeApp {
       SQSBuilder.buildSQSAsyncClient(config)
     implicit val s3ObjectVerifier =
       new S3ObjectVerifier()
-    implicit val s3StorageBackend: StorageBackend = new S3StorageBackend(s3Client)
+    implicit val s3StorageBackend: StorageBackend =
+      new S3StorageBackend(s3Client)
 
     implicit val bagService =
       new BagService()

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/Main.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/Main.scala
@@ -5,23 +5,13 @@ import akka.stream.ActorMaterializer
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.typesafe.config.Config
-import uk.ac.wellcome.messaging.typesafe.{
-  AlpakkaSqsWorkerConfigBuilder,
-  CloudwatchMonitoringClientBuilder,
-  SQSBuilder
-}
+import uk.ac.wellcome.messaging.typesafe.{AlpakkaSqsWorkerConfigBuilder, CloudwatchMonitoringClientBuilder, SQSBuilder}
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
-import uk.ac.wellcome.platform.archive.bagverifier.services.{
-  BagVerifier,
-  BagVerifierWorker,
-  S3ObjectVerifier
-}
+import uk.ac.wellcome.platform.archive.bagverifier.services.{BagVerifier, BagVerifierWorker, S3ObjectVerifier}
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagService
-import uk.ac.wellcome.platform.archive.common.config.builders.{
-  IngestUpdaterBuilder,
-  OperationNameBuilder,
-  OutgoingPublisherBuilder
-}
+import uk.ac.wellcome.platform.archive.common.config.builders.{IngestUpdaterBuilder, OperationNameBuilder, OutgoingPublisherBuilder}
+import uk.ac.wellcome.storage.StorageBackend
+import uk.ac.wellcome.storage.s3.S3StorageBackend
 import uk.ac.wellcome.storage.typesafe.S3Builder
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
@@ -45,6 +35,8 @@ object Main extends WellcomeTypesafeApp {
       SQSBuilder.buildSQSAsyncClient(config)
     implicit val s3ObjectVerifier =
       new S3ObjectVerifier()
+    implicit val s3StorageBackend: StorageBackend = new S3StorageBackend(s3Client)
+
     implicit val bagService =
       new BagService()
 

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorker.scala
@@ -5,7 +5,10 @@ import com.amazonaws.services.sqs.AmazonSQSAsync
 import grizzled.slf4j.Logging
 import org.apache.commons.codec.digest.MessageDigestAlgorithms
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.sqsworker.alpakka.{AlpakkaSQSWorker, AlpakkaSQSWorkerConfig}
+import uk.ac.wellcome.messaging.sqsworker.alpakka.{
+  AlpakkaSQSWorker,
+  AlpakkaSQSWorkerConfig
+}
 import uk.ac.wellcome.messaging.worker.models.Result
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
 import uk.ac.wellcome.platform.archive.bagverifier.models.VerificationSummary
@@ -33,8 +36,8 @@ class BagVerifierWorker[IngestsDestination, OutgoingDestination](
 
   private val worker =
     AlpakkaSQSWorker[BagInformationPayload, VerificationSummary](
-      alpakkaSQSWorkerConfig) {
-      payload => Future.fromTry { processMessage(payload) }
+      alpakkaSQSWorkerConfig) { payload =>
+      Future.fromTry { processMessage(payload) }
     }
 
   val algorithm: String = MessageDigestAlgorithms.SHA_256

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/S3ObjectVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/S3ObjectVerifier.scala
@@ -9,7 +9,7 @@ import scala.util.{Failure, Success}
 class S3ObjectVerifier(implicit s3Client: AmazonS3)
     extends Verifier
     with Logging {
-  import uk.ac.wellcome.platform.archive.common.storage.services.S3StreamableInstances._
+  import uk.ac.wellcome.platform.archive.common.storage.services.StreamableInstances._
 
   private def compareChecksum(a: Checksum, b: Checksum) = {
     debug(s"Comparing $a, $b")

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/S3ObjectVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/S3ObjectVerifier.scala
@@ -3,6 +3,8 @@ package uk.ac.wellcome.platform.archive.bagverifier.services
 import com.amazonaws.services.s3.AmazonS3
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.common.verify._
+import uk.ac.wellcome.storage.StorageBackend
+import uk.ac.wellcome.storage.s3.S3StorageBackend
 
 import scala.util.{Failure, Success}
 
@@ -10,6 +12,8 @@ class S3ObjectVerifier(implicit s3Client: AmazonS3)
     extends Verifier
     with Logging {
   import uk.ac.wellcome.platform.archive.common.storage.services.StreamableInstances._
+
+  implicit val storageBackend: StorageBackend = new S3StorageBackend(s3Client)
 
   private def compareChecksum(a: Checksum, b: Checksum) = {
     debug(s"Comparing $a, $b")

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
@@ -1,113 +1,106 @@
 package uk.ac.wellcome.platform.archive.bagverifier
 
-import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.platform.archive.bagverifier.fixtures.BagVerifierFixtures
+import uk.ac.wellcome.platform.archive.common.BagInformationPayload
 import uk.ac.wellcome.platform.archive.common.fixtures.BagLocationFixtures
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  Ingest,
-  IngestStatusUpdate
-}
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
+import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestStatusUpdate}
 
 class BagVerifierFeatureTest
     extends FunSpec
     with Matchers
-    with ScalaFutures
     with BagLocationFixtures
-    with IntegrationPatience
     with IngestUpdateAssertions
     with BagVerifierFixtures
     with PayloadGenerators {
 
   it(
     "updates the ingest monitor and sends an outgoing notification if verification succeeds") {
-    withLocalSnsTopic { ingestTopic =>
-      withLocalSnsTopic { outgoingTopic =>
-        withLocalSqsQueueAndDlq {
-          case QueuePair(queue, dlq) =>
-            withBagVerifierWorker(ingestTopic, outgoingTopic, queue) { _ =>
-              withLocalS3Bucket { bucket =>
-                withBag(bucket) {
-                  case (bagRootLocation, _) =>
-                    val payload = createBagInformationPayloadWith(
-                      bagRootLocation = bagRootLocation
+    val ingests = createMessageSender
+    val outgoing = createMessageSender
+
+    withLocalSqsQueueAndDlq {
+      case QueuePair(queue, dlq) =>
+        withBagVerifierWorker(ingests, outgoing, queue) { _ =>
+          withLocalS3Bucket { bucket =>
+            withBag(storageBackend, namespace = bucket.name) {
+              case (bagRootLocation, _) =>
+                val payload = createBagInformationPayloadWith(
+                  bagRootLocation = bagRootLocation
+                )
+
+                sendNotificationToSQS(queue, payload)
+
+                eventually {
+                  assertReceivesIngestEvents(ingests)(
+                    payload.ingestId,
+                    expectedDescriptions = Seq(
+                      "Verification started",
+                      "Verification succeeded"
                     )
+                  )
 
-                    sendNotificationToSQS(queue, payload)
+                  outgoing.messages
+                    .map { _.body }
+                    .map { fromJson[BagInformationPayload](_).get } shouldBe Seq(payload)
 
-                    eventually {
-                      listMessagesReceivedFromSNS(outgoingTopic)
-
-                      assertTopicReceivesIngestEvents(
-                        payload.ingestId,
-                        ingestTopic,
-                        expectedDescriptions = Seq(
-                          "Verification started",
-                          "Verification succeeded"
-                        )
-                      )
-
-                      assertSnsReceivesOnly(payload, topic = outgoingTopic)
-
-                      assertQueueEmpty(queue)
-                      assertQueueEmpty(dlq)
-                    }
+                  assertQueueEmpty(queue)
+                  assertQueueEmpty(dlq)
                 }
-              }
             }
+          }
         }
-      }
     }
   }
 
   it(
     "deletes the SQS message if the bag can be verified but has incorrect checksums") {
-    withLocalSnsTopic { ingestTopic =>
-      withLocalSnsTopic { outgoingTopic =>
-        withLocalSqsQueueAndDlq {
-          case QueuePair(queue, dlq) =>
-            withBagVerifierWorker(ingestTopic, outgoingTopic, queue) { _ =>
-              withLocalS3Bucket { bucket =>
-                withBag(
-                  bucket,
-                  createDataManifest = dataManifestWithWrongChecksum) {
-                  case (bagRootLocation, _) =>
-                    val payload = createBagInformationPayloadWith(
-                      bagRootLocation = bagRootLocation
-                    )
+    val ingests = createMessageSender
+    val outgoing = createMessageSender
 
-                    sendNotificationToSQS(queue, payload)
 
-                    eventually {
-                      assertTopicReceivesIngestUpdates(
-                        payload.ingestId,
-                        ingestTopic) { ingestUpdates =>
-                        ingestUpdates.size shouldBe 2
+    withLocalSqsQueueAndDlq {
+      case QueuePair(queue, dlq) =>
+        withBagVerifierWorker(ingests, outgoing, queue) { _ =>
+          withLocalS3Bucket { bucket =>
+            withBag(
+              storageBackend,
+              namespace = bucket.name,
+              createDataManifest = dataManifestWithWrongChecksum) {
+              case (bagRootLocation, _) =>
+                val payload = createBagInformationPayloadWith(
+                  bagRootLocation = bagRootLocation
+                )
 
-                        val ingestStart = ingestUpdates.head
-                        ingestStart.events.head.description shouldBe "Verification started"
+                sendNotificationToSQS(queue, payload)
 
-                        val ingestFailed =
-                          ingestUpdates.tail.head
-                            .asInstanceOf[IngestStatusUpdate]
-                        ingestFailed.status shouldBe Ingest.Failed
-                        ingestFailed.events.head.description shouldBe "Verification failed"
-                      }
+                eventually {
+                  assertReceivesIngestUpdates(ingests)(
+                    payload.ingestId) { ingestUpdates =>
+                    ingestUpdates.size shouldBe 2
 
-                      assertSnsReceivesNothing(outgoingTopic)
+                    val ingestStart = ingestUpdates.head
+                    ingestStart.events.head.description shouldBe "Verification started"
 
-                      assertQueueEmpty(queue)
-                      assertQueueEmpty(dlq)
-                    }
+                    val ingestFailed =
+                      ingestUpdates.tail.head
+                        .asInstanceOf[IngestStatusUpdate]
+                    ingestFailed.status shouldBe Ingest.Failed
+                    ingestFailed.events.head.description shouldBe "Verification failed"
+                  }
+
+                  outgoing.messages shouldBe empty
+
+                  assertQueueEmpty(queue)
+                  assertQueueEmpty(dlq)
                 }
-              }
             }
+          }
         }
-      }
     }
   }
 }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
@@ -44,9 +44,7 @@ class BagVerifierFeatureTest
                     )
                   )
 
-                  outgoing.messages
-                    .map { _.body }
-                    .map { fromJson[BagInformationPayload](_).get } shouldBe Seq(payload)
+                  outgoing.getMessages[BagInformationPayload]() shouldBe Seq(payload)
 
                   assertQueueEmpty(queue)
                   assertQueueEmpty(dlq)

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
@@ -8,7 +8,10 @@ import uk.ac.wellcome.platform.archive.common.BagInformationPayload
 import uk.ac.wellcome.platform.archive.common.fixtures.BagLocationFixtures
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestStatusUpdate}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  Ingest,
+  IngestStatusUpdate
+}
 
 class BagVerifierFeatureTest
     extends FunSpec
@@ -44,7 +47,8 @@ class BagVerifierFeatureTest
                     )
                   )
 
-                  outgoing.getMessages[BagInformationPayload]() shouldBe Seq(payload)
+                  outgoing.getMessages[BagInformationPayload]() shouldBe Seq(
+                    payload)
 
                   assertQueueEmpty(queue)
                   assertQueueEmpty(dlq)
@@ -59,7 +63,6 @@ class BagVerifierFeatureTest
     "deletes the SQS message if the bag can be verified but has incorrect checksums") {
     val ingests = createMessageSender
     val outgoing = createMessageSender
-
 
     withLocalSqsQueueAndDlq {
       case QueuePair(queue, dlq) =>
@@ -77,18 +80,18 @@ class BagVerifierFeatureTest
                 sendNotificationToSQS(queue, payload)
 
                 eventually {
-                  assertReceivesIngestUpdates(ingests)(
-                    payload.ingestId) { ingestUpdates =>
-                    ingestUpdates.size shouldBe 2
+                  assertReceivesIngestUpdates(ingests)(payload.ingestId) {
+                    ingestUpdates =>
+                      ingestUpdates.size shouldBe 2
 
-                    val ingestStart = ingestUpdates.head
-                    ingestStart.events.head.description shouldBe "Verification started"
+                      val ingestStart = ingestUpdates.head
+                      ingestStart.events.head.description shouldBe "Verification started"
 
-                    val ingestFailed =
-                      ingestUpdates.tail.head
-                        .asInstanceOf[IngestStatusUpdate]
-                    ingestFailed.status shouldBe Ingest.Failed
-                    ingestFailed.events.head.description shouldBe "Verification failed"
+                      val ingestFailed =
+                        ingestUpdates.tail.head
+                          .asInstanceOf[IngestStatusUpdate]
+                      ingestFailed.status shouldBe Ingest.Failed
+                      ingestFailed.events.head.description shouldBe "Verification failed"
                   }
 
                   outgoing.messages shouldBe empty

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
@@ -1,52 +1,50 @@
 package uk.ac.wellcome.platform.archive.bagverifier.fixtures
 
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.messaging.fixtures.SNS.Topic
+import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
-import uk.ac.wellcome.platform.archive.bagverifier.services.{
-  BagVerifier,
-  BagVerifierWorker,
-  S3ObjectVerifier
-}
+import uk.ac.wellcome.platform.archive.bagverifier.services.{BagVerifier, BagVerifierWorker, S3ObjectVerifier}
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagService
-import uk.ac.wellcome.platform.archive.common.fixtures.{
-  MonitoringClientFixture,
-  OperationFixtures
-}
-
-import scala.concurrent.ExecutionContext.Implicits.global
+import uk.ac.wellcome.platform.archive.common.fixtures.{MonitoringClientFixture, OperationFixtures}
+import uk.ac.wellcome.storage.fixtures.S3
 
 trait BagVerifierFixtures
     extends AlpakkaSQSWorkerFixtures
     with SQS
     with OperationFixtures
-    with MonitoringClientFixture {
-  def withBagVerifierWorker[R](ingestTopic: Topic,
-                               outgoingTopic: Topic,
+    with MonitoringClientFixture
+    with S3 {
+  def withBagVerifierWorker[R](ingests: MessageSender[String],
+                               outgoing: MessageSender[String],
                                queue: Queue =
                                  Queue("fixture", arn = "arn::fixture"))(
-    testWith: TestWith[BagVerifierWorker, R]): R =
+    testWith: TestWith[BagVerifierWorker[String, String], R]): R =
     withMonitoringClient { implicit monitoringClient =>
       withActorSystem { implicit actorSystem =>
         withMaterializer(actorSystem) { implicit mat =>
           withVerifier { verifier =>
-            withIngestUpdater("verification", ingestTopic) { ingestUpdater =>
-              withOutgoingPublisher("verification", outgoingTopic) {
-                outgoingPublisher =>
-                  val service = new BagVerifierWorker(
-                    alpakkaSQSWorkerConfig = createAlpakkaSQSWorkerConfig(queue),
-                    ingestUpdater = ingestUpdater,
-                    outgoingPublisher = outgoingPublisher,
-                    verifier = verifier
-                  )
+            val ingestUpdater = createIngestUpdater(
+              stepName = "verification",
+              messageSender = ingests
+            )
 
-                  service.run()
+            val outgoingPublisher = createOutgoingPublisher(
+              operationName = "verification",
+              messageSender = outgoing
+            )
 
-                  testWith(service)
-              }
-            }
+            val service = new BagVerifierWorker(
+              alpakkaSQSWorkerConfig = createAlpakkaSQSWorkerConfig(queue),
+              ingestUpdater = ingestUpdater,
+              outgoingPublisher = outgoingPublisher,
+              verifier = verifier
+            )
+
+            service.run()
+
+            testWith(service)
           }
         }
       }
@@ -54,6 +52,7 @@ trait BagVerifierFixtures
 
   def withVerifier[R](testWith: TestWith[BagVerifier, R]): R =
     withMaterializer { implicit mat =>
+
       implicit val _bagService = new BagService()
       implicit val _s3ObjectVerifier = new S3ObjectVerifier()
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
@@ -5,9 +5,16 @@ import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
-import uk.ac.wellcome.platform.archive.bagverifier.services.{BagVerifier, BagVerifierWorker, S3ObjectVerifier}
+import uk.ac.wellcome.platform.archive.bagverifier.services.{
+  BagVerifier,
+  BagVerifierWorker,
+  S3ObjectVerifier
+}
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagService
-import uk.ac.wellcome.platform.archive.common.fixtures.{MonitoringClientFixture, OperationFixtures}
+import uk.ac.wellcome.platform.archive.common.fixtures.{
+  MonitoringClientFixture,
+  OperationFixtures
+}
 import uk.ac.wellcome.storage.fixtures.S3
 
 trait BagVerifierFixtures
@@ -52,7 +59,6 @@ trait BagVerifierFixtures
 
   def withVerifier[R](testWith: TestWith[BagVerifier, R]): R =
     withMaterializer { implicit mat =>
-
       implicit val _bagService = new BagService()
       implicit val _s3ObjectVerifier = new S3ObjectVerifier()
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
@@ -3,9 +3,19 @@ package uk.ac.wellcome.platform.archive.bagverifier.services
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers, OptionValues, TryValues}
 import uk.ac.wellcome.platform.archive.bagverifier.fixtures.BagVerifierFixtures
-import uk.ac.wellcome.platform.archive.bagverifier.models.{VerificationFailureSummary, VerificationIncompleteSummary, VerificationSuccessSummary}
-import uk.ac.wellcome.platform.archive.common.fixtures.{BagLocationFixtures, FileEntry}
-import uk.ac.wellcome.platform.archive.common.storage.models.{IngestFailed, IngestStepSucceeded}
+import uk.ac.wellcome.platform.archive.bagverifier.models.{
+  VerificationFailureSummary,
+  VerificationIncompleteSummary,
+  VerificationSuccessSummary
+}
+import uk.ac.wellcome.platform.archive.common.fixtures.{
+  BagLocationFixtures,
+  FileEntry
+}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  IngestFailed,
+  IngestStepSucceeded
+}
 import uk.ac.wellcome.storage.fixtures.S3
 
 class BagVerifierTest
@@ -29,7 +39,10 @@ class BagVerifierTest
 
   it("passes a bag with correct checksum values ") {
     withLocalS3Bucket { bucket =>
-      withBag(storageBackend, namespace = bucket.name, dataFileCount = dataFileCount) {
+      withBag(
+        storageBackend,
+        namespace = bucket.name,
+        dataFileCount = dataFileCount) {
         case (root, _) =>
           withVerifier { verifier =>
             val ingestStep = verifier.verify(root)
@@ -155,7 +168,10 @@ class BagVerifierTest
     def noDataManifest(files: StringTuple): Option[FileEntry] = None
 
     withLocalS3Bucket { bucket =>
-      withBag(storageBackend, namespace = bucket.name, createDataManifest = noDataManifest) {
+      withBag(
+        storageBackend,
+        namespace = bucket.name,
+        createDataManifest = noDataManifest) {
         case (root, _) =>
           withVerifier { verifier =>
             val ingestStep = verifier.verify(root)
@@ -179,7 +195,10 @@ class BagVerifierTest
     def noTagManifest(files: StringTuple): Option[FileEntry] = None
 
     withLocalS3Bucket { bucket =>
-      withBag(storageBackend, namespace = bucket.name, createTagManifest = noTagManifest) {
+      withBag(
+        storageBackend,
+        namespace = bucket.name,
+        createTagManifest = noTagManifest) {
         case (root, _) =>
           withVerifier { verifier =>
             val ingestStep = verifier.verify(root)

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
@@ -3,19 +3,10 @@ package uk.ac.wellcome.platform.archive.bagverifier.services
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{FunSpec, Matchers, OptionValues, TryValues}
 import uk.ac.wellcome.platform.archive.bagverifier.fixtures.BagVerifierFixtures
-import uk.ac.wellcome.platform.archive.bagverifier.models.{
-  VerificationFailureSummary,
-  VerificationIncompleteSummary,
-  VerificationSuccessSummary
-}
-import uk.ac.wellcome.platform.archive.common.fixtures.{
-  BagLocationFixtures,
-  FileEntry
-}
-import uk.ac.wellcome.platform.archive.common.storage.models.{
-  IngestFailed,
-  IngestStepSucceeded
-}
+import uk.ac.wellcome.platform.archive.bagverifier.models.{VerificationFailureSummary, VerificationIncompleteSummary, VerificationSuccessSummary}
+import uk.ac.wellcome.platform.archive.common.fixtures.{BagLocationFixtures, FileEntry}
+import uk.ac.wellcome.platform.archive.common.storage.models.{IngestFailed, IngestStepSucceeded}
+import uk.ac.wellcome.storage.fixtures.S3
 
 class BagVerifierTest
     extends FunSpec
@@ -24,7 +15,8 @@ class BagVerifierTest
     with TryValues
     with OptionValues
     with BagLocationFixtures
-    with BagVerifierFixtures {
+    with BagVerifierFixtures
+    with S3 {
 
   type StringTuple = List[(String, String)]
 
@@ -37,7 +29,7 @@ class BagVerifierTest
 
   it("passes a bag with correct checksum values ") {
     withLocalS3Bucket { bucket =>
-      withBag(bucket, dataFileCount = dataFileCount) {
+      withBag(storageBackend, namespace = bucket.name, dataFileCount = dataFileCount) {
         case (root, _) =>
           withVerifier { verifier =>
             val ingestStep = verifier.verify(root)
@@ -59,7 +51,8 @@ class BagVerifierTest
   it("fails a bag with an incorrect checksum in the file manifest") {
     withLocalS3Bucket { bucket =>
       withBag(
-        bucket,
+        storageBackend,
+        namespace = bucket.name,
         dataFileCount = dataFileCount,
         createDataManifest = dataManifestWithWrongChecksum) {
         case (root, _) =>
@@ -90,7 +83,8 @@ class BagVerifierTest
   it("fails a bag with an incorrect checksum in the tag manifest") {
     withLocalS3Bucket { bucket =>
       withBag(
-        bucket,
+        storageBackend,
+        namespace = bucket.name,
         dataFileCount = dataFileCount,
         createTagManifest = tagManifestWithWrongChecksum) {
         case (root, _) =>
@@ -127,7 +121,8 @@ class BagVerifierTest
 
     withLocalS3Bucket { bucket =>
       withBag(
-        bucket,
+        storageBackend,
+        namespace = bucket.name,
         dataFileCount = dataFileCount,
         createDataManifest = createDataManifestWithExtraFile) {
         case (root, _) =>
@@ -160,7 +155,7 @@ class BagVerifierTest
     def noDataManifest(files: StringTuple): Option[FileEntry] = None
 
     withLocalS3Bucket { bucket =>
-      withBag(bucket, createDataManifest = noDataManifest) {
+      withBag(storageBackend, namespace = bucket.name, createDataManifest = noDataManifest) {
         case (root, _) =>
           withVerifier { verifier =>
             val ingestStep = verifier.verify(root)
@@ -184,7 +179,7 @@ class BagVerifierTest
     def noTagManifest(files: StringTuple): Option[FileEntry] = None
 
     withLocalS3Bucket { bucket =>
-      withBag(bucket, createTagManifest = noTagManifest) {
+      withBag(storageBackend, namespace = bucket.name, createTagManifest = noTagManifest) {
         case (root, _) =>
           withVerifier { verifier =>
             val ingestStep = verifier.verify(root)

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
@@ -47,13 +47,7 @@ class BagVerifierWorkerTest
               )
             )
 
-            outgoing.messages
-              .map {
-                _.body
-              }
-              .map {
-                fromJson[BagInformationPayload](_).get
-              } shouldBe Seq(payload)
+            outgoing.getMessages[BagInformationPayload]() shouldBe Seq(payload)
         }
       }
     }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
@@ -7,7 +7,10 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.bagverifier.fixtures.BagVerifierFixtures
 import uk.ac.wellcome.platform.archive.common.BagInformationPayload
-import uk.ac.wellcome.platform.archive.common.fixtures.{BagLocationFixtures, FileEntry}
+import uk.ac.wellcome.platform.archive.common.fixtures.{
+  BagLocationFixtures,
+  FileEntry
+}
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
@@ -59,7 +62,10 @@ class BagVerifierWorkerTest
 
     withBagVerifierWorker(ingests, outgoing) { service =>
       withLocalS3Bucket { bucket =>
-        withBag(storageBackend, namespace = bucket.name, createDataManifest = dataManifestWithWrongChecksum) {
+        withBag(
+          storageBackend,
+          namespace = bucket.name,
+          createDataManifest = dataManifestWithWrongChecksum) {
           case (bagRootLocation, _) =>
             val payload = createBagInformationPayloadWith(
               bagRootLocation = bagRootLocation
@@ -85,14 +91,17 @@ class BagVerifierWorkerTest
 
   it("only updates the ingest monitor if it cannot perform the verification") {
     def dontCreateTheDataManifest(
-                                   dataFiles: List[(String, String)]): Option[FileEntry] = None
+      dataFiles: List[(String, String)]): Option[FileEntry] = None
 
     val ingests = createMessageSender
     val outgoing = createMessageSender
 
     withBagVerifierWorker(ingests, outgoing) { service =>
       withLocalS3Bucket { bucket =>
-        withBag(storageBackend, namespace = bucket.name, createDataManifest = dontCreateTheDataManifest) {
+        withBag(
+          storageBackend,
+          namespace = bucket.name,
+          createDataManifest = dontCreateTheDataManifest) {
           case (bagRootLocation, _) =>
             val payload = createBagInformationPayloadWith(
               bagRootLocation = bagRootLocation
@@ -123,7 +132,8 @@ class BagVerifierWorkerTest
       destination = randomAlphanumeric(),
       subject = randomAlphanumeric()
     ) {
-      override def sendT[T](t: T)(implicit encoder: Encoder[T]): Try[Unit] = Failure(new Throwable("BOOM!"))
+      override def sendT[T](t: T)(implicit encoder: Encoder[T]): Try[Unit] =
+        Failure(new Throwable("BOOM!"))
     }
 
     withBagVerifierWorker(ingests, outgoing) { service =>

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
@@ -1,17 +1,18 @@
 package uk.ac.wellcome.platform.archive.bagverifier.services
 
+import io.circe.Encoder
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.fixtures.SNS.Topic
+import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.bagverifier.fixtures.BagVerifierFixtures
-import uk.ac.wellcome.platform.archive.common.fixtures.{
-  BagLocationFixtures,
-  FileEntry
-}
+import uk.ac.wellcome.platform.archive.common.BagInformationPayload
+import uk.ac.wellcome.platform.archive.common.fixtures.{BagLocationFixtures, FileEntry}
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
-import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
+import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
+
+import scala.util.{Failure, Success, Try}
 
 class BagVerifierWorkerTest
     extends FunSpec
@@ -24,69 +25,65 @@ class BagVerifierWorkerTest
     with PayloadGenerators {
 
   it(
-    "updates the ingest monitor and sends an outgoing notification if verification succeeds") {
-    withLocalSnsTopic { ingestTopic =>
-      withLocalSnsTopic { outgoingTopic =>
-        withBagVerifierWorker(ingestTopic, outgoingTopic) { service =>
-          withLocalS3Bucket { bucket =>
-            withBag(bucket) {
-              case (bagRootLocation, _) =>
-                val payload = createBagInformationPayloadWith(
-                  bagRootLocation = bagRootLocation
-                )
+    "updates the ingests app and sends an outgoing notification if verification succeeds") {
+    val ingests = createMessageSender
+    val outgoing = createMessageSender
 
-                val future = service.processMessage(payload)
+    withBagVerifierWorker(ingests, outgoing) { service =>
+      withLocalS3Bucket { bucket =>
+        withBag(storageBackend, namespace = bucket.name) {
+          case (bagRootLocation, _) =>
+            val payload = createBagInformationPayloadWith(
+              bagRootLocation = bagRootLocation
+            )
 
-                whenReady(future) { _ =>
-                  eventually {
-                    assertTopicReceivesIngestEvents(
-                      payload.ingestId,
-                      ingestTopic,
-                      expectedDescriptions = Seq(
-                        "Verification started",
-                        "Verification succeeded"
-                      )
-                    )
+            service.processMessage(payload) shouldBe a[Success[_]]
 
-                    assertSnsReceivesOnly(payload, topic = outgoingTopic)
-                  }
-                }
-            }
-          }
+            assertReceivesIngestEvents(ingests)(
+              payload.ingestId,
+              expectedDescriptions = Seq(
+                "Verification started",
+                "Verification succeeded"
+              )
+            )
+
+            outgoing.messages
+              .map {
+                _.body
+              }
+              .map {
+                fromJson[BagInformationPayload](_).get
+              } shouldBe Seq(payload)
         }
       }
     }
   }
 
   it("only updates the ingest monitor if verification fails") {
-    withLocalSnsTopic { ingestTopic =>
-      withLocalSnsTopic { outgoingTopic =>
-        withBagVerifierWorker(ingestTopic, outgoingTopic) { service =>
-          withLocalS3Bucket { bucket =>
-            withBag(bucket, createDataManifest = dataManifestWithWrongChecksum) {
-              case (bagRootLocation, _) =>
-                val payload = createBagInformationPayloadWith(
-                  bagRootLocation = bagRootLocation
-                )
+    val ingests = createMessageSender
+    val outgoing = createMessageSender
 
-                val future = service.processMessage(payload)
+    withBagVerifierWorker(ingests, outgoing) { service =>
+      withLocalS3Bucket { bucket =>
+        withBag(storageBackend, namespace = bucket.name, createDataManifest = dataManifestWithWrongChecksum) {
+          case (bagRootLocation, _) =>
+            val payload = createBagInformationPayloadWith(
+              bagRootLocation = bagRootLocation
+            )
 
-                whenReady(future) { _ =>
-                  assertSnsReceivesNothing(outgoingTopic)
+            service.processMessage(payload) shouldBe a[Success[_]]
 
-                  assertTopicReceivesIngestStatus(
-                    ingestId = payload.ingestId,
-                    ingestTopic = ingestTopic,
-                    status = Ingest.Failed
-                  ) { events =>
-                    val description = events.map {
-                      _.description
-                    }.head
-                    description should startWith("Verification failed")
-                  }
-                }
+            outgoing.messages shouldBe empty
+
+            assertReceivesIngestStatus(ingests)(
+              ingestId = payload.ingestId,
+              status = Ingest.Failed
+            ) { events =>
+              val description = events.map {
+                _.description
+              }.head
+              description should startWith("Verification failed")
             }
-          }
         }
       }
     }
@@ -94,67 +91,62 @@ class BagVerifierWorkerTest
 
   it("only updates the ingest monitor if it cannot perform the verification") {
     def dontCreateTheDataManifest(
-      dataFiles: List[(String, String)]): Option[FileEntry] = None
+                                   dataFiles: List[(String, String)]): Option[FileEntry] = None
 
-    withLocalSnsTopic { ingestTopic =>
-      withLocalSnsTopic { outgoingTopic =>
-        withBagVerifierWorker(ingestTopic, outgoingTopic) { service =>
-          withLocalS3Bucket { bucket =>
-            withBag(bucket, createDataManifest = dontCreateTheDataManifest) {
-              case (bagRootLocation, _) =>
-                val payload = createBagInformationPayloadWith(
-                  bagRootLocation = bagRootLocation
-                )
+    val ingests = createMessageSender
+    val outgoing = createMessageSender
 
-                val future = service.processMessage(payload)
+    withBagVerifierWorker(ingests, outgoing) { service =>
+      withLocalS3Bucket { bucket =>
+        withBag(storageBackend, namespace = bucket.name, createDataManifest = dontCreateTheDataManifest) {
+          case (bagRootLocation, _) =>
+            val payload = createBagInformationPayloadWith(
+              bagRootLocation = bagRootLocation
+            )
 
-                whenReady(future) { _ =>
-                  eventually {
+            service.processMessage(payload) shouldBe a[Success[_]]
 
-                    assertSnsReceivesNothing(outgoingTopic)
+            outgoing.messages shouldBe empty
 
-                    assertTopicReceivesIngestStatus(
-                      ingestId = payload.ingestId,
-                      ingestTopic = ingestTopic,
-                      status = Ingest.Failed
-                    ) { events =>
-                      val description = events.map {
-                        _.description
-                      }.head
-                      description should startWith("Verification failed")
-                    }
-                  }
-                }
+            assertReceivesIngestStatus(ingests)(
+              ingestId = payload.ingestId,
+              status = Ingest.Failed
+            ) { events =>
+              val description = events.map {
+                _.description
+              }.head
+              description should startWith("Verification failed")
             }
-          }
         }
       }
     }
   }
 
   it("sends a ingest update before it sends an outgoing message") {
-    withLocalSnsTopic { ingestTopic =>
-      withBagVerifierWorker(ingestTopic, Topic("no-such-outgoing")) { service =>
-        withLocalS3Bucket { bucket =>
-          withBag(bucket) {
-            case (bagRootLocation, _) =>
-              val payload = createBagInformationPayloadWith(
-                bagRootLocation = bagRootLocation
-              )
+    val ingests = createMessageSender
 
-              val future = service.processMessage(payload)
+    val outgoing = new MemoryMessageSender(
+      destination = randomAlphanumeric(),
+      subject = randomAlphanumeric()
+    ) {
+      override def sendT[T](t: T)(implicit encoder: Encoder[T]): Try[Unit] = Failure(new Throwable("BOOM!"))
+    }
 
-              whenReady(future.failed) { _ =>
-                assertTopicReceivesIngestEvent(
-                  ingestId = payload.ingestId,
-                  ingestTopic = ingestTopic
-                ) { events =>
-                  events.map {
-                    _.description
-                  } shouldBe List("Verification succeeded")
-                }
-              }
-          }
+    withBagVerifierWorker(ingests, outgoing) { service =>
+      withLocalS3Bucket { bucket =>
+        withBag(storageBackend, namespace = bucket.name) {
+          case (bagRootLocation, _) =>
+            val payload = createBagInformationPayloadWith(
+              bagRootLocation = bagRootLocation
+            )
+
+            service.processMessage(payload) shouldBe a[Failure[_]]
+
+            assertReceivesIngestEvent(ingests)(payload.ingestId) { events =>
+              events.map {
+                _.description
+              } shouldBe List("Verification succeeded")
+            }
         }
       }
     }

--- a/common/docker-compose.yml
+++ b/common/docker-compose.yml
@@ -8,7 +8,3 @@ dynamodb:
   image: peopleperhour/dynamodb
   ports:
     - "45678:8000"
-sns:
-  image: wellcome/fake-sns
-  ports:
-    - "9292:9292"

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/IngestID.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/IngestID.scala
@@ -20,7 +20,7 @@ object IngestID {
   implicit val decoder: Decoder[IngestID] =
     Decoder.instance[IngestID](cursor => cursor.value.as[UUID].map(IngestID(_)))
 
-  implicit def fmtSpace: DynamoFormat[IngestID] =
+  implicit def evidence: DynamoFormat[IngestID] =
     DynamoFormat.coercedXmap[IngestID, String, IllegalArgumentException](
       id => IngestID(UUID.fromString(id))
     )(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagService.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagService.scala
@@ -1,25 +1,23 @@
 package uk.ac.wellcome.platform.archive.common.bagit.services
 
-import com.amazonaws.services.s3.AmazonS3
 import grizzled.slf4j.Logging
-import uk.ac.wellcome.platform.archive.common.storage.services.S3StreamableInstances
+import uk.ac.wellcome.platform.archive.common.storage.services.StreamableInstances
 import uk.ac.wellcome.platform.archive.common.verify.{HashingAlgorithm, SHA256}
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.{ObjectLocation, StorageBackend}
 
 import scala.util.{Failure, Try}
 
-class BagService()(implicit s3Client: AmazonS3) extends Logging {
+class BagService()(implicit storageBackend: StorageBackend) extends Logging {
 
-  import S3StreamableInstances._
+  import StreamableInstances._
   import uk.ac.wellcome.platform.archive.common.bagit.models._
 
-  val checksumAlgorithm = SHA256
+  val checksumAlgorithm: HashingAlgorithm = SHA256
 
-  private def recoverable[T](tryT: Try[T])(message: String) = {
+  private def recoverable[T](tryT: Try[T])(message: String): Try[T] =
     tryT.recoverWith {
       case e => Failure(new RuntimeException(s"$message: ${e.getMessage}"))
     }
-  }
 
   def retrieve(root: ObjectLocation): Try[Bag] = {
     debug(s"BagService attempting to create Bag @ $root")

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/config/builders/IngestUpdaterBuilder.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/config/builders/IngestUpdaterBuilder.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.platform.archive.common.config.builders
 
 import com.typesafe.config.Config
+import uk.ac.wellcome.messaging.sns.SNSConfig
 import uk.ac.wellcome.messaging.typesafe.SNSBuilder
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 
@@ -8,12 +9,13 @@ import scala.concurrent.ExecutionContext
 
 object IngestUpdaterBuilder {
   def build(config: Config, operationName: String)(
-    implicit ec: ExecutionContext): IngestUpdater =
+    implicit ec: ExecutionContext): IngestUpdater[SNSConfig] =
     new IngestUpdater(
       stepName = operationName,
-      snsWriter = SNSBuilder.buildSNSWriter(
+      messageSender = SNSBuilder.buildSNSMessageSender(
         config = config,
-        namespace = "ingest"
+        namespace = "ingest",
+        subject = "Sent by IngestUpdater"
       )
     )
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/config/builders/IngestUpdaterBuilder.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/config/builders/IngestUpdaterBuilder.scala
@@ -5,11 +5,8 @@ import uk.ac.wellcome.messaging.sns.SNSConfig
 import uk.ac.wellcome.messaging.typesafe.SNSBuilder
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 
-import scala.concurrent.ExecutionContext
-
 object IngestUpdaterBuilder {
-  def build(config: Config, operationName: String)(
-    implicit ec: ExecutionContext): IngestUpdater[SNSConfig] =
+  def build(config: Config, operationName: String): IngestUpdater[SNSConfig] =
     new IngestUpdater(
       stepName = operationName,
       messageSender = SNSBuilder.buildSNSMessageSender(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/config/builders/OutgoingPublisherBuilder.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/config/builders/OutgoingPublisherBuilder.scala
@@ -1,16 +1,18 @@
 package uk.ac.wellcome.platform.archive.common.config.builders
 
 import com.typesafe.config.Config
+import uk.ac.wellcome.messaging.sns.SNSConfig
 import uk.ac.wellcome.messaging.typesafe.SNSBuilder
 import uk.ac.wellcome.platform.archive.common.operation.services.OutgoingPublisher
 
 object OutgoingPublisherBuilder {
-  def build(config: Config, operationName: String): OutgoingPublisher =
+  def build(config: Config, operationName: String): OutgoingPublisher[SNSConfig] =
     new OutgoingPublisher(
       operationName = operationName,
-      snsWriter = SNSBuilder.buildSNSWriter(
+      messageSender = SNSBuilder.buildSNSMessageSender(
         config = config,
-        namespace = "outgoing"
+        namespace = "outgoing",
+        subject = "Sent by OutgoingPublisher"
       )
     )
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/config/builders/OutgoingPublisherBuilder.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/config/builders/OutgoingPublisherBuilder.scala
@@ -6,7 +6,8 @@ import uk.ac.wellcome.messaging.typesafe.SNSBuilder
 import uk.ac.wellcome.platform.archive.common.operation.services.OutgoingPublisher
 
 object OutgoingPublisherBuilder {
-  def build(config: Config, operationName: String): OutgoingPublisher[SNSConfig] =
+  def build(config: Config,
+            operationName: String): OutgoingPublisher[SNSConfig] =
     new OutgoingPublisher(
       operationName = operationName,
       messageSender = SNSBuilder.buildSNSMessageSender(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/dynamo.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/dynamo.scala
@@ -14,32 +14,37 @@ object dynamo {
     location: ObjectLocation
   )
 
-  implicit val dynamoFormat: DynamoFormat[Entry[String, EmptyMetadata]] = new DynamoFormat[Entry[String, EmptyMetadata]] {
-    override def read(av: AttributeValue): Either[DynamoReadError, Entry[String, EmptyMetadata]] =
-      DynamoFormat[HybridRecord].read(av).map { hybridRecord =>
-        Entry(
-          id = hybridRecord.id,
-          version = hybridRecord.version,
-          location = hybridRecord.location,
-          metadata = EmptyMetadata()
-        )
-      }
+  implicit val dynamoFormat: DynamoFormat[Entry[String, EmptyMetadata]] =
+    new DynamoFormat[Entry[String, EmptyMetadata]] {
+      override def read(av: AttributeValue)
+        : Either[DynamoReadError, Entry[String, EmptyMetadata]] =
+        DynamoFormat[HybridRecord].read(av).map { hybridRecord =>
+          Entry(
+            id = hybridRecord.id,
+            version = hybridRecord.version,
+            location = hybridRecord.location,
+            metadata = EmptyMetadata()
+          )
+        }
 
-    override def write(entry: Entry[String, EmptyMetadata]): AttributeValue =
-      DynamoFormat[HybridRecord].write(
+      override def write(entry: Entry[String, EmptyMetadata]): AttributeValue =
+        DynamoFormat[HybridRecord].write(
+          HybridRecord(
+            id = entry.id,
+            version = entry.version,
+            location = entry.location
+          )
+        )
+    }
+
+  implicit val updateExpressionGenerator
+    : UpdateExpressionGenerator[Entry[String, EmptyMetadata]] =
+    (entry: Entry[String, EmptyMetadata]) =>
+      UpdateExpressionGenerator[HybridRecord].generateUpdateExpression(
         HybridRecord(
           id = entry.id,
           version = entry.version,
           location = entry.location
         )
-      )
-  }
-
-  implicit val updateExpressionGenerator: UpdateExpressionGenerator[Entry[String, EmptyMetadata]] = (entry: Entry[String, EmptyMetadata]) => UpdateExpressionGenerator[HybridRecord].generateUpdateExpression(
-    HybridRecord(
-      id = entry.id,
-      version = entry.version,
-      location = entry.location
     )
-  )
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/dynamo.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/dynamo.scala
@@ -1,0 +1,45 @@
+package uk.ac.wellcome.platform.archive.common
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue
+import com.gu.scanamo.DynamoFormat
+import com.gu.scanamo.error.DynamoReadError
+import uk.ac.wellcome.storage.dynamo._
+import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.vhs.{EmptyMetadata, Entry}
+
+object dynamo {
+  case class HybridRecord(
+    id: String,
+    version: Int,
+    location: ObjectLocation
+  )
+
+  implicit val dynamoFormat: DynamoFormat[Entry[String, EmptyMetadata]] = new DynamoFormat[Entry[String, EmptyMetadata]] {
+    override def read(av: AttributeValue): Either[DynamoReadError, Entry[String, EmptyMetadata]] =
+      DynamoFormat[HybridRecord].read(av).map { hybridRecord =>
+        Entry(
+          id = hybridRecord.id,
+          version = hybridRecord.version,
+          location = hybridRecord.location,
+          metadata = EmptyMetadata()
+        )
+      }
+
+    override def write(entry: Entry[String, EmptyMetadata]): AttributeValue =
+      DynamoFormat[HybridRecord].write(
+        HybridRecord(
+          id = entry.id,
+          version = entry.version,
+          location = entry.location
+        )
+      )
+  }
+
+  implicit val updateExpressionGenerator: UpdateExpressionGenerator[Entry[String, EmptyMetadata]] = (entry: Entry[String, EmptyMetadata]) => UpdateExpressionGenerator[HybridRecord].generateUpdateExpression(
+    HybridRecord(
+      id = entry.id,
+      version = entry.version,
+      location = entry.location
+    )
+  )
+}

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/http/WellcomeHttpApp.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/http/WellcomeHttpApp.scala
@@ -119,10 +119,7 @@ class WellcomeHttpApp(routes: Route,
     ExceptionHandler {
       case err: Exception =>
         logger.error(s"Unexpected exception $err")
-        val error = InternalServerErrorResponse(
-          context = contextURL,
-          statusCode = InternalServerError
-        )
+        val error = InternalServerErrorResponse(contextURL)
         httpMetrics.sendMetricForStatus(InternalServerError)
         complete(InternalServerError -> error)
     }
@@ -133,10 +130,7 @@ class WellcomeHttpApp(routes: Route,
       .mapAsync(parallelism = 1)(data => {
         val description = data.utf8String
         if (statusCode.intValue() >= 500) {
-          val response = InternalServerErrorResponse(
-            context = contextURL,
-            statusCode = statusCode
-          )
+          val response = InternalServerErrorResponse(contextURL)
           Marshal(response).to[MessageEntity]
         } else {
           val response = UserErrorResponse(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/http/models/ErrorResponse.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/http/models/ErrorResponse.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.archive.common.http.models
 
 import java.net.URL
 
-import akka.http.scaladsl.model.StatusCode
+import akka.http.scaladsl.model.{StatusCode, StatusCodes}
 import io.circe.generic.extras.JsonKey
 
 case class UserErrorResponse(
@@ -33,10 +33,10 @@ case class InternalServerErrorResponse(
 )
 
 case object InternalServerErrorResponse {
-  def apply(context: URL, statusCode: StatusCode): InternalServerErrorResponse =
+  def apply(context: URL): InternalServerErrorResponse =
     InternalServerErrorResponse(
       context = context.toString,
-      httpStatus = statusCode.intValue(),
-      label = statusCode.reason()
+      httpStatus = StatusCodes.InternalServerError.intValue,
+      label = StatusCodes.InternalServerError.reason
     )
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdater.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdater.scala
@@ -8,14 +8,12 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models._
 
-import scala.concurrent.ExecutionContext
 import scala.util.Try
 
 class IngestUpdater[Destination](
   stepName: String,
   messageSender: MessageSender[Destination]
-)(implicit ec: ExecutionContext)
-    extends Logging {
+) extends Logging {
 
   def start(ingestId: IngestID): Try[Unit] =
     send(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdater.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdater.scala
@@ -2,21 +2,22 @@ package uk.ac.wellcome.platform.archive.common.ingests.services
 
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.sns.SNSWriter
+import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.platform.archive.common.IngestID
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models._
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
+import scala.util.Try
 
-class IngestUpdater(
+class IngestUpdater[Destination](
   stepName: String,
-  snsWriter: SNSWriter
+  messageSender: MessageSender[Destination]
 )(implicit ec: ExecutionContext)
     extends Logging {
 
-  def start(ingestId: IngestID): Future[Unit] =
+  def start(ingestId: IngestID): Try[Unit] =
     send(
       ingestId = ingestId,
       step = IngestStepStarted(ingestId)
@@ -26,7 +27,7 @@ class IngestUpdater(
     ingestId: IngestID,
     step: IngestStep[R],
     bagId: Option[BagId] = None
-  ): Future[Unit] = {
+  ): Try[Unit] = {
     val update = step match {
       case IngestCompleted(_) =>
         IngestStatusUpdate(
@@ -65,17 +66,10 @@ class IngestUpdater(
         )
     }
 
-    snsWriter
-      .writeMessage[IngestUpdate](
-        update,
-        subject = s"Sent by ${this.getClass.getSimpleName}"
-      )
-      .map { _ =>
-        ()
-      }
+    messageSender.sendT[IngestUpdate](update)
   }
 
-  def sendEvent(ingestId: IngestID, messages: Seq[String]): Future[Unit] = {
+  def sendEvent(ingestId: IngestID, messages: Seq[String]): Try[Unit] = {
     val update: IngestUpdate = IngestEventUpdate(
       id = ingestId,
       events = messages.map { m: String =>
@@ -83,14 +77,7 @@ class IngestUpdater(
       }
     )
 
-    snsWriter
-      .writeMessage[IngestUpdate](
-        update,
-        subject = s"Sent by ${this.getClass.getSimpleName}"
-      )
-      .map { _ =>
-        ()
-      }
+    messageSender.sendT[IngestUpdate](update)
   }
 
   val descriptionMaxLength = 250

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
@@ -1,20 +1,13 @@
 package uk.ac.wellcome.platform.archive.common.storage.services
 
-import com.amazonaws.services.s3.AmazonS3
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagService
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  InfrequentAccessStorageProvider,
-  StorageLocation
-}
-import uk.ac.wellcome.platform.archive.common.storage.models.{
-  StorageManifest,
-  StorageSpace
-}
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.platform.archive.common.ingests.models.{InfrequentAccessStorageProvider, StorageLocation}
+import uk.ac.wellcome.platform.archive.common.storage.models.{StorageManifest, StorageSpace}
+import uk.ac.wellcome.storage.{ObjectLocation, StorageBackend}
 
 import scala.util.Try
 
-class StorageManifestService(implicit s3Client: AmazonS3) {
+class StorageManifestService(implicit storageBackend: StorageBackend) {
   val bagService = new BagService()
 
   def retrieve(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
@@ -1,8 +1,14 @@
 package uk.ac.wellcome.platform.archive.common.storage.services
 
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagService
-import uk.ac.wellcome.platform.archive.common.ingests.models.{InfrequentAccessStorageProvider, StorageLocation}
-import uk.ac.wellcome.platform.archive.common.storage.models.{StorageManifest, StorageSpace}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  InfrequentAccessStorageProvider,
+  StorageLocation
+}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  StorageManifest,
+  StorageSpace
+}
 import uk.ac.wellcome.storage.{ObjectLocation, StorageBackend}
 
 import scala.util.Try

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestVHS.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestVHS.scala
@@ -2,25 +2,21 @@ package uk.ac.wellcome.platform.archive.common.storage.services
 
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
-import uk.ac.wellcome.storage.ObjectStore
-import uk.ac.wellcome.storage.dynamo._
 import uk.ac.wellcome.storage.vhs.{EmptyMetadata, VersionedHybridStore}
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
 
 class StorageManifestVHS(
-  underlying: VersionedHybridStore[StorageManifest,
-                                   EmptyMetadata,
-                                   ObjectStore[StorageManifest]]
-)(implicit ec: ExecutionContext) {
+  underlying: VersionedHybridStore[String, StorageManifest, EmptyMetadata]
+) {
 
-  def getRecord(id: BagId): Future[Option[StorageManifest]] =
-    underlying.getRecord(id = id.toString)
+  def getRecord(id: BagId): Try[Option[StorageManifest]] =
+    underlying.get(id = id.toString)
 
   def updateRecord(ifNotExisting: StorageManifest)(
-    ifExisting: StorageManifest => StorageManifest): Future[Unit] =
+    ifExisting: StorageManifest => StorageManifest): Try[Unit] =
     underlying
-      .updateRecord(
+      .update(
         id = ifNotExisting.id.toString
       )(
         ifNotExisting = (ifNotExisting, EmptyMetadata())
@@ -35,6 +31,6 @@ class StorageManifestVHS(
         ()
       }
 
-  def insertRecord(storageManifest: StorageManifest): Future[Unit] =
+  def insertRecord(storageManifest: StorageManifest): Try[Unit] =
     updateRecord(storageManifest)(_ => storageManifest)
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StreamableInstances.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StreamableInstances.scala
@@ -2,27 +2,21 @@ package uk.ac.wellcome.platform.archive.common.storage.services
 
 import java.io.InputStream
 
-import com.amazonaws.services.s3.AmazonS3
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.common.storage.{Resolvable, Streamable}
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.{ObjectLocation, StorageBackend}
 
 import scala.util.Try
 
-object S3StreamableInstances {
+object StreamableInstances {
 
   implicit class ObjectLocationStreamable(location: ObjectLocation)(
-    implicit s3Client: AmazonS3)
+    implicit storageBackend: StorageBackend)
       extends Logging {
     def toInputStream: Try[InputStream] = {
       debug(s"Converting $location to InputStream")
 
-      val result = Try(
-        s3Client.getObject(
-          location.namespace,
-          location.key
-        )
-      ).map(_.getObjectContent)
+      val result = storageBackend.get(location)
 
       debug(s"Got: $result")
 
@@ -30,19 +24,19 @@ object S3StreamableInstances {
     }
   }
 
-  implicit class ResolvableStreamable[T](t: T)(implicit s3Client: AmazonS3,
+  implicit class ResolvableStreamable[T](t: T)(implicit storageBackend: StorageBackend,
                                                resolver: Resolvable[T])
       extends Logging {
-    def from(root: ObjectLocation) = {
+    def from(root: ObjectLocation): Try[InputStream] = {
       debug(s"Attempting to resolve Streamable $t")
 
       val streamable = new Streamable[T, InputStream] {
         override def stream(t: T): Try[InputStream] = {
           debug(s"Converting $t to InputStream")
 
-          val resolved = resolver.resolve(root)(t)
+          val resolvedLocation: ObjectLocation = resolver.resolve(root)(t)
 
-          resolved.toInputStream
+          resolvedLocation.toInputStream
         }
       }
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StreamableInstances.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StreamableInstances.scala
@@ -24,8 +24,9 @@ object StreamableInstances {
     }
   }
 
-  implicit class ResolvableStreamable[T](t: T)(implicit storageBackend: StorageBackend,
-                                               resolver: Resolvable[T])
+  implicit class ResolvableStreamable[T](t: T)(
+    implicit storageBackend: StorageBackend,
+    resolver: Resolvable[T])
       extends Logging {
     def from(root: ObjectLocation): Try[InputStream] = {
       debug(s"Attempting to resolve Streamable $t")

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagIt.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagIt.scala
@@ -5,6 +5,7 @@ import java.time.LocalDate
 
 import uk.ac.wellcome.platform.archive.common.bagit.models._
 
+import scala.collection.immutable
 import scala.util.Random
 
 trait BagIt extends RandomThings {
@@ -160,22 +161,14 @@ trait BagIt extends RandomThings {
       """.stripMargin.trim
   }
 
-  private def createDataFiles(dataFileCount: Int) = {
-    val subPathLength = Random.nextInt(3)
-    val subPathDirectories = (0 to subPathLength).map { _ =>
-      randomAlphanumericWithSpace()
-    }
-    val subPath = subPathDirectories.mkString("/")
-
-    (1 to dataFileCount).map { _ =>
-      val fileName = randomAlphanumericWithSpace()
-      val filePath = s"data/$subPath/$fileName.txt"
+  private def createDataFiles(dataFileCount: Int): immutable.Seq[FileEntry] =
+    (1 to dataFileCount).map { count =>
+      val filePath = s"data/$count.txt"
       val fileContents = Random.nextString(256)
       FileEntry(filePath, fileContents)
     }
-  }
 
-  def createValidDigest(string: String) =
+  def createValidDigest(string: String): String =
     MessageDigest
       .getInstance("SHA-256")
       .digest(string.getBytes)

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagLocationFixtures.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagLocationFixtures.scala
@@ -6,6 +6,7 @@ import uk.ac.wellcome.platform.archive.common.generators.{BagInfoGenerators, Sto
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.{ObjectLocation, StorageBackend}
 import uk.ac.wellcome.storage.SerialisationStrategy.stringStrategy
+import uk.ac.wellcome.storage.memory.MemoryStorageBackend
 
 trait BagLocationFixtures
     extends BagInfoGenerators
@@ -13,7 +14,7 @@ trait BagLocationFixtures
     with StorageSpaceGenerators {
 
   def withBag[R](
-    backend: StorageBackend,
+    backend: StorageBackend = new MemoryStorageBackend(),
     namespace: String = "BagLocationFixtures",
     bagInfo: BagInfo = createBagInfo,
     dataFileCount: Int = 1,

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagLocationFixtures.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagLocationFixtures.scala
@@ -2,7 +2,10 @@ package uk.ac.wellcome.platform.archive.common.fixtures
 
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagInfo
-import uk.ac.wellcome.platform.archive.common.generators.{BagInfoGenerators, StorageSpaceGenerators}
+import uk.ac.wellcome.platform.archive.common.generators.{
+  BagInfoGenerators,
+  StorageSpaceGenerators
+}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.{ObjectLocation, StorageBackend}
 import uk.ac.wellcome.storage.SerialisationStrategy.stringStrategy

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagLocationFixtures.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagLocationFixtures.scala
@@ -4,9 +4,8 @@ import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagInfo
 import uk.ac.wellcome.platform.archive.common.generators.{BagInfoGenerators, StorageSpaceGenerators}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.{ObjectLocation, StorageBackend}
 import uk.ac.wellcome.storage.SerialisationStrategy.stringStrategy
-import uk.ac.wellcome.storage.memory.MemoryStorageBackend
 
 trait BagLocationFixtures
     extends BagInfoGenerators
@@ -14,7 +13,8 @@ trait BagLocationFixtures
     with StorageSpaceGenerators {
 
   def withBag[R](
-    backend: MemoryStorageBackend,
+    backend: StorageBackend,
+    namespace: String = "BagLocationFixtures",
     bagInfo: BagInfo = createBagInfo,
     dataFileCount: Int = 1,
     storageSpace: StorageSpace = createStorageSpace,
@@ -37,7 +37,7 @@ trait BagLocationFixtures
     debug(s"fileEntries: $fileEntries")
 
     val storageSpaceRootLocation = ObjectLocation(
-      namespace = "BagLocationFixtures",
+      namespace = namespace,
       key = storageSpace.toString
     )
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/OperationFixtures.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/OperationFixtures.scala
@@ -1,13 +1,11 @@
 package uk.ac.wellcome.platform.archive.common.fixtures
 
 import uk.ac.wellcome.messaging.MessageSender
-import uk.ac.wellcome.messaging.fixtures.SNS
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
-import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services.OutgoingPublisher
 
-trait OperationFixtures extends SNS with MetricsSenderFixture with RandomThings {
+trait OperationFixtures extends RandomThings {
   type Destination = String
 
   def createStepName: String = randomAlphanumeric()

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/OperationFixtures.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/OperationFixtures.scala
@@ -1,28 +1,33 @@
 package uk.ac.wellcome.platform.archive.common.fixtures
 
-import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.fixtures.SNS
-import uk.ac.wellcome.messaging.fixtures.SNS.Topic
+import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services.OutgoingPublisher
 
-import scala.concurrent.ExecutionContext.Implicits.global
+trait OperationFixtures extends SNS with MetricsSenderFixture with RandomThings {
+  type Destination = String
 
-trait OperationFixtures extends SNS with MetricsSenderFixture {
-  def withIngestUpdater[R](stepName: String, topic: Topic)(
-    testWith: TestWith[IngestUpdater, R]): R =
-    withSNSWriter(topic) { snsWriter =>
-      val ingestNotifier = new IngestUpdater(stepName, snsWriter)
+  def createStepName: String = randomAlphanumeric()
 
-      testWith(ingestNotifier)
-    }
+  def createMessageSender: MemoryMessageSender = new MemoryMessageSender(
+    destination = randomAlphanumeric(),
+    subject = randomAlphanumeric()
+  )
 
-  def withOutgoingPublisher[R](operationName: String, topic: Topic)(
-    testWith: TestWith[OutgoingPublisher, R]): R =
-    withSNSWriter(topic) { snsWriter =>
-      val outgoingNotifier = new OutgoingPublisher(operationName, snsWriter)
+  def createIngestUpdater(stepName: String = createStepName, messageSender: MessageSender[Destination] = createMessageSender): IngestUpdater[Destination] =
+    new IngestUpdater[String](
+      stepName = stepName,
+      messageSender = messageSender
+    )
 
-      testWith(outgoingNotifier)
-    }
+  def createOperationName: String = randomAlphanumeric()
+
+  def createOutgoingPublisher(operationName: String = createOperationName, messageSender: MessageSender[Destination] = createMessageSender): OutgoingPublisher[Destination] =
+    new OutgoingPublisher[Destination](
+      operationName = operationName,
+      messageSender = messageSender
+    )
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/OperationFixtures.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/OperationFixtures.scala
@@ -15,7 +15,9 @@ trait OperationFixtures extends RandomThings {
     subject = randomAlphanumeric()
   )
 
-  def createIngestUpdater(stepName: String = createStepName, messageSender: MessageSender[Destination] = createMessageSender): IngestUpdater[Destination] =
+  def createIngestUpdater(stepName: String = createStepName,
+                          messageSender: MessageSender[Destination] =
+                            createMessageSender): IngestUpdater[Destination] =
     new IngestUpdater[String](
       stepName = stepName,
       messageSender = messageSender
@@ -23,7 +25,10 @@ trait OperationFixtures extends RandomThings {
 
   def createOperationName: String = randomAlphanumeric()
 
-  def createOutgoingPublisher(operationName: String = createOperationName, messageSender: MessageSender[Destination] = createMessageSender): OutgoingPublisher[Destination] =
+  def createOutgoingPublisher(operationName: String = createOperationName,
+                              messageSender: MessageSender[Destination] =
+                                createMessageSender)
+    : OutgoingPublisher[Destination] =
     new OutgoingPublisher[Destination](
       operationName = operationName,
       messageSender = messageSender

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageManifestVHSFixture.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageManifestVHSFixture.scala
@@ -7,7 +7,7 @@ import uk.ac.wellcome.storage.memory.{MemoryObjectStore, MemoryVersionedDao}
 import uk.ac.wellcome.storage.vhs.{EmptyMetadata, Entry, VersionedHybridStore}
 import uk.ac.wellcome.storage.{ObjectStore, VersionedDao}
 
-import scala.util.Try
+import scala.util.{Failure, Try}
 
 trait StorageManifestVHSFixture {
   def createStorageManifestDao: MemoryVersionedDao[String, Entry[String, EmptyMetadata]] = MemoryVersionedDao[String, Entry[String, EmptyMetadata]]()
@@ -21,6 +21,19 @@ trait StorageManifestVHSFixture {
     val underlying = new VersionedHybridStore[String, StorageManifest, EmptyMetadata] {
       override protected val versionedDao: VersionedDao[String, VHSEntry] = dao
       override protected val objectStore: ObjectStore[StorageManifest] = store
+    }
+
+    new StorageManifestVHS(underlying)
+  }
+
+  def createBrokenStorageManifestVHS: StorageManifestVHS = {
+    val underlying = new VersionedHybridStore[String, StorageManifest, EmptyMetadata] {
+      override protected val versionedDao: VersionedDao[String, VHSEntry] = createStorageManifestDao
+      override protected val objectStore: ObjectStore[StorageManifest] = createStorageManifestStore
+
+      override def update(id: String)(ifNotExisting: => (StorageManifest, EmptyMetadata))(ifExisting: (StorageManifest, EmptyMetadata) => (StorageManifest, EmptyMetadata)): Try[VHSEntry] = Failure(new Throwable("BOOM! BrokenStorageManifestVHS.update()"))
+
+      override def get(id: String): Try[Option[StorageManifest]] = Failure(new Throwable("BOOM! BrokenStorageManifestVHS.get()"))
     }
 
     new StorageManifestVHS(underlying)

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageManifestVHSFixture.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageManifestVHSFixture.scala
@@ -10,31 +10,46 @@ import uk.ac.wellcome.storage.{ObjectStore, VersionedDao}
 import scala.util.{Failure, Try}
 
 trait StorageManifestVHSFixture {
-  def createStorageManifestDao: MemoryVersionedDao[String, Entry[String, EmptyMetadata]] = MemoryVersionedDao[String, Entry[String, EmptyMetadata]]()
+  def createStorageManifestDao
+    : MemoryVersionedDao[String, Entry[String, EmptyMetadata]] =
+    MemoryVersionedDao[String, Entry[String, EmptyMetadata]]()
 
-  def createStorageManifestStore: MemoryObjectStore[StorageManifest] = new MemoryObjectStore[StorageManifest]()
+  def createStorageManifestStore: MemoryObjectStore[StorageManifest] =
+    new MemoryObjectStore[StorageManifest]()
 
   def createStorageManifestVHS(
-    dao: VersionedDao[String, Entry[String, EmptyMetadata]] = createStorageManifestDao,
+    dao: VersionedDao[String, Entry[String, EmptyMetadata]] =
+      createStorageManifestDao,
     store: ObjectStore[StorageManifest] = createStorageManifestStore
   ): StorageManifestVHS = {
-    val underlying = new VersionedHybridStore[String, StorageManifest, EmptyMetadata] {
-      override protected val versionedDao: VersionedDao[String, VHSEntry] = dao
-      override protected val objectStore: ObjectStore[StorageManifest] = store
-    }
+    val underlying =
+      new VersionedHybridStore[String, StorageManifest, EmptyMetadata] {
+        override protected val versionedDao: VersionedDao[String, VHSEntry] =
+          dao
+        override protected val objectStore: ObjectStore[StorageManifest] = store
+      }
 
     new StorageManifestVHS(underlying)
   }
 
   def createBrokenStorageManifestVHS: StorageManifestVHS = {
-    val underlying = new VersionedHybridStore[String, StorageManifest, EmptyMetadata] {
-      override protected val versionedDao: VersionedDao[String, VHSEntry] = createStorageManifestDao
-      override protected val objectStore: ObjectStore[StorageManifest] = createStorageManifestStore
+    val underlying =
+      new VersionedHybridStore[String, StorageManifest, EmptyMetadata] {
+        override protected val versionedDao: VersionedDao[String, VHSEntry] =
+          createStorageManifestDao
+        override protected val objectStore: ObjectStore[StorageManifest] =
+          createStorageManifestStore
 
-      override def update(id: String)(ifNotExisting: => (StorageManifest, EmptyMetadata))(ifExisting: (StorageManifest, EmptyMetadata) => (StorageManifest, EmptyMetadata)): Try[VHSEntry] = Failure(new Throwable("BOOM! BrokenStorageManifestVHS.update()"))
+        override def update(id: String)(
+          ifNotExisting: => (StorageManifest, EmptyMetadata))(
+          ifExisting: (
+            StorageManifest,
+            EmptyMetadata) => (StorageManifest, EmptyMetadata)): Try[VHSEntry] =
+          Failure(new Throwable("BOOM! BrokenStorageManifestVHS.update()"))
 
-      override def get(id: String): Try[Option[StorageManifest]] = Failure(new Throwable("BOOM! BrokenStorageManifestVHS.get()"))
-    }
+        override def get(id: String): Try[Option[StorageManifest]] =
+          Failure(new Throwable("BOOM! BrokenStorageManifestVHS.get()"))
+      }
 
     new StorageManifestVHS(underlying)
   }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageManifestVHSFixture.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageManifestVHSFixture.scala
@@ -1,36 +1,36 @@
 package uk.ac.wellcome.platform.archive.common.fixtures
 
-import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
 import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestVHS
-import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
-import uk.ac.wellcome.storage.fixtures.LocalVersionedHybridStore
-import uk.ac.wellcome.storage.fixtures.S3.Bucket
-import uk.ac.wellcome.storage.vhs.EmptyMetadata
+import uk.ac.wellcome.storage.memory.{MemoryObjectStore, MemoryVersionedDao}
+import uk.ac.wellcome.storage.vhs.{EmptyMetadata, Entry, VersionedHybridStore}
+import uk.ac.wellcome.storage.{ObjectStore, VersionedDao}
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
+import scala.util.Try
 
-trait StorageManifestVHSFixture extends LocalVersionedHybridStore {
-  def withStorageManifestVHS[R](table: Table, bucket: Bucket)(
-    testWith: TestWith[StorageManifestVHS, R]): R =
-    withTypeVHS[StorageManifest, EmptyMetadata, R](bucket, table) { vhs =>
-      val storageManifestVHS = new StorageManifestVHS(underlying = vhs)
-      testWith(storageManifestVHS)
+trait StorageManifestVHSFixture {
+  def createStorageManifestDao: MemoryVersionedDao[String, Entry[String, EmptyMetadata]] = MemoryVersionedDao[String, Entry[String, EmptyMetadata]]()
+
+  def createStorageManifestStore: MemoryObjectStore[StorageManifest] = new MemoryObjectStore[StorageManifest]()
+
+  def createStorageManifestVHS(
+    dao: VersionedDao[String, Entry[String, EmptyMetadata]] = createStorageManifestDao,
+    store: ObjectStore[StorageManifest] = createStorageManifestStore
+  ): StorageManifestVHS = {
+    val underlying = new VersionedHybridStore[String, StorageManifest, EmptyMetadata] {
+      override protected val versionedDao: VersionedDao[String, VHSEntry] = dao
+      override protected val objectStore: ObjectStore[StorageManifest] = store
     }
 
+    new StorageManifestVHS(underlying)
+  }
+
   def storeSingleManifest(vhs: StorageManifestVHS,
-                          storageManifest: StorageManifest): Future[Unit] =
+                          storageManifest: StorageManifest): Try[Unit] =
     vhs.updateRecord(
       ifNotExisting = storageManifest
     )(
       ifExisting = _ => throw new RuntimeException("VHS should be empty!")
     )
-
-  def getStorageManifest(table: Table, id: BagId): StorageManifest = {
-    val hybridRecord = getHybridRecord(table, id.toString)
-    getObjectFromS3[StorageManifest](hybridRecord.location)
-  }
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/fixtures/IngestUpdateAssertions.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/fixtures/IngestUpdateAssertions.scala
@@ -11,7 +11,8 @@ import uk.ac.wellcome.platform.archive.common.ingests.models._
 import scala.util.Try
 
 trait IngestUpdateAssertions extends Inside with Logging { this: Matchers =>
-  def assertReceivesIngestUpdates(messageSender: MemoryMessageSender)(ingestId: IngestID)(assert: Seq[IngestUpdate] => Assertion): Assertion = {
+  def assertReceivesIngestUpdates(messageSender: MemoryMessageSender)(
+    ingestId: IngestID)(assert: Seq[IngestUpdate] => Assertion): Assertion = {
     val ingestUpdates = messageSender.getMessages[IngestUpdate]()
 
     assert(ingestUpdates)

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/fixtures/IngestUpdateAssertions.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/fixtures/IngestUpdateAssertions.scala
@@ -1,23 +1,34 @@
 package uk.ac.wellcome.platform.archive.common.ingests.fixtures
 
 import grizzled.slf4j.Logging
-import org.scalatest.{Assertion, Inside}
+import org.scalatest.{Assertion, Inside, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.fixtures.SNS
-import uk.ac.wellcome.messaging.fixtures.SNS.Topic
+import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.common.IngestID
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 
 import scala.util.Try
 
-trait IngestUpdateAssertions extends SNS with Inside with Logging {
-  def assertTopicReceivesIngestStatus[R](ingestId: IngestID,
-                                         ingestTopic: SNS.Topic,
-                                         status: Ingest.Status,
-                                         expectedBag: Option[BagId] = None)(
-    assert: Seq[IngestEvent] => R): Assertion =
-    assertTopicReceivesIngestUpdates(ingestId, ingestTopic) { ingestUpdates =>
+trait IngestUpdateAssertions extends Inside with Logging { this: Matchers =>
+
+  def assertReceivesIngestUpdates(messageSender: MemoryMessageSender)(ingestId: IngestID)(assert: Seq[IngestUpdate] => Assertion): Assertion = {
+    val ingestUpdates =
+      messageSender.messages
+        .map { _.body }
+        .map { fromJson[IngestUpdate](_).get }
+
+    assert(ingestUpdates)
+  }
+
+  def assertReceivesIngestStatus[R](messageSender: MemoryMessageSender)(
+    ingestId: IngestID,
+    status: Ingest.Status,
+    expectedBag: Option[BagId] = None
+  )(
+    assert: Seq[IngestEvent] => R
+  ): Assertion =
+    assertReceivesIngestUpdates(messageSender)(ingestId) { ingestUpdates =>
       ingestUpdates.size should be > 0
 
       val (success, failures) = ingestUpdates
@@ -40,22 +51,13 @@ trait IngestUpdateAssertions extends SNS with Inside with Logging {
       success should have size 1
     }
 
-  def assertTopicReceivesIngestUpdates(
+  def assertReceivesIngestEvents(
+    messageSender: MemoryMessageSender
+  )(
     ingestId: IngestID,
-    ingestTopic: Topic,
-  )(assert: Seq[IngestUpdate] => Assertion): Assertion = {
-    val ingestUpdates: Seq[IngestUpdate] =
-      listNotifications[IngestUpdate](ingestTopic).map { _.get }.distinct
-
-    assert(ingestUpdates)
-  }
-
-  def assertTopicReceivesIngestEvents(
-    ingestId: IngestID,
-    ingestTopic: Topic,
     expectedDescriptions: Seq[String]
   ): Assertion =
-    assertTopicReceivesIngestUpdates(ingestId, ingestTopic) { ingestUpdates =>
+    assertReceivesIngestUpdates(messageSender)(ingestId) { ingestUpdates =>
       val eventDescriptions: Seq[String] =
         ingestUpdates
           .flatMap { _.events }
@@ -65,10 +67,14 @@ trait IngestUpdateAssertions extends SNS with Inside with Logging {
       eventDescriptions should contain theSameElementsAs expectedDescriptions
     }
 
-  def assertTopicReceivesIngestEvent(
-    ingestId: IngestID,
-    ingestTopic: SNS.Topic)(assert: Seq[IngestEvent] => Assertion): Assertion =
-    assertTopicReceivesIngestUpdates(ingestId, ingestTopic) { ingestUpdates =>
+  def assertReceivesIngestEvent(
+    messageSender: MemoryMessageSender
+  )(
+    ingestId: IngestID
+  )(
+    assert: Seq[IngestEvent] => Assertion
+  ): Assertion =
+    assertReceivesIngestUpdates(messageSender)(ingestId) { ingestUpdates =>
       ingestUpdates.size should be > 0
 
       val (success, _) = ingestUpdates

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/fixtures/IngestUpdateAssertions.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/fixtures/IngestUpdateAssertions.scala
@@ -11,12 +11,8 @@ import uk.ac.wellcome.platform.archive.common.ingests.models._
 import scala.util.Try
 
 trait IngestUpdateAssertions extends Inside with Logging { this: Matchers =>
-
   def assertReceivesIngestUpdates(messageSender: MemoryMessageSender)(ingestId: IngestID)(assert: Seq[IngestUpdate] => Assertion): Assertion = {
-    val ingestUpdates =
-      messageSender.messages
-        .map { _.body }
-        .map { fromJson[IngestUpdate](_).get }
+    val ingestUpdates = messageSender.getMessages[IngestUpdate]()
 
     assert(ingestUpdates)
   }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdaterTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdaterTest.scala
@@ -1,11 +1,12 @@
 package uk.ac.wellcome.platform.archive.common.ingests.services
 
-import org.scalatest.FunSpec
+import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.common.IngestID
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
 import uk.ac.wellcome.platform.archive.common.fixtures.OperationFixtures
 import uk.ac.wellcome.platform.archive.common.generators.{BagIdGenerators, IngestOperationGenerators}
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
+import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
 import uk.ac.wellcome.platform.archive.common.storage.models.IngestStepStarted
 
 import scala.util.Success
@@ -15,7 +16,8 @@ class IngestUpdaterTest
     with IngestUpdateAssertions
     with OperationFixtures
     with IngestOperationGenerators
-    with BagIdGenerators {
+    with BagIdGenerators
+    with Matchers {
 
   val stepName: String = createStepName
   val ingestId: IngestID = createIngestID
@@ -35,19 +37,10 @@ class IngestUpdaterTest
 
     sendingOperationNotice shouldBe Success(())
 
-    println(messageSender.messages)
-    true shouldBe false
-
-//          eventually {
-//            assertTopicReceivesIngestEvent(ingestId, ingestTopic) { events =>
-//              events should have size 1
-//              events.head.description shouldBe s"${stepName.capitalize} succeeded"
-//            }
-//          }
-//        }
-//
-//      }
-//    }
+    assertReceivesIngestEvent(messageSender)(ingestId) { events =>
+      events should have size 1
+      events.head.description shouldBe s"${stepName.capitalize} succeeded"
+    }
   }
 
   it("sends an ingest update when completed") {
@@ -66,23 +59,13 @@ class IngestUpdaterTest
 
     sendingOperationNotice shouldBe Success(())
 
-    println(messageSender.messages)
-    true shouldBe false
-
-//        whenReady(sendingOperationNotice) { _ =>
-//          eventually {
-//            assertTopicReceivesIngestStatus(
-//              ingestId,
-//              ingestTopic,
-//              Ingest.Completed,
-//              Some(bagId)) { events =>
-//              events should have size 1
-//              events.head.description shouldBe s"${stepName.capitalize} succeeded (completed)"
-//            }
-//          }
-//        }
-//      }
-//    }
+    assertReceivesIngestStatus(messageSender)(
+      ingestId,
+      Ingest.Completed,
+      Some(bagId)) { events =>
+      events should have size 1
+      events.head.description shouldBe s"${stepName.capitalize} succeeded (completed)"
+    }
   }
 
   it("sends an ingest update when failed") {
@@ -101,23 +84,13 @@ class IngestUpdaterTest
 
     sendingOperationNotice shouldBe Success(())
 
-    println(messageSender.messages)
-    true shouldBe false
-
-//        whenReady(sendingOperationNotice) { _ =>
-//          eventually {
-//            assertTopicReceivesIngestStatus(
-//              ingestId,
-//              ingestTopic,
-//              Ingest.Failed,
-//              Some(bagId)) { events =>
-//              events should have size 1
-//              events.head.description shouldBe s"${stepName.capitalize} failed"
-//            }
-//          }
-//        }
-//      }
-//    }
+    assertReceivesIngestStatus(messageSender)(
+      ingestId,
+      Ingest.Failed,
+      Some(bagId)) { events =>
+      events should have size 1
+      events.head.description shouldBe s"${stepName.capitalize} failed"
+    }
   }
 
   it("sends an ingest update when an ingest step starts") {
@@ -135,19 +108,10 @@ class IngestUpdaterTest
 
     sendingOperationNotice shouldBe Success(())
 
-    println(messageSender.messages)
-    true shouldBe false
-
-//        whenReady(sendingOperationNotice) { _ =>
-//          eventually {
-//            assertTopicReceivesIngestEvent(ingestId, ingestTopic) { events =>
-//              events should have size 1
-//              events.head.description shouldBe s"${stepName.capitalize} started"
-//            }
-//          }
-//        }
-//      }
-//    }
+    assertReceivesIngestEvent(messageSender)(ingestId) { events =>
+      events should have size 1
+      events.head.description shouldBe s"${stepName.capitalize} started"
+    }
   }
 
   it("sends an ingest update when failed with a failure message") {
@@ -171,22 +135,12 @@ class IngestUpdaterTest
 
     sendingOperationNotice shouldBe Success(())
 
-    println(messageSender.messages)
-    true shouldBe false
-
-//        whenReady(sendingOperationNotice) { _ =>
-//          eventually {
-//            assertTopicReceivesIngestStatus(
-//              ingestId,
-//              ingestTopic,
-//              Ingest.Failed,
-//              Some(bagId)) { events =>
-//              events should have size 1
-//              events.head.description shouldBe s"${stepName.capitalize} failed - $failureMessage"
-//            }
-//          }
-//        }
-//      }
-//    }
+    assertReceivesIngestStatus(messageSender)(
+      ingestId,
+      Ingest.Failed,
+      Some(bagId)) { events =>
+      events should have size 1
+      events.head.description shouldBe s"${stepName.capitalize} failed - $failureMessage"
+    }
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdaterTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdaterTest.scala
@@ -4,7 +4,10 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.common.IngestID
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
 import uk.ac.wellcome.platform.archive.common.fixtures.OperationFixtures
-import uk.ac.wellcome.platform.archive.common.generators.{BagIdGenerators, IngestOperationGenerators}
+import uk.ac.wellcome.platform.archive.common.generators.{
+  BagIdGenerators,
+  IngestOperationGenerators
+}
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
 import uk.ac.wellcome.platform.archive.common.storage.models.IngestStepStarted

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdaterTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdaterTest.scala
@@ -1,160 +1,192 @@
 package uk.ac.wellcome.platform.archive.common.ingests.services
 
 import org.scalatest.FunSpec
-import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
+import uk.ac.wellcome.platform.archive.common.IngestID
+import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
 import uk.ac.wellcome.platform.archive.common.fixtures.OperationFixtures
-import uk.ac.wellcome.platform.archive.common.generators.{
-  BagIdGenerators,
-  IngestOperationGenerators
-}
+import uk.ac.wellcome.platform.archive.common.generators.{BagIdGenerators, IngestOperationGenerators}
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
 import uk.ac.wellcome.platform.archive.common.storage.models.IngestStepStarted
+
+import scala.util.Success
 
 class IngestUpdaterTest
     extends FunSpec
-    with ScalaFutures
     with IngestUpdateAssertions
-    with Eventually
-    with IntegrationPatience
     with OperationFixtures
     with IngestOperationGenerators
     with BagIdGenerators {
 
-  val stepName: String = randomAlphanumeric()
+  val stepName: String = createStepName
+  val ingestId: IngestID = createIngestID
+  val summary: TestSummary = createTestSummary()
+  val bagId: BagId = createBagId
 
   it("sends an ingest update when successful") {
-    withLocalSnsTopic { ingestTopic =>
-      withIngestUpdater(stepName, ingestTopic) { ingestUpdater =>
-        val ingestId = createIngestID
-        val summary = createTestSummary()
+    val messageSender = createMessageSender
 
-        val sendingOperationNotice =
-          ingestUpdater.send(ingestId, createOperationSuccessWith(summary))
+    val ingestUpdater = createIngestUpdater(
+      stepName = stepName,
+      messageSender = messageSender
+    )
 
-        whenReady(sendingOperationNotice) { _ =>
-          eventually {
-            assertTopicReceivesIngestEvent(ingestId, ingestTopic) { events =>
-              events should have size 1
-              events.head.description shouldBe s"${stepName.capitalize} succeeded"
-            }
-          }
-        }
+    val sendingOperationNotice =
+      ingestUpdater.send(ingestId, createOperationSuccessWith(summary))
 
-      }
-    }
+    sendingOperationNotice shouldBe Success(())
+
+    println(messageSender.messages)
+    true shouldBe false
+
+//          eventually {
+//            assertTopicReceivesIngestEvent(ingestId, ingestTopic) { events =>
+//              events should have size 1
+//              events.head.description shouldBe s"${stepName.capitalize} succeeded"
+//            }
+//          }
+//        }
+//
+//      }
+//    }
   }
 
   it("sends an ingest update when completed") {
-    withLocalSnsTopic { ingestTopic =>
-      withIngestUpdater(stepName, ingestTopic) { ingestUpdater =>
-        val ingestId = createIngestID
-        val summary = createTestSummary()
+    val messageSender = createMessageSender
 
-        val bagId = createBagId
-        val sendingOperationNotice = ingestUpdater.send(
-          ingestId = ingestId,
-          step = createOperationCompletedWith(summary),
-          bagId = Some(bagId)
-        )
+    val ingestUpdater = createIngestUpdater(
+      stepName = stepName,
+      messageSender = messageSender
+    )
 
-        whenReady(sendingOperationNotice) { _ =>
-          eventually {
-            assertTopicReceivesIngestStatus(
-              ingestId,
-              ingestTopic,
-              Ingest.Completed,
-              Some(bagId)) { events =>
-              events should have size 1
-              events.head.description shouldBe s"${stepName.capitalize} succeeded (completed)"
-            }
-          }
-        }
-      }
-    }
+    val sendingOperationNotice = ingestUpdater.send(
+      ingestId = ingestId,
+      step = createOperationCompletedWith(summary),
+      bagId = Some(bagId)
+    )
+
+    sendingOperationNotice shouldBe Success(())
+
+    println(messageSender.messages)
+    true shouldBe false
+
+//        whenReady(sendingOperationNotice) { _ =>
+//          eventually {
+//            assertTopicReceivesIngestStatus(
+//              ingestId,
+//              ingestTopic,
+//              Ingest.Completed,
+//              Some(bagId)) { events =>
+//              events should have size 1
+//              events.head.description shouldBe s"${stepName.capitalize} succeeded (completed)"
+//            }
+//          }
+//        }
+//      }
+//    }
   }
 
   it("sends an ingest update when failed") {
-    withLocalSnsTopic { ingestTopic =>
-      withIngestUpdater(stepName, ingestTopic) { ingestUpdater =>
-        val ingestId = createIngestID
-        val summary = createTestSummary()
+    val messageSender = createMessageSender
 
-        val bagId = createBagId
-        val sendingOperationNotice = ingestUpdater.send(
-          ingestId = ingestId,
-          step = createIngestFailureWith(summary),
-          bagId = Some(bagId)
-        )
+    val ingestUpdater = createIngestUpdater(
+      stepName = stepName,
+      messageSender = messageSender
+    )
 
-        whenReady(sendingOperationNotice) { _ =>
-          eventually {
-            assertTopicReceivesIngestStatus(
-              ingestId,
-              ingestTopic,
-              Ingest.Failed,
-              Some(bagId)) { events =>
-              events should have size 1
-              events.head.description shouldBe s"${stepName.capitalize} failed"
-            }
-          }
-        }
-      }
-    }
+    val sendingOperationNotice = ingestUpdater.send(
+      ingestId = ingestId,
+      step = createIngestFailureWith(summary),
+      bagId = Some(bagId)
+    )
+
+    sendingOperationNotice shouldBe Success(())
+
+    println(messageSender.messages)
+    true shouldBe false
+
+//        whenReady(sendingOperationNotice) { _ =>
+//          eventually {
+//            assertTopicReceivesIngestStatus(
+//              ingestId,
+//              ingestTopic,
+//              Ingest.Failed,
+//              Some(bagId)) { events =>
+//              events should have size 1
+//              events.head.description shouldBe s"${stepName.capitalize} failed"
+//            }
+//          }
+//        }
+//      }
+//    }
   }
 
   it("sends an ingest update when an ingest step starts") {
-    withLocalSnsTopic { ingestTopic =>
-      withIngestUpdater(stepName, ingestTopic) { ingestUpdater =>
-        val ingestId = createIngestID
+    val messageSender = createMessageSender
 
-        val sendingOperationNotice = ingestUpdater.send(
-          ingestId = ingestId,
-          step = IngestStepStarted(ingestId)
-        )
+    val ingestUpdater = createIngestUpdater(
+      stepName = stepName,
+      messageSender = messageSender
+    )
 
-        whenReady(sendingOperationNotice) { _ =>
-          eventually {
-            assertTopicReceivesIngestEvent(ingestId, ingestTopic) { events =>
-              events should have size 1
-              events.head.description shouldBe s"${stepName.capitalize} started"
-            }
-          }
-        }
-      }
-    }
+    val sendingOperationNotice = ingestUpdater.send(
+      ingestId = ingestId,
+      step = IngestStepStarted(ingestId)
+    )
+
+    sendingOperationNotice shouldBe Success(())
+
+    println(messageSender.messages)
+    true shouldBe false
+
+//        whenReady(sendingOperationNotice) { _ =>
+//          eventually {
+//            assertTopicReceivesIngestEvent(ingestId, ingestTopic) { events =>
+//              events should have size 1
+//              events.head.description shouldBe s"${stepName.capitalize} started"
+//            }
+//          }
+//        }
+//      }
+//    }
   }
 
   it("sends an ingest update when failed with a failure message") {
-    withLocalSnsTopic { ingestTopic =>
-      withIngestUpdater(stepName, ingestTopic) { ingestUpdater =>
-        val ingestId = createIngestID
-        val summary = createTestSummary()
-        val failureMessage = randomAlphanumeric(length = 50)
+    val messageSender = createMessageSender
 
-        val bagId = createBagId
-        val sendingOperationNotice = ingestUpdater.send(
-          ingestId = ingestId,
-          step = createIngestFailureWith(
-            summary,
-            maybeFailureMessage = Some(failureMessage)
-          ),
-          bagId = Some(bagId)
-        )
+    val ingestUpdater = createIngestUpdater(
+      stepName = stepName,
+      messageSender = messageSender
+    )
 
-        whenReady(sendingOperationNotice) { _ =>
-          eventually {
-            assertTopicReceivesIngestStatus(
-              ingestId,
-              ingestTopic,
-              Ingest.Failed,
-              Some(bagId)) { events =>
-              events should have size 1
-              events.head.description shouldBe s"${stepName.capitalize} failed - $failureMessage"
-            }
-          }
-        }
-      }
-    }
+    val failureMessage = randomAlphanumeric(length = 50)
+
+    val sendingOperationNotice = ingestUpdater.send(
+      ingestId = ingestId,
+      step = createIngestFailureWith(
+        summary,
+        maybeFailureMessage = Some(failureMessage)
+      ),
+      bagId = Some(bagId)
+    )
+
+    sendingOperationNotice shouldBe Success(())
+
+    println(messageSender.messages)
+    true shouldBe false
+
+//        whenReady(sendingOperationNotice) { _ =>
+//          eventually {
+//            assertTopicReceivesIngestStatus(
+//              ingestId,
+//              ingestTopic,
+//              Ingest.Failed,
+//              Some(bagId)) { events =>
+//              events should have size 1
+//              events.head.description shouldBe s"${stepName.capitalize} failed - $failureMessage"
+//            }
+//          }
+//        }
+//      }
+//    }
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/operation/services/OutgoingPublisherTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/operation/services/OutgoingPublisherTest.scala
@@ -35,11 +35,7 @@ class OutgoingPublisherTest
 
       sendingOperationNotice shouldBe Success(())
 
-      val receivedMessages = messageSender.messages
-        .map { _.body }
-        .map { fromJson[IngestRequestPayload](_).get }
-
-      receivedMessages shouldBe List(outgoing)
+      messageSender.getMessages[IngestRequestPayload]() shouldBe Seq(outgoing)
     }
   }
 
@@ -56,10 +52,6 @@ class OutgoingPublisherTest
 
     sendingOperationNotice shouldBe Success(())
 
-    val receivedMessages = messageSender.messages
-      .map { _.body }
-      .map { fromJson[IngestRequestPayload](_).get }
-
-    receivedMessages shouldBe empty
+    messageSender.messages shouldBe empty
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/operation/services/OutgoingPublisherTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/operation/services/OutgoingPublisherTest.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.platform.archive.common.operation.services
 import org.scalatest.FunSpec
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.platform.archive.common.IngestRequestPayload
 import uk.ac.wellcome.platform.archive.common.fixtures.OperationFixtures
 import uk.ac.wellcome.platform.archive.common.generators.{IngestOperationGenerators, PayloadGenerators}
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
@@ -27,21 +28,18 @@ class OutgoingPublisherTest
         messageSender = messageSender
       )
 
-      val outgoing = createIngestRequestPayload
+      val outgoing: IngestRequestPayload = createIngestRequestPayload
 
       val sendingOperationNotice: Try[Unit] =
         outgoingPublisher.sendIfSuccessful(operation, outgoing)
 
       sendingOperationNotice shouldBe Success(())
 
-      println(messageSender.messages)
-      true shouldBe false
+      val receivedMessages = messageSender.messages
+        .map { _.body }
+        .map { fromJson[IngestRequestPayload](_).get }
 
-//          whenReady(sendingOperationNotice) { _ =>
-//            assertSnsReceivesOnly(outgoing, topic)
-//          }
-//        }
-//      }
+      receivedMessages shouldBe List(outgoing)
     }
   }
 
@@ -58,20 +56,10 @@ class OutgoingPublisherTest
 
     sendingOperationNotice shouldBe Success(())
 
-    println(messageSender.messages)
-    true shouldBe false
+    val receivedMessages = messageSender.messages
+      .map { _.body }
+      .map { fromJson[IngestRequestPayload](_).get }
 
-//    withLocalSnsTopic { topic =>
-//      withOutgoingPublisher(operationName, topic) { outgoingPublisher =>
-//        val outgoing = createIngestRequestPayload
-//
-//        val sendingOperationNotice =
-//          outgoingPublisher.sendIfSuccessful(createOperationFailure(), outgoing)
-//
-//        whenReady(sendingOperationNotice) { _ =>
-//          assertSnsReceivesNothing(topic)
-//        }
-//      }
-//    }
+    receivedMessages shouldBe empty
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/operation/services/OutgoingPublisherTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/operation/services/OutgoingPublisherTest.scala
@@ -5,7 +5,10 @@ import org.scalatest.prop.TableDrivenPropertyChecks._
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.common.IngestRequestPayload
 import uk.ac.wellcome.platform.archive.common.fixtures.OperationFixtures
-import uk.ac.wellcome.platform.archive.common.generators.{IngestOperationGenerators, PayloadGenerators}
+import uk.ac.wellcome.platform.archive.common.generators.{
+  IngestOperationGenerators,
+  PayloadGenerators
+}
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
 
 import scala.util.{Success, Try}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3StreamableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3StreamableTest.scala
@@ -14,7 +14,7 @@ class S3StreamableTest
     with TryValues
     with RandomThings {
 
-  import S3StreamableInstances._
+  import StreamableInstances._
 
   case class Thing(stuff: String)
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
@@ -2,8 +2,14 @@ package uk.ac.wellcome.platform.archive.common.storage.services
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagPath
-import uk.ac.wellcome.platform.archive.common.fixtures.{BagLocationFixtures, FileEntry}
-import uk.ac.wellcome.platform.archive.common.ingests.models.{InfrequentAccessStorageProvider, StorageLocation}
+import uk.ac.wellcome.platform.archive.common.fixtures.{
+  BagLocationFixtures,
+  FileEntry
+}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  InfrequentAccessStorageProvider,
+  StorageLocation
+}
 import uk.ac.wellcome.platform.archive.common.verify.SHA256
 import uk.ac.wellcome.storage.StorageBackend
 import uk.ac.wellcome.storage.fixtures.S3
@@ -17,7 +23,8 @@ class StorageManifestServiceTest
 
   def createBackend = new MemoryStorageBackend()
 
-  def createStorageManifestService(storageBackend: StorageBackend = createBackend): StorageManifestService =
+  def createStorageManifestService(
+    storageBackend: StorageBackend = createBackend): StorageManifestService =
     new StorageManifestService()(storageBackend)
 
   it("returns a StorageManifest if reading a bag location succeeds") {
@@ -81,7 +88,8 @@ class StorageManifestServiceTest
 
       withBag(backend) {
         case (bagRootLocation, storageSpace) =>
-          backend.storage = backend.storage - bagRootLocation.join("bag-info.txt")
+          backend.storage = backend.storage - bagRootLocation.join(
+            "bag-info.txt")
 
           val maybeManifest = service.retrieve(
             bagRootLocation = bagRootLocation,
@@ -102,7 +110,8 @@ class StorageManifestServiceTest
 
       withBag(backend) {
         case (bagRootLocation, storageSpace) =>
-          backend.storage = backend.storage - bagRootLocation.join("manifest-sha256.txt")
+          backend.storage = backend.storage - bagRootLocation.join(
+            "manifest-sha256.txt")
 
           val maybeManifest = service.retrieve(
             bagRootLocation = bagRootLocation,
@@ -112,7 +121,8 @@ class StorageManifestServiceTest
           val err = maybeManifest.failed.get
 
           err shouldBe a[RuntimeException]
-          err.getMessage should startWith("Error getting file manifest: Nothing at ")
+          err.getMessage should startWith(
+            "Error getting file manifest: Nothing at ")
           err.getMessage should endWith("/manifest-sha256.txt")
       }
     }
@@ -144,7 +154,8 @@ class StorageManifestServiceTest
 
       withBag(backend) {
         case (bagRootLocation, storageSpace) =>
-          backend.storage = backend.storage - bagRootLocation.join("tagmanifest-sha256.txt")
+          backend.storage = backend.storage - bagRootLocation.join(
+            "tagmanifest-sha256.txt")
 
           val maybeManifest = service.retrieve(
             bagRootLocation = bagRootLocation,
@@ -154,7 +165,8 @@ class StorageManifestServiceTest
           val err = maybeManifest.failed.get
 
           err shouldBe a[RuntimeException]
-          err.getMessage should startWith("Error getting tag manifest: Nothing at ")
+          err.getMessage should startWith(
+            "Error getting tag manifest: Nothing at ")
           err.getMessage should endWith("/tagmanifest-sha256.txt")
       }
     }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
@@ -1,199 +1,182 @@
 package uk.ac.wellcome.platform.archive.common.storage.services
 
 import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagPath
-import uk.ac.wellcome.platform.archive.common.fixtures.{
-  BagLocationFixtures,
-  FileEntry
-}
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  InfrequentAccessStorageProvider,
-  StorageLocation
-}
+import uk.ac.wellcome.platform.archive.common.fixtures.{BagLocationFixtures, FileEntry}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{InfrequentAccessStorageProvider, StorageLocation}
 import uk.ac.wellcome.platform.archive.common.verify.SHA256
+import uk.ac.wellcome.storage.StorageBackend
+import uk.ac.wellcome.storage.fixtures.S3
+import uk.ac.wellcome.storage.memory.MemoryStorageBackend
 
 class StorageManifestServiceTest
     extends FunSpec
     with Matchers
-    with BagLocationFixtures {
+    with BagLocationFixtures
+    with S3 {
 
-  def withStorageManifestService[R](
-    testWith: TestWith[StorageManifestService, R]): R =
-    testWith(new StorageManifestService())
+  def createBackend = new MemoryStorageBackend()
+
+  def createStorageManifestService(storageBackend: StorageBackend = createBackend): StorageManifestService =
+    new StorageManifestService()(storageBackend)
 
   it("returns a StorageManifest if reading a bag location succeeds") {
-    withLocalS3Bucket { bucket =>
-      val bagInfo = createBagInfo
-      withBag(bucket, bagInfo = bagInfo) {
-        case (bagRootLocation, storageSpace) =>
-          withStorageManifestService { service =>
-            val maybeManifest = service.retrieve(
-              bagRootLocation = bagRootLocation,
-              storageSpace = storageSpace
-            )
+    val backend = createBackend
+    val service = createStorageManifestService(backend)
 
-            val storageManifest = maybeManifest.get
+    val bagInfo = createBagInfo
+    withBag(backend, bagInfo = bagInfo) {
+      case (bagRootLocation, storageSpace) =>
+        val maybeManifest = service.retrieve(
+          bagRootLocation = bagRootLocation,
+          storageSpace = storageSpace
+        )
 
-            storageManifest.space shouldBe storageSpace
-            storageManifest.info shouldBe bagInfo
+        val storageManifest = maybeManifest.get
 
-            storageManifest.manifest.checksumAlgorithm shouldBe SHA256
-            storageManifest.manifest.files should have size 1
+        storageManifest.space shouldBe storageSpace
+        storageManifest.info shouldBe bagInfo
 
-            storageManifest.tagManifest.checksumAlgorithm shouldBe SHA256
-            storageManifest.tagManifest.files should have size 3
-            val actualFiles = storageManifest.tagManifest.files.map { _.path }
-            val expectedFiles = List(
-              BagPath("manifest-sha256.txt"),
-              BagPath("bag-info.txt"),
-              BagPath("bagit.txt")
-            )
-            actualFiles should contain theSameElementsAs expectedFiles
+        storageManifest.manifest.checksumAlgorithm shouldBe SHA256
+        storageManifest.manifest.files should have size 1
 
-            storageManifest.locations shouldBe List(
-              StorageLocation(
-                provider = InfrequentAccessStorageProvider,
-                location = bagRootLocation
-              )
-            )
-          }
-      }
+        storageManifest.tagManifest.checksumAlgorithm shouldBe SHA256
+        storageManifest.tagManifest.files should have size 3
+        val actualFiles = storageManifest.tagManifest.files.map { _.path }
+        val expectedFiles = List(
+          BagPath("manifest-sha256.txt"),
+          BagPath("bag-info.txt"),
+          BagPath("bagit.txt")
+        )
+        actualFiles should contain theSameElementsAs expectedFiles
+
+        storageManifest.locations shouldBe List(
+          StorageLocation(
+            provider = InfrequentAccessStorageProvider,
+            location = bagRootLocation
+          )
+        )
     }
   }
 
   describe("returns a Left upon error") {
     it("if no files are at the BagLocation") {
-      withLocalS3Bucket { bucket =>
-        withStorageManifestService { service =>
+      val service = createStorageManifestService()
+
+      val maybeManifest = service.retrieve(
+        bagRootLocation = createObjectLocation,
+        storageSpace = createStorageSpace
+      )
+
+      val err = maybeManifest.failed.get
+
+      err shouldBe a[RuntimeException]
+      err.getMessage should startWith("Error getting bag info: Nothing at ")
+      err.getMessage should endWith("/bag-info.txt")
+    }
+
+    it("the bag-info.txt file is missing") {
+      val backend = createBackend
+      val service = createStorageManifestService(backend)
+
+      withBag(backend) {
+        case (bagRootLocation, storageSpace) =>
+          backend.storage = backend.storage - bagRootLocation.join("bag-info.txt")
+
           val maybeManifest = service.retrieve(
-            bagRootLocation = createObjectLocationWith(bucket),
-            storageSpace = createStorageSpace
+            bagRootLocation = bagRootLocation,
+            storageSpace = storageSpace
           )
 
           val err = maybeManifest.failed.get
 
           err shouldBe a[RuntimeException]
-          err.getMessage should include("The specified key does not exist.")
-        }
+          err.getMessage should startWith("Error getting bag info: Nothing at ")
+          err.getMessage should endWith("/bag-info.txt")
       }
     }
 
-    it("the bag-info.txt file is missing") {
-      withLocalS3Bucket { bucket =>
-        withBag(bucket) {
-          case (bagRootLocation, storageSpace) =>
-            s3Client.deleteObject(
-              bagRootLocation.namespace,
-              bagRootLocation.key + "/bag-info.txt"
-            )
+    it("the manifest file is missing") {
+      val backend = createBackend
+      val service = createStorageManifestService(backend)
 
-            withStorageManifestService { service =>
-              val maybeManifest = service.retrieve(
-                bagRootLocation = bagRootLocation,
-                storageSpace = storageSpace
-              )
+      withBag(backend) {
+        case (bagRootLocation, storageSpace) =>
+          backend.storage = backend.storage - bagRootLocation.join("manifest-sha256.txt")
 
-              val err = maybeManifest.failed.get
+          val maybeManifest = service.retrieve(
+            bagRootLocation = bagRootLocation,
+            storageSpace = storageSpace
+          )
 
-              err shouldBe a[RuntimeException]
-              err.getMessage should include("The specified key does not exist.")
+          val err = maybeManifest.failed.get
 
-            }
-        }
-      }
-    }
-
-    it("the manifest.txt file is missing") {
-      withLocalS3Bucket { bucket =>
-        withBag(bucket) {
-          case (bagRootLocation, storageSpace) =>
-            s3Client.deleteObject(
-              bagRootLocation.namespace,
-              bagRootLocation.key + "/manifest-sha256.txt"
-            )
-
-            withStorageManifestService { service =>
-              val maybeManifest = service.retrieve(
-                bagRootLocation = bagRootLocation,
-                storageSpace = storageSpace
-              )
-
-              val err = maybeManifest.failed.get
-
-              err shouldBe a[RuntimeException]
-              err.getMessage should include("The specified key does not exist.")
-            }
-        }
+          err shouldBe a[RuntimeException]
+          err.getMessage should startWith("Error getting file manifest: Nothing at ")
+          err.getMessage should endWith("/manifest-sha256.txt")
       }
     }
 
     it("if the manifest.txt file has a badly formatted line") {
-      withLocalS3Bucket { bucket =>
-        withBag(
-          bucket,
-          createDataManifest =
-            _ => Some(FileEntry("manifest-sha256.txt", "bleeergh!"))) {
-          case (bagRootLocation, storageSpace) =>
-            withStorageManifestService { service =>
-              val maybeManifest = service.retrieve(
-                bagRootLocation = bagRootLocation,
-                storageSpace = storageSpace
-              )
+      val backend = createBackend
+      val service = createStorageManifestService(backend)
 
-              val err = maybeManifest.failed.get
+      withBag(
+        backend,
+        createDataManifest =
+          _ => Some(FileEntry("manifest-sha256.txt", "bleeergh!"))) {
+        case (bagRootLocation, storageSpace) =>
+          val maybeManifest = service.retrieve(
+            bagRootLocation = bagRootLocation,
+            storageSpace = storageSpace
+          )
 
-              err shouldBe a[RuntimeException]
-              err.getMessage shouldBe "Error getting file manifest: Failed to parse: List(bleeergh!)"
-            }
-        }
+          val err = maybeManifest.failed.get
 
+          err shouldBe a[RuntimeException]
+          err.getMessage shouldBe "Error getting file manifest: Failed to parse: List(bleeergh!)"
       }
     }
 
-    it("the tagmanifest.txt file is missing") {
-      withLocalS3Bucket { bucket =>
-        withBag(bucket) {
-          case (bagRootLocation, storageSpace) =>
-            s3Client.deleteObject(
-              bagRootLocation.namespace,
-              bagRootLocation.key + "/tagmanifest-sha256.txt"
-            )
+    it("the tag manifest file is missing") {
+      val backend = createBackend
+      val service = createStorageManifestService(backend)
 
-            withStorageManifestService { service =>
-              val maybeManifest = service.retrieve(
-                bagRootLocation = bagRootLocation,
-                storageSpace = storageSpace
-              )
+      withBag(backend) {
+        case (bagRootLocation, storageSpace) =>
+          backend.storage = backend.storage - bagRootLocation.join("tagmanifest-sha256.txt")
 
-              val err = maybeManifest.failed.get
+          val maybeManifest = service.retrieve(
+            bagRootLocation = bagRootLocation,
+            storageSpace = storageSpace
+          )
 
-              err shouldBe a[RuntimeException]
-              err.getMessage should include("The specified key does not exist.")
-            }
-        }
+          val err = maybeManifest.failed.get
+
+          err shouldBe a[RuntimeException]
+          err.getMessage should startWith("Error getting tag manifest: Nothing at ")
+          err.getMessage should endWith("/tagmanifest-sha256.txt")
       }
     }
 
-    it("if the tag-manifest.txt file has a badly formatted line") {
-      withLocalS3Bucket { bucket =>
-        withBag(
-          bucket,
-          createTagManifest =
-            _ => Some(FileEntry("tagmanifest-sha256.txt", "blaaargh!"))) {
-          case (bagRootLocation, storageSpace) =>
-            withStorageManifestService { service =>
-              val maybeManifest = service.retrieve(
-                bagRootLocation = bagRootLocation,
-                storageSpace = storageSpace
-              )
+    it("if the tag manifest file has a badly formatted line") {
+      val backend = createBackend
+      val service = createStorageManifestService(backend)
 
-              val err = maybeManifest.failed.get
+      withBag(
+        backend,
+        createTagManifest =
+          _ => Some(FileEntry("tagmanifest-sha256.txt", "blaaargh!"))) {
+        case (bagRootLocation, storageSpace) =>
+          val maybeManifest = service.retrieve(
+            bagRootLocation = bagRootLocation,
+            storageSpace = storageSpace
+          )
 
-              err shouldBe a[RuntimeException]
-              err.getMessage shouldBe "Error getting tag manifest: Failed to parse: List(blaaargh!)"
-            }
-        }
+          val err = maybeManifest.failed.get
+
+          err shouldBe a[RuntimeException]
+          err.getMessage shouldBe "Error getting tag manifest: Failed to parse: List(blaaargh!)"
       }
     }
   }

--- a/ingests/docker-compose.yml
+++ b/ingests/docker-compose.yml
@@ -1,7 +1,3 @@
-sns:
-  image: wellcome/fake-sns
-  ports:
-    - "9292:9292"
 sqs:
   image: s12v/elasticmq
   ports:

--- a/ingests/src/main/scala/uk/ac/wellcome/platform/archive/ingests/Main.scala
+++ b/ingests/src/main/scala/uk/ac/wellcome/platform/archive/ingests/Main.scala
@@ -4,18 +4,11 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.typesafe.config.Config
-import uk.ac.wellcome.messaging.typesafe.{
-  AlpakkaSqsWorkerConfigBuilder,
-  CloudwatchMonitoringClientBuilder,
-  SNSBuilder,
-  SQSBuilder
-}
+import uk.ac.wellcome.messaging.sns.SNSConfig
+import uk.ac.wellcome.messaging.typesafe.{AlpakkaSqsWorkerConfigBuilder, CloudwatchMonitoringClientBuilder, SNSBuilder, SQSBuilder}
 import uk.ac.wellcome.messaging.worker.monitoring.CloudwatchMonitoringClient
 import uk.ac.wellcome.platform.archive.common.ingests.monitor.DynamoIngestTracker
-import uk.ac.wellcome.platform.archive.ingests.services.{
-  CallbackNotificationService,
-  IngestsWorker
-}
+import uk.ac.wellcome.platform.archive.ingests.services.{CallbackNotificationService, IngestsWorker}
 import uk.ac.wellcome.storage.typesafe.DynamoBuilder
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
@@ -42,8 +35,8 @@ object Main extends WellcomeTypesafeApp {
       dynamoConfig = DynamoBuilder.buildDynamoConfig(config)
     )
 
-    val callbackNotificationService = new CallbackNotificationService(
-      snsWriter = SNSBuilder.buildSNSWriter(config)
+    val callbackNotificationService = new CallbackNotificationService[SNSConfig](
+      messageSender = SNSBuilder.buildSNSMessageSender(config, subject = "Sent from the ingests service")
     )
 
     new IngestsWorker(

--- a/ingests/src/main/scala/uk/ac/wellcome/platform/archive/ingests/Main.scala
+++ b/ingests/src/main/scala/uk/ac/wellcome/platform/archive/ingests/Main.scala
@@ -5,10 +5,18 @@ import akka.stream.ActorMaterializer
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.typesafe.config.Config
 import uk.ac.wellcome.messaging.sns.SNSConfig
-import uk.ac.wellcome.messaging.typesafe.{AlpakkaSqsWorkerConfigBuilder, CloudwatchMonitoringClientBuilder, SNSBuilder, SQSBuilder}
+import uk.ac.wellcome.messaging.typesafe.{
+  AlpakkaSqsWorkerConfigBuilder,
+  CloudwatchMonitoringClientBuilder,
+  SNSBuilder,
+  SQSBuilder
+}
 import uk.ac.wellcome.messaging.worker.monitoring.CloudwatchMonitoringClient
 import uk.ac.wellcome.platform.archive.common.ingests.monitor.DynamoIngestTracker
-import uk.ac.wellcome.platform.archive.ingests.services.{CallbackNotificationService, IngestsWorker}
+import uk.ac.wellcome.platform.archive.ingests.services.{
+  CallbackNotificationService,
+  IngestsWorker
+}
 import uk.ac.wellcome.storage.typesafe.DynamoBuilder
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
@@ -35,9 +43,12 @@ object Main extends WellcomeTypesafeApp {
       dynamoConfig = DynamoBuilder.buildDynamoConfig(config)
     )
 
-    val callbackNotificationService = new CallbackNotificationService[SNSConfig](
-      messageSender = SNSBuilder.buildSNSMessageSender(config, subject = "Sent from the ingests service")
-    )
+    val callbackNotificationService =
+      new CallbackNotificationService[SNSConfig](
+        messageSender = SNSBuilder.buildSNSMessageSender(
+          config,
+          subject = "Sent from the ingests service")
+      )
 
     new IngestsWorker(
       alpakkaSQSWorkerConfig = AlpakkaSqsWorkerConfigBuilder.build(config),

--- a/ingests/src/main/scala/uk/ac/wellcome/platform/archive/ingests/Main.scala
+++ b/ingests/src/main/scala/uk/ac/wellcome/platform/archive/ingests/Main.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.messaging.typesafe.{
   SQSBuilder
 }
 import uk.ac.wellcome.messaging.worker.monitoring.CloudwatchMonitoringClient
-import uk.ac.wellcome.platform.archive.common.ingests.monitor.IngestTracker
+import uk.ac.wellcome.platform.archive.common.ingests.monitor.DynamoIngestTracker
 import uk.ac.wellcome.platform.archive.ingests.services.{
   CallbackNotificationService,
   IngestsWorker
@@ -37,7 +37,7 @@ object Main extends WellcomeTypesafeApp {
     implicit val sqsClient: AmazonSQSAsync =
       SQSBuilder.buildSQSAsyncClient(config)
 
-    val ingestTracker = new IngestTracker(
+    val ingestTracker = new DynamoIngestTracker(
       dynamoDbClient = DynamoBuilder.buildDynamoClient(config),
       dynamoConfig = DynamoBuilder.buildDynamoConfig(config)
     )

--- a/ingests/src/main/scala/uk/ac/wellcome/platform/archive/ingests/Main.scala
+++ b/ingests/src/main/scala/uk/ac/wellcome/platform/archive/ingests/Main.scala
@@ -38,7 +38,7 @@ object Main extends WellcomeTypesafeApp {
       SQSBuilder.buildSQSAsyncClient(config)
 
     val ingestTracker = new DynamoIngestTracker(
-      dynamoDbClient = DynamoBuilder.buildDynamoClient(config),
+      dynamoClient = DynamoBuilder.buildDynamoClient(config),
       dynamoConfig = DynamoBuilder.buildDynamoConfig(config)
     )
 

--- a/ingests/src/main/scala/uk/ac/wellcome/platform/archive/ingests/services/CallbackNotificationService.scala
+++ b/ingests/src/main/scala/uk/ac/wellcome/platform/archive/ingests/services/CallbackNotificationService.scala
@@ -5,11 +5,16 @@ import java.net.URI
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.platform.archive.common.ingests.models.Callback.Pending
-import uk.ac.wellcome.platform.archive.common.ingests.models.{Callback, CallbackNotification, Ingest}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  Callback,
+  CallbackNotification,
+  Ingest
+}
 
 import scala.util.{Success, Try}
 
-class CallbackNotificationService[MessageDestination](messageSender: MessageSender[MessageDestination]) {
+class CallbackNotificationService[MessageDestination](
+  messageSender: MessageSender[MessageDestination]) {
   def sendNotification(ingest: Ingest): Try[Unit] =
     ingest.callback match {
       case Some(Callback(callbackUri, Pending)) =>

--- a/ingests/src/main/scala/uk/ac/wellcome/platform/archive/ingests/services/CallbackNotificationService.scala
+++ b/ingests/src/main/scala/uk/ac/wellcome/platform/archive/ingests/services/CallbackNotificationService.scala
@@ -3,43 +3,31 @@ package uk.ac.wellcome.platform.archive.ingests.services
 import java.net.URI
 
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.sns.SNSWriter
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  Callback,
-  CallbackNotification,
-  Ingest
-}
+import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.platform.archive.common.ingests.models.Callback.Pending
+import uk.ac.wellcome.platform.archive.common.ingests.models.{Callback, CallbackNotification, Ingest}
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Success, Try}
 
-class CallbackNotificationService(snsWriter: SNSWriter)(
-  implicit ec: ExecutionContext) {
-  def sendNotification(ingest: Ingest): Future[Unit] =
+class CallbackNotificationService[MessageDestination](messageSender: MessageSender[MessageDestination]) {
+  def sendNotification(ingest: Ingest): Try[Unit] =
     ingest.callback match {
       case Some(Callback(callbackUri, Pending)) =>
         ingest.status match {
           case Ingest.Completed | Ingest.Failed =>
             sendSnsMessage(callbackUri, ingest = ingest)
-          case _ => Future.successful(())
+          case _ => Success(())
         }
-      case _ => Future.successful(())
+      case _ => Success(())
     }
 
-  private def sendSnsMessage(callbackUri: URI, ingest: Ingest): Future[Unit] = {
+  private def sendSnsMessage(callbackUri: URI, ingest: Ingest): Try[Unit] = {
     val callbackNotification = CallbackNotification(
       ingestId = ingest.id,
       callbackUri = callbackUri,
       payload = ingest
     )
 
-    snsWriter
-      .writeMessage(
-        callbackNotification,
-        subject = s"sent by ${this.getClass.getSimpleName}"
-      )
-      .map { _ =>
-        ()
-      }
+    messageSender.sendT(callbackNotification)
   }
 }

--- a/ingests/src/main/scala/uk/ac/wellcome/platform/archive/ingests/services/IngestsWorker.scala
+++ b/ingests/src/main/scala/uk/ac/wellcome/platform/archive/ingests/services/IngestsWorker.scala
@@ -8,7 +8,7 @@ import uk.ac.wellcome.messaging.sqsworker.alpakka.{AlpakkaSQSWorker, AlpakkaSQSW
 import uk.ac.wellcome.messaging.worker.models.{DeterministicFailure, Result, Successful}
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
 import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestUpdate}
-import uk.ac.wellcome.platform.archive.common.ingests.monitor.DynamoIngestTracker
+import uk.ac.wellcome.platform.archive.common.ingests.monitor.IngestTracker
 import uk.ac.wellcome.typesafe.Runnable
 
 import scala.concurrent.Future
@@ -16,7 +16,7 @@ import scala.util.{Failure, Success, Try}
 
 class IngestsWorker[MessageDestination](
   alpakkaSQSWorkerConfig: AlpakkaSQSWorkerConfig,
-  ingestTracker: DynamoIngestTracker,
+  ingestTracker: IngestTracker,
   callbackNotificationService: CallbackNotificationService[MessageDestination]
 )(implicit
   actorSystem: ActorSystem,

--- a/ingests/src/main/scala/uk/ac/wellcome/platform/archive/ingests/services/IngestsWorker.scala
+++ b/ingests/src/main/scala/uk/ac/wellcome/platform/archive/ingests/services/IngestsWorker.scala
@@ -4,10 +4,20 @@ import akka.actor.ActorSystem
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.sqsworker.alpakka.{AlpakkaSQSWorker, AlpakkaSQSWorkerConfig}
-import uk.ac.wellcome.messaging.worker.models.{DeterministicFailure, Result, Successful}
+import uk.ac.wellcome.messaging.sqsworker.alpakka.{
+  AlpakkaSQSWorker,
+  AlpakkaSQSWorkerConfig
+}
+import uk.ac.wellcome.messaging.worker.models.{
+  DeterministicFailure,
+  Result,
+  Successful
+}
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
-import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestUpdate}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  Ingest,
+  IngestUpdate
+}
 import uk.ac.wellcome.platform.archive.common.ingests.monitor.IngestTracker
 import uk.ac.wellcome.typesafe.Runnable
 
@@ -26,8 +36,8 @@ class IngestsWorker[MessageDestination](
     with Logging {
 
   private val worker =
-    AlpakkaSQSWorker[IngestUpdate, Ingest](alpakkaSQSWorkerConfig) {
-      update => Future.fromTry { processMessage(update) }
+    AlpakkaSQSWorker[IngestUpdate, Ingest](alpakkaSQSWorkerConfig) { update =>
+      Future.fromTry { processMessage(update) }
     }
 
   def processMessage(ingestUpdate: IngestUpdate): Try[Result[Ingest]] = Try {
@@ -39,7 +49,7 @@ class IngestsWorker[MessageDestination](
 
     result match {
       case Success(ingest) => Successful(Some(ingest))
-      case Failure(err) => DeterministicFailure(err, summary = None)
+      case Failure(err)    => DeterministicFailure(err, summary = None)
     }
   }
 

--- a/ingests/src/main/scala/uk/ac/wellcome/platform/archive/ingests/services/IngestsWorker.scala
+++ b/ingests/src/main/scala/uk/ac/wellcome/platform/archive/ingests/services/IngestsWorker.scala
@@ -18,15 +18,15 @@ import uk.ac.wellcome.platform.archive.common.ingests.models.{
   Ingest,
   IngestUpdate
 }
-import uk.ac.wellcome.platform.archive.common.ingests.monitor.IngestTracker
+import uk.ac.wellcome.platform.archive.common.ingests.monitor.DynamoIngestTracker
 import uk.ac.wellcome.typesafe.Runnable
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class IngestsWorker(
-  alpakkaSQSWorkerConfig: AlpakkaSQSWorkerConfig,
-  ingestTracker: IngestTracker,
-  callbackNotificationService: CallbackNotificationService
+                     alpakkaSQSWorkerConfig: AlpakkaSQSWorkerConfig,
+                     ingestTracker: DynamoIngestTracker,
+                     callbackNotificationService: CallbackNotificationService
 )(implicit
   actorSystem: ActorSystem,
   ec: ExecutionContext,

--- a/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/IngestsFeatureTest.scala
+++ b/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/IngestsFeatureTest.scala
@@ -3,13 +3,13 @@ package uk.ac.wellcome.platform.archive.ingests
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest.Completed
-import uk.ac.wellcome.platform.archive.common.ingests.models.{CallbackNotification, IngestUpdate}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  CallbackNotification,
+  IngestUpdate
+}
 import uk.ac.wellcome.platform.archive.ingests.fixtures._
 
-class IngestsFeatureTest
-    extends FunSpec
-    with Matchers
-    with IngestsFixtures {
+class IngestsFeatureTest extends FunSpec with Matchers with IngestsFixtures {
 
   it("updates an existing ingest status to Completed") {
     withConfiguredApp {
@@ -37,7 +37,8 @@ class IngestsFeatureTest
             payload = expectedIngest
           )
 
-          messageSender.getMessages[CallbackNotification]() shouldBe Seq(expectedMessage)
+          messageSender.getMessages[CallbackNotification]() shouldBe Seq(
+            expectedMessage)
 
           assertIngestCreated(ingestTracker)(ingest)
 

--- a/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/IngestsFeatureTest.scala
+++ b/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/IngestsFeatureTest.scala
@@ -37,9 +37,7 @@ class IngestsFeatureTest
             payload = expectedIngest
           )
 
-          messageSender.messages
-            .map { _.body }
-            .map { fromJson[CallbackNotification](_).get } shouldBe Seq(expectedMessage)
+          messageSender.getMessages[CallbackNotification]() shouldBe Seq(expectedMessage)
 
           assertIngestCreated(ingestTracker)(ingest)
 

--- a/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/fixtures/CallbackNotificationServiceFixture.scala
+++ b/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/fixtures/CallbackNotificationServiceFixture.scala
@@ -1,17 +1,14 @@
 package uk.ac.wellcome.platform.archive.ingests.fixtures
 
 import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.fixtures.SNS
-import uk.ac.wellcome.messaging.fixtures.SNS.Topic
 import uk.ac.wellcome.platform.archive.ingests.services.CallbackNotificationService
 
-import scala.concurrent.ExecutionContext.Implicits.global
-
 trait CallbackNotificationServiceFixture extends SNS {
-  def withCallbackNotificationService[R](topic: Topic)(
-    testWith: TestWith[CallbackNotificationService, R]): R =
-    withSNSWriter(topic) { snsWriter =>
-      val service = new CallbackNotificationService(snsWriter)
-      testWith(service)
-    }
+  def withCallbackNotificationService[R](messageSender: MessageSender[String])(
+    testWith: TestWith[CallbackNotificationService[String], R]): R = {
+    val service = new CallbackNotificationService(messageSender)
+    testWith(service)
+  }
 }

--- a/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/fixtures/IngestsFixtures.scala
+++ b/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/fixtures/IngestsFixtures.scala
@@ -6,10 +6,16 @@ import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
-import uk.ac.wellcome.platform.archive.common.fixtures.{MonitoringClientFixture, OperationFixtures}
+import uk.ac.wellcome.platform.archive.common.fixtures.{
+  MonitoringClientFixture,
+  OperationFixtures
+}
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestTrackerFixture
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
-import uk.ac.wellcome.platform.archive.common.ingests.monitor.{IngestTracker, MemoryIngestTracker}
+import uk.ac.wellcome.platform.archive.common.ingests.monitor.{
+  IngestTracker,
+  MemoryIngestTracker
+}
 import uk.ac.wellcome.platform.archive.ingests.services.IngestsWorker
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDb
 
@@ -24,7 +30,9 @@ trait IngestsFixtures
     with MonitoringClientFixture
     with OperationFixtures {
 
-  def withIngestWorker[R](queue: Queue, ingestTracker: IngestTracker, sender: MessageSender[String])(
+  def withIngestWorker[R](queue: Queue,
+                          ingestTracker: IngestTracker,
+                          sender: MessageSender[String])(
     testWith: TestWith[IngestsWorker[String], R]): R =
     withMonitoringClient { implicit monitoringClient =>
       withActorSystem { implicit actorSystem =>
@@ -54,7 +62,9 @@ trait IngestsFixtures
     testWith(createdIngest)
   }
 
-  def withConfiguredApp[R](testWith: TestWith[(Queue, MemoryMessageSender, MemoryIngestTracker), R]): R = {
+  def withConfiguredApp[R](
+    testWith: TestWith[(Queue, MemoryMessageSender, MemoryIngestTracker), R])
+    : R = {
     withLocalSqsQueue { queue =>
       val messageSender = createMessageSender
       val ingestTracker = new MemoryIngestTracker()

--- a/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/fixtures/IngestsFixtures.scala
+++ b/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/fixtures/IngestsFixtures.scala
@@ -8,7 +8,7 @@ import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
 import uk.ac.wellcome.platform.archive.common.fixtures.MonitoringClientFixture
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestTrackerFixture
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
-import uk.ac.wellcome.platform.archive.common.ingests.monitor.IngestTracker
+import uk.ac.wellcome.platform.archive.common.ingests.monitor.DynamoIngestTracker
 import uk.ac.wellcome.platform.archive.ingests.services.IngestsWorker
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDb
@@ -46,7 +46,7 @@ trait IngestsFixtures
       }
     }
 
-  def withIngest[R](ingestTracker: IngestTracker)(
+  def withIngest[R](ingestTracker: DynamoIngestTracker)(
     testWith: TestWith[Ingest, R]): R = {
     val createdIngest = createIngest
 

--- a/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/fixtures/IngestsFixtures.scala
+++ b/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/fixtures/IngestsFixtures.scala
@@ -9,10 +9,9 @@ import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.common.fixtures.{MonitoringClientFixture, OperationFixtures}
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestTrackerFixture
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
-import uk.ac.wellcome.platform.archive.common.ingests.monitor.IngestTracker
+import uk.ac.wellcome.platform.archive.common.ingests.monitor.{IngestTracker, MemoryIngestTracker}
 import uk.ac.wellcome.platform.archive.ingests.services.IngestsWorker
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDb
-import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
 
 import scala.util.Success
 
@@ -25,24 +24,22 @@ trait IngestsFixtures
     with MonitoringClientFixture
     with OperationFixtures {
 
-  def withIngestWorker[R](queue: Queue, table: Table, sender: MessageSender[String])(
+  def withIngestWorker[R](queue: Queue, ingestTracker: IngestTracker, sender: MessageSender[String])(
     testWith: TestWith[IngestsWorker[String], R]): R =
     withMonitoringClient { implicit monitoringClient =>
       withActorSystem { implicit actorSystem =>
         withMaterializer { implicit materializer =>
-          withIngestTracker(table) { ingestTracker =>
-            withCallbackNotificationService(sender) {
-              callbackNotificationService =>
-                val service = new IngestsWorker(
-                  alpakkaSQSWorkerConfig = createAlpakkaSQSWorkerConfig(queue),
-                  ingestTracker = ingestTracker,
-                  callbackNotificationService = callbackNotificationService
-                )
+          withCallbackNotificationService(sender) {
+            callbackNotificationService =>
+              val service = new IngestsWorker(
+                alpakkaSQSWorkerConfig = createAlpakkaSQSWorkerConfig(queue),
+                ingestTracker = ingestTracker,
+                callbackNotificationService = callbackNotificationService
+              )
 
-                service.run()
+              service.run()
 
-                testWith(service)
-            }
+              testWith(service)
           }
         }
       }
@@ -57,13 +54,12 @@ trait IngestsFixtures
     testWith(createdIngest)
   }
 
-  def withConfiguredApp[R](testWith: TestWith[(Queue, MemoryMessageSender, Table), R]): R = {
+  def withConfiguredApp[R](testWith: TestWith[(Queue, MemoryMessageSender, MemoryIngestTracker), R]): R = {
     withLocalSqsQueue { queue =>
       val messageSender = createMessageSender
-      withIngestTrackerTable { table =>
-        withIngestWorker(queue, table, messageSender) { _ =>
-          testWith((queue, messageSender, table))
-        }
+      val ingestTracker = new MemoryIngestTracker()
+      withIngestWorker(queue, ingestTracker, messageSender) { _ =>
+        testWith((queue, messageSender, ingestTracker))
       }
     }
   }

--- a/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/fixtures/IngestsFixtures.scala
+++ b/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/fixtures/IngestsFixtures.scala
@@ -2,18 +2,19 @@ package uk.ac.wellcome.platform.archive.ingests.fixtures
 
 import org.scalatest.concurrent.ScalaFutures
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.messaging.fixtures.SNS.Topic
+import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
-import uk.ac.wellcome.platform.archive.common.fixtures.MonitoringClientFixture
+import uk.ac.wellcome.messaging.memory.MemoryMessageSender
+import uk.ac.wellcome.platform.archive.common.fixtures.{MonitoringClientFixture, OperationFixtures}
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestTrackerFixture
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
-import uk.ac.wellcome.platform.archive.common.ingests.monitor.DynamoIngestTracker
+import uk.ac.wellcome.platform.archive.common.ingests.monitor.IngestTracker
 import uk.ac.wellcome.platform.archive.ingests.services.IngestsWorker
-import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDb
+import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
 
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.Success
 
 trait IngestsFixtures
     extends LocalDynamoDb
@@ -21,15 +22,16 @@ trait IngestsFixtures
     with IngestTrackerFixture
     with CallbackNotificationServiceFixture
     with AlpakkaSQSWorkerFixtures
-    with MonitoringClientFixture {
+    with MonitoringClientFixture
+    with OperationFixtures {
 
-  def withIngestWorker[R](queue: Queue, table: Table, topic: Topic)(
-    testWith: TestWith[IngestsWorker, R]): R =
+  def withIngestWorker[R](queue: Queue, table: Table, sender: MessageSender[String])(
+    testWith: TestWith[IngestsWorker[String], R]): R =
     withMonitoringClient { implicit monitoringClient =>
       withActorSystem { implicit actorSystem =>
         withMaterializer { implicit materializer =>
           withIngestTracker(table) { ingestTracker =>
-            withCallbackNotificationService(topic) {
+            withCallbackNotificationService(sender) {
               callbackNotificationService =>
                 val service = new IngestsWorker(
                   alpakkaSQSWorkerConfig = createAlpakkaSQSWorkerConfig(queue),
@@ -46,22 +48,21 @@ trait IngestsFixtures
       }
     }
 
-  def withIngest[R](ingestTracker: DynamoIngestTracker)(
+  def withIngest[R](ingestTracker: IngestTracker)(
     testWith: TestWith[Ingest, R]): R = {
     val createdIngest = createIngest
 
-    whenReady(
-      ingestTracker
-        .initialise(createdIngest))(testWith(_))
+    ingestTracker.initialise(createdIngest) shouldBe a[Success[_]]
+
+    testWith(createdIngest)
   }
 
-  def withConfiguredApp[R](testWith: TestWith[(Queue, Topic, Table), R]): R = {
+  def withConfiguredApp[R](testWith: TestWith[(Queue, MemoryMessageSender, Table), R]): R = {
     withLocalSqsQueue { queue =>
-      withLocalSnsTopic { topic =>
-        withIngestTrackerTable { table =>
-          withIngestWorker(queue, table, topic) { _ =>
-            testWith((queue, topic, table))
-          }
+      val messageSender = createMessageSender
+      withIngestTrackerTable { table =>
+        withIngestWorker(queue, table, messageSender) { _ =>
+          testWith((queue, messageSender, table))
         }
       }
     }

--- a/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/services/CallbackNotificationServiceTest.scala
+++ b/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/services/CallbackNotificationServiceTest.scala
@@ -5,7 +5,11 @@ import org.scalatest.prop.TableDrivenPropertyChecks._
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.common.fixtures.OperationFixtures
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
-import uk.ac.wellcome.platform.archive.common.ingests.models.{Callback, CallbackNotification, Ingest}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  Callback,
+  CallbackNotification,
+  Ingest
+}
 import uk.ac.wellcome.platform.archive.ingests.fixtures.CallbackNotificationServiceFixture
 
 import scala.util.Success
@@ -42,7 +46,8 @@ class CallbackNotificationServiceTest
           payload = ingest
         )
 
-        messageSender.getMessages[CallbackNotification]()  shouldBe Seq(expectedNotification)
+        messageSender.getMessages[CallbackNotification]() shouldBe Seq(
+          expectedNotification)
       }
     }
   }

--- a/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/services/CallbackNotificationServiceTest.scala
+++ b/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/services/CallbackNotificationServiceTest.scala
@@ -42,9 +42,7 @@ class CallbackNotificationServiceTest
           payload = ingest
         )
 
-        messageSender.messages
-          .map { _.body }
-          .map { fromJson[CallbackNotification](_).get } shouldBe Seq(expectedNotification)
+        messageSender.getMessages[CallbackNotification]()  shouldBe Seq(expectedNotification)
       }
     }
   }

--- a/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/services/CallbackNotificationServiceTest.scala
+++ b/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/services/CallbackNotificationServiceTest.scala
@@ -1,22 +1,20 @@
 package uk.ac.wellcome.platform.archive.ingests.services
 
 import org.scalatest.FunSpec
-import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.platform.archive.common.fixtures.OperationFixtures
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  Callback,
-  CallbackNotification,
-  Ingest
-}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{Callback, CallbackNotification, Ingest}
 import uk.ac.wellcome.platform.archive.ingests.fixtures.CallbackNotificationServiceFixture
+
+import scala.util.Success
 
 class CallbackNotificationServiceTest
     extends FunSpec
-    with ScalaFutures
     with CallbackNotificationServiceFixture
-    with IngestGenerators {
+    with IngestGenerators
+    with OperationFixtures {
 
   val sendsCallbackStatus = Table(
     ("ingest-status", "callback-status"),
@@ -27,27 +25,26 @@ class CallbackNotificationServiceTest
   it(
     "sends a notification if there's a pending callback and the ingest is complete") {
     forAll(sendsCallbackStatus) { (ingestStatus, callbackStatus) =>
-      withLocalSnsTopic { topic =>
-        withCallbackNotificationService(topic) { service =>
-          val ingest = createIngestWith(
-            status = ingestStatus,
-            callback = Some(
-              createCallbackWith(status = callbackStatus)
-            )
+      val messageSender = createMessageSender
+      withCallbackNotificationService(messageSender) { service =>
+        val ingest = createIngestWith(
+          status = ingestStatus,
+          callback = Some(
+            createCallbackWith(status = callbackStatus)
           )
+        )
 
-          val future = service.sendNotification(ingest)
+        service.sendNotification(ingest) shouldBe a[Success[_]]
 
-          whenReady(future) { _ =>
-            val expectedNotification = CallbackNotification(
-              ingestId = ingest.id,
-              callbackUri = ingest.callback.get.uri,
-              payload = ingest
-            )
+        val expectedNotification = CallbackNotification(
+          ingestId = ingest.id,
+          callbackUri = ingest.callback.get.uri,
+          payload = ingest
+        )
 
-            assertSnsReceivesOnly(expectedNotification, topic = topic)
-          }
-        }
+        messageSender.messages
+          .map { _.body }
+          .map { fromJson[CallbackNotification](_).get } shouldBe Seq(expectedNotification)
       }
     }
   }
@@ -68,44 +65,30 @@ class CallbackNotificationServiceTest
 
   it("doesn't send a notification if the callback has already been sent") {
     forAll(doesNotSendCallbackStatus) { (ingestStatus, callbackStatus) =>
-      withLocalSnsTopic { topic =>
-        withCallbackNotificationService(topic) { service =>
-          val ingest = createIngestWith(
-            status = ingestStatus,
-            callback = Some(createCallbackWith(status = callbackStatus))
-          )
+      val messageSender = createMessageSender
+      withCallbackNotificationService(messageSender) { service =>
+        val ingest = createIngestWith(
+          status = ingestStatus,
+          callback = Some(createCallbackWith(status = callbackStatus))
+        )
 
-          val future = service.sendNotification(ingest)
+        service.sendNotification(ingest) shouldBe a[Success[_]]
 
-          // Sleep for half a second to be sure the message would have been
-          // sent if it was going to.
-          Thread.sleep(500)
-
-          whenReady(future) { _ =>
-            assertSnsReceivesNothing(topic)
-          }
-        }
+        messageSender.messages shouldBe empty
       }
     }
   }
 
   it("doesn't send a notification if there's no callback information") {
-    withLocalSnsTopic { topic =>
-      withCallbackNotificationService(topic) { service =>
-        val ingest = createIngestWith(
-          callback = None
-        )
+    val messageSender = createMessageSender
+    withCallbackNotificationService(messageSender) { service =>
+      val ingest = createIngestWith(
+        callback = None
+      )
 
-        val future = service.sendNotification(ingest)
+      service.sendNotification(ingest) shouldBe a[Success[_]]
 
-        // Sleep for half a second to be sure the message would have been
-        // sent if it was going to.
-        Thread.sleep(500)
-
-        whenReady(future) { _ =>
-          assertSnsReceivesNothing(topic)
-        }
-      }
+      messageSender.messages shouldBe empty
     }
   }
 }

--- a/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/services/IngestsWorkerServiceTest.scala
+++ b/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/services/IngestsWorkerServiceTest.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.platform.archive.ingests.services
 
+import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException
 import io.circe.Encoder
 import org.scalatest.FunSpec
 import uk.ac.wellcome.json.JsonUtil._
@@ -131,9 +132,7 @@ class IngestsWorkerServiceTest
           err shouldBe a[DeterministicFailure[_]]
           err
             .asInstanceOf[DeterministicFailure[_]]
-            .failure shouldBe a[RuntimeException]
-          println(err)
-          true shouldBe false
+            .failure shouldBe a[ConditionalCheckFailedException]
         }
       }
     }

--- a/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/services/IngestsWorkerServiceTest.scala
+++ b/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/services/IngestsWorkerServiceTest.scala
@@ -7,7 +7,10 @@ import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.messaging.worker.models.DeterministicFailure
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.models.CallbackNotification
-import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest.{Completed, Processing}
+import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest.{
+  Completed,
+  Processing
+}
 import uk.ac.wellcome.platform.archive.common.ingests.monitor.MemoryIngestTracker
 import uk.ac.wellcome.platform.archive.ingests.fixtures.IngestsFixtures
 
@@ -44,7 +47,8 @@ class IngestsWorkerServiceTest
           payload = expectedIngest
         )
 
-        messageSender.getMessages[CallbackNotification]() shouldBe Seq(callbackNotification)
+        messageSender.getMessages[CallbackNotification]() shouldBe Seq(
+          callbackNotification)
 
         assertIngestCreated(ingestTracker)(expectedIngest)
 
@@ -135,7 +139,8 @@ class IngestsWorkerServiceTest
         destination = randomAlphanumeric(),
         subject = randomAlphanumeric()
       ) {
-        override def sendT[T](t: T)(implicit encoder: Encoder[T]): Try[Unit] = Failure(new Throwable("BOOM!"))
+        override def sendT[T](t: T)(implicit encoder: Encoder[T]): Try[Unit] =
+          Failure(new Throwable("BOOM!"))
       }
 
       withIngestWorker(queue, ingestTracker, brokenSender) { service =>

--- a/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/services/IngestsWorkerServiceTest.scala
+++ b/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/services/IngestsWorkerServiceTest.scala
@@ -44,13 +44,7 @@ class IngestsWorkerServiceTest
           payload = expectedIngest
         )
 
-        messageSender.messages
-          .map {
-            _.body
-          }
-          .map {
-            fromJson[CallbackNotification](_).get
-          } shouldBe Seq(callbackNotification)
+        messageSender.getMessages[CallbackNotification]() shouldBe Seq(callbackNotification)
 
         assertIngestCreated(ingestTracker)(expectedIngest)
 

--- a/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/services/IngestsWorkerServiceTest.scala
+++ b/ingests/src/test/scala/uk/ac/wellcome/platform/archive/ingests/services/IngestsWorkerServiceTest.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.platform.archive.ingests.services
 
-import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException
 import io.circe.Encoder
 import org.scalatest.FunSpec
 import uk.ac.wellcome.json.JsonUtil._
@@ -9,6 +8,7 @@ import uk.ac.wellcome.messaging.worker.models.DeterministicFailure
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.models.CallbackNotification
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest.{Completed, Processing}
+import uk.ac.wellcome.platform.archive.common.ingests.monitor.MemoryIngestTracker
 import uk.ac.wellcome.platform.archive.ingests.fixtures.IngestsFixtures
 
 import scala.util.{Failure, Success, Try}
@@ -19,156 +19,147 @@ class IngestsWorkerServiceTest
     with IngestsFixtures {
   it("updates an existing ingest to Completed") {
     withLocalSqsQueue { queue =>
-      withIngestTrackerTable { table =>
-        val messageSender = createMessageSender
-        withIngestWorker(queue, table, messageSender) { service =>
-          withIngestTracker(table) { monitor =>
-            withIngest(monitor) { ingest =>
-              val ingestStatusUpdate =
-                createIngestStatusUpdateWith(
-                  id = ingest.id,
-                  status = Completed
-                )
+      val ingestTracker = new MemoryIngestTracker()
+      val ingest = ingestTracker.initialise(createIngest).get
 
-              service.processMessage(ingestStatusUpdate) shouldBe a[Success[_]]
+      val messageSender = createMessageSender
+      withIngestWorker(queue, ingestTracker, messageSender) { service =>
+        val ingestStatusUpdate =
+          createIngestStatusUpdateWith(
+            id = ingest.id,
+            status = Completed
+          )
 
-              val expectedIngest = ingest.copy(
-                status = Completed,
-                events = ingestStatusUpdate.events,
-                bag = ingestStatusUpdate.affectedBag
-              )
+        service.processMessage(ingestStatusUpdate) shouldBe a[Success[_]]
 
-              val callbackNotification = CallbackNotification(
-                ingestId = ingest.id,
-                callbackUri = ingest.callback.get.uri,
-                payload = expectedIngest
-              )
+        val expectedIngest = ingest.copy(
+          status = Completed,
+          events = ingestStatusUpdate.events,
+          bag = ingestStatusUpdate.affectedBag
+        )
 
-              messageSender.messages
-                .map { _.body }
-                .map { fromJson[CallbackNotification](_).get } shouldBe Seq(callbackNotification)
+        val callbackNotification = CallbackNotification(
+          ingestId = ingest.id,
+          callbackUri = ingest.callback.get.uri,
+          payload = expectedIngest
+        )
 
-              assertIngestCreated(expectedIngest, table)
-
-              assertIngestRecordedRecentEvents(
-                id = ingestStatusUpdate.id,
-                expectedEventDescriptions = ingestStatusUpdate.events.map {
-                  _.description
-                },
-                table = table
-              )
-            }
+        messageSender.messages
+          .map {
+            _.body
           }
-        }
+          .map {
+            fromJson[CallbackNotification](_).get
+          } shouldBe Seq(callbackNotification)
 
+        assertIngestCreated(ingestTracker)(expectedIngest)
+
+        assertIngestRecordedRecentEvents(ingestTracker)(
+          id = ingestStatusUpdate.id,
+          expectedEventDescriptions = ingestStatusUpdate.events.map {
+            _.description
+          }
+        )
       }
     }
   }
 
   it("adds multiple events to an ingest") {
     withLocalSqsQueue { queue =>
-      withIngestTrackerTable { table =>
-        val messageSender = createMessageSender
-        withIngestWorker(queue, table, messageSender) { service =>
-          withIngestTracker(table) { monitor =>
-            withIngest(monitor) { ingest =>
-              val ingestStatusUpdate1 =
-                createIngestStatusUpdateWith(
-                  id = ingest.id,
-                  status = Processing
-                )
+      val ingestTracker = new MemoryIngestTracker()
+      val ingest = ingestTracker.initialise(createIngest).get
 
-              val ingestStatusUpdate2 =
-                createIngestStatusUpdateWith(
-                  id = ingest.id,
-                  status = Processing,
-                  maybeBag = ingestStatusUpdate1.affectedBag
-                )
+      val messageSender = createMessageSender
+      withIngestWorker(queue, ingestTracker, messageSender) { service =>
+        val ingestStatusUpdate1 =
+          createIngestStatusUpdateWith(
+            id = ingest.id,
+            status = Processing
+          )
 
-              val expectedIngest = ingest.copy(
-                status = Completed,
-                events = ingestStatusUpdate1.events ++ ingestStatusUpdate2.events,
-                bag = ingestStatusUpdate1.affectedBag
-              )
+        val ingestStatusUpdate2 =
+          createIngestStatusUpdateWith(
+            id = ingest.id,
+            status = Processing,
+            maybeBag = ingestStatusUpdate1.affectedBag
+          )
 
-              service.processMessage(ingestStatusUpdate1) shouldBe a[Success[_]]
-              service.processMessage(ingestStatusUpdate2) shouldBe a[Success[_]]
+        val expectedIngest = ingest.copy(
+          status = Completed,
+          events = ingestStatusUpdate1.events ++ ingestStatusUpdate2.events,
+          bag = ingestStatusUpdate1.affectedBag
+        )
 
-              assertIngestCreated(expectedIngest, table)
+        service.processMessage(ingestStatusUpdate1) shouldBe a[Success[_]]
+        service.processMessage(ingestStatusUpdate2) shouldBe a[Success[_]]
 
-              val expectedEventDescriptions =
-                (ingestStatusUpdate1.events ++ ingestStatusUpdate2.events)
-                  .map {
-                    _.description
-                  }
+        assertIngestCreated(ingestTracker)(expectedIngest)
 
-              assertIngestRecordedRecentEvents(
-                id = ingestStatusUpdate1.id,
-                expectedEventDescriptions = expectedEventDescriptions,
-                table = table
-              )
+        val expectedEventDescriptions =
+          (ingestStatusUpdate1.events ++ ingestStatusUpdate2.events)
+            .map {
+              _.description
             }
-          }
-        }
+
+        assertIngestRecordedRecentEvents(ingestTracker)(
+          id = ingestStatusUpdate1.id,
+          expectedEventDescriptions = expectedEventDescriptions
+        )
       }
     }
   }
 
   it("fails if the ingest is not in the table") {
     withLocalSqsQueue { queue =>
-      withIngestTrackerTable { table =>
-        val messageSender = createMessageSender
-        withIngestWorker(queue, table, messageSender) { service =>
-          val ingestStatusUpdate =
-            createIngestStatusUpdateWith(
-              status = Completed
-            )
+      val ingestTracker = new MemoryIngestTracker()
+      val messageSender = createMessageSender
 
-          val result = service.processMessage(ingestStatusUpdate)
-          result shouldBe a[Success[_]]
+      withIngestWorker(queue, ingestTracker, messageSender) { service =>
+        val ingestStatusUpdate = createIngestStatusUpdateWith(
+          status = Completed
+        )
 
-          val err = result.get
+        val result = service.processMessage(ingestStatusUpdate)
+        result shouldBe a[Success[_]]
 
-          err shouldBe a[DeterministicFailure[_]]
-          err
-            .asInstanceOf[DeterministicFailure[_]]
-            .failure shouldBe a[ConditionalCheckFailedException]
-        }
+        val err = result.get
+
+        err shouldBe a[DeterministicFailure[_]]
+        err
+          .asInstanceOf[DeterministicFailure[_]]
+          .failure shouldBe a[Throwable]
       }
     }
   }
 
   it("fails if publishing a message fails") {
     withLocalSqsQueue { queue =>
-      withIngestTrackerTable { table =>
-        val brokenSender = new MemoryMessageSender(
-          destination = randomAlphanumeric(),
-          subject = randomAlphanumeric()
-        ) {
-          override def sendT[T](t: T)(implicit encoder: Encoder[T]): Try[Unit] = Failure(new Throwable("BOOM!"))
-        }
+      val ingestTracker = new MemoryIngestTracker()
+      val ingest = ingestTracker.initialise(createIngest).get
 
-        withIngestWorker(queue, table, brokenSender) { service =>
-          withIngestTracker(table) { monitor =>
-            withIngest(monitor) { ingest =>
-              val ingestStatusUpdate =
-                createIngestStatusUpdateWith(
-                  id = ingest.id,
-                  status = Completed
-                )
+      val brokenSender = new MemoryMessageSender(
+        destination = randomAlphanumeric(),
+        subject = randomAlphanumeric()
+      ) {
+        override def sendT[T](t: T)(implicit encoder: Encoder[T]): Try[Unit] = Failure(new Throwable("BOOM!"))
+      }
 
-              val result = service.processMessage(ingestStatusUpdate)
-              result shouldBe a[Success[_]]
+      withIngestWorker(queue, ingestTracker, brokenSender) { service =>
+        val ingestStatusUpdate =
+          createIngestStatusUpdateWith(
+            id = ingest.id,
+            status = Completed
+          )
 
-              val err = result.get
-              err shouldBe a[DeterministicFailure[_]]
-              err
-                .asInstanceOf[DeterministicFailure[_]]
-                .failure shouldBe a[Throwable]
+        val result = service.processMessage(ingestStatusUpdate)
+        result shouldBe a[Success[_]]
 
-            }
-          }
-        }
+        val err = result.get
+        err shouldBe a[DeterministicFailure[_]]
+        err
+          .asInstanceOf[DeterministicFailure[_]]
+          .failure shouldBe a[Throwable]
+
       }
     }
   }

--- a/ingests_common/docker-compose.yml
+++ b/ingests_common/docker-compose.yml
@@ -1,7 +1,3 @@
-sns:
-  image: wellcome/fake-sns
-  ports:
-    - "9292:9292"
 dynamodb:
   image: peopleperhour/dynamodb
   ports:

--- a/ingests_common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/monitor/DynamoIngestTracker.scala
+++ b/ingests_common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/monitor/DynamoIngestTracker.scala
@@ -18,7 +18,7 @@ import uk.ac.wellcome.storage.type_classes.IdGetter
 import scala.util.{Failure, Success, Try}
 
 class DynamoIngestTracker(
-  dynamoDbClient: AmazonDynamoDB,
+  dynamoClient: AmazonDynamoDB,
   dynamoConfig: DynamoConfig
 ) extends Logging with IngestTracker {
 
@@ -29,7 +29,7 @@ class DynamoIngestTracker(
   implicit val updateExpressionGenerator: UpdateExpressionGenerator[Ingest] = (t: Ingest) => throw new Throwable("This method should never be used")
 
   val underlying = new DynamoDao[IngestID, Ingest](
-    dynamoClient = dynamoDbClient,
+    dynamoClient = dynamoClient,
     dynamoConfig = dynamoConfig
   ) {
     override protected def buildGetKeyExpression(ident: IngestID): UniqueKey[_] =
@@ -108,7 +108,7 @@ class DynamoIngestTracker(
       .limit(30)
       .query(('bagIdIndex -> bagId.toString).descending)
 
-    val result: Seq[Either[DynamoReadError, BagIngest]] = Scanamo.exec(dynamoDbClient)(query)
+    val result: Seq[Either[DynamoReadError, BagIngest]] = Scanamo.exec(dynamoClient)(query)
 
     val ingests = result.collect { case Right(ingest) => ingest }
     val failures = result.collect { case Left(err) => err }

--- a/ingests_common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/monitor/DynamoIngestTracker.scala
+++ b/ingests_common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/monitor/DynamoIngestTracker.scala
@@ -6,6 +6,7 @@ import com.gu.scanamo.error.{ConditionNotMet, DynamoReadError, ScanamoError}
 import com.gu.scanamo.ops.ScanamoOps
 import com.gu.scanamo.query.UniqueKey
 import com.gu.scanamo.syntax._
+import com.gu.scanamo.update.UpdateExpression
 import com.gu.scanamo.{Scanamo, Table}
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.common.IngestID
@@ -59,7 +60,7 @@ class DynamoIngestTracker(
 
     val eventsUpdate = appendAll('events -> update.events.toList)
 
-    val mergedUpdate = update match {
+    val mergedUpdate: UpdateExpression = update match {
       case _: IngestEventUpdate =>
         eventsUpdate
       case statusUpdate: IngestStatusUpdate =>

--- a/ingests_common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/monitor/DynamoIngestTracker.scala
+++ b/ingests_common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/monitor/DynamoIngestTracker.scala
@@ -1,0 +1,113 @@
+package uk.ac.wellcome.platform.archive.common.ingests.monitor
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+import com.gu.scanamo.{Scanamo, Table}
+import com.gu.scanamo.error.DynamoReadError
+import com.gu.scanamo.query.UniqueKey
+import com.gu.scanamo.syntax._
+import grizzled.slf4j.Logging
+import uk.ac.wellcome.platform.archive.common.IngestID
+import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
+import uk.ac.wellcome.platform.archive.common.ingests.models._
+import uk.ac.wellcome.storage.dynamo.{DynamoConfig, DynamoDao, UpdateExpressionGenerator}
+import uk.ac.wellcome.storage.type_classes.IdGetter
+
+import scala.util.{Failure, Success, Try}
+
+class DynamoIngestTracker(
+  dynamoDbClient: AmazonDynamoDB,
+  dynamoConfig: DynamoConfig
+) extends Logging with IngestTracker {
+
+  implicit val idGetter: IdGetter[Ingest] = (ingest: Ingest) => ingest.id.toString
+
+  implicit val updateExpressionGenerator: UpdateExpressionGenerator[Ingest] = UpdateExpressionGenerator[Ingest]
+
+  val underlying = new DynamoDao[IngestID, Ingest](
+    dynamoClient = dynamoDbClient,
+    dynamoConfig = dynamoConfig
+  ) {
+    override protected def buildGetKeyExpression(ident: IngestID): UniqueKey[_] =
+      'id -> ident.toString
+
+    override protected def buildPutKeyExpression(ingest: Ingest): UniqueKey[_] =
+      'id -> idGetter.id(ingest)
+  }
+
+  def get(id: IngestID): Try[Option[Ingest]] = underlying.get(id)
+
+  def initialise(ingest: Ingest): Try[Ingest] = {
+    debug(s"initializing archive ingest tracker with $ingest")
+
+    val ops = underlying.table
+      .given(not(attributeExists('id)))
+      .update('id -> ingest.id.toString, underlying.buildUpdate(ingest).get)
+
+    underlying.executeOps(id = ingest.id.toString, ops = ops)
+  }
+
+  def update(update: IngestUpdate): Try[Ingest] = {
+    debug(s"Updating record:${update.id} with:$update")
+
+    val eventsUpdate = appendAll('events -> update.events.toList)
+
+    val mergedUpdate = update match {
+      case _: IngestEventUpdate =>
+        eventsUpdate
+      case statusUpdate: IngestStatusUpdate =>
+        val bagUpdate = statusUpdate.affectedBag
+          .map(
+            bag =>
+              set('bag -> bag) and set(
+                'bagIdIndex -> bag.toString
+            ))
+          .toList
+
+        (List(
+          eventsUpdate,
+          set('status -> statusUpdate.status)
+        ) ++ bagUpdate)
+          .reduce(_ and _)
+
+      case callbackStatusUpdate: IngestCallbackStatusUpdate =>
+        eventsUpdate and set(
+          'callback \ 'status -> callbackStatusUpdate.callbackStatus)
+    }
+
+    val ops = underlying.table
+      .given(attributeExists('id))
+      .update('id -> update.id.toString, mergedUpdate)
+
+    underlying.executeOps(id = update.id.toString, ops = ops)
+  }
+
+  /** Find stored ingest given a bagId, uses the secondary index to link a bag to the ingest(s)
+    * that created it.
+    *
+    * This is intended to meet a particular use case for DLCS during migration and not as part of the
+    * public/documented API.  Consider either removing this functionality or enhancing it to be fully
+    * featured if a use case arises after migration.
+    *
+    * return a list of Either BagIngest or error querying DynamoDb
+    *
+    * Returns at most 30 associated ingests with most recent first -- to simplify the code by avoiding
+    * pagination, but still fulfilling DLCS's requirements.
+    */
+  def findByBagId(bagId: BagId): Try[Seq[BagIngest]] = {
+    val query = Table[BagIngest](dynamoConfig.table)
+      .index(dynamoConfig.index)
+      .limit(30)
+      .query(('bagIdIndex -> bagId.toString).descending)
+
+    val result: Seq[Either[DynamoReadError, BagIngest]] = Scanamo.exec(dynamoDbClient)(query)
+
+    val ingests = result.collect { case Right(ingest) => ingest }
+    val failures = result.collect { case Left(err) => err }
+
+    if (failures.isEmpty) {
+      Failure(new RuntimeException(s"Errors reading from DynamoDB: $failures"))
+    } else {
+      Success(ingests)
+    }
+  }
+}

--- a/ingests_common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/monitor/IngestTracker.scala
+++ b/ingests_common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/monitor/IngestTracker.scala
@@ -1,139 +1,17 @@
 package uk.ac.wellcome.platform.archive.common.ingests.monitor
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
-import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException
-import com.gu.scanamo._
-import com.gu.scanamo.error.{ConditionNotMet, DynamoReadError}
-import com.gu.scanamo.syntax._
-import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.common.IngestID
-import uk.ac.wellcome.platform.archive.common.IngestID._
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
-import uk.ac.wellcome.platform.archive.common.ingests.models._
-import uk.ac.wellcome.storage.dynamo._
+import uk.ac.wellcome.platform.archive.common.ingests.models.{BagIngest, Ingest, IngestUpdate}
 
-import scala.concurrent.{blocking, ExecutionContext, Future}
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 
-class IngestTracker(
-  dynamoDbClient: AmazonDynamoDB,
-  dynamoConfig: DynamoConfig
-)(implicit ec: ExecutionContext)
-    extends Logging {
+trait IngestTracker {
+  def get(id: IngestID): Try[Option[Ingest]]
 
-  def get(id: IngestID): Future[Option[Ingest]] = Future {
-    Scanamo
-      .get[Ingest](dynamoDbClient)(dynamoConfig.table)('id -> id.toString)
-      .map {
-        case Right(ingest) => ingest
-        case Left(err) =>
-          throw new RuntimeException(s"Failed to read from DynamoDB: $err")
-      }
-  }
+  def initialise(ingest: Ingest): Try[Ingest]
 
-  def initialise(ingest: Ingest): Future[Ingest] = {
-    val ingestTable = Table[Ingest](dynamoConfig.table)
-    debug(s"initializing archive ingest tracker with $ingest")
+  def update(update: IngestUpdate): Try[Ingest]
 
-    val ops = ingestTable
-      .given(not(attributeExists('id)))
-      .put(ingest)
-
-    Future {
-      blocking(Scanamo.exec(dynamoDbClient)(ops)) match {
-        case Left(e: ConditionalCheckFailedException) =>
-          throw IdConstraintError(
-            s"There is already a ingest tracker with id:${ingest.id}",
-            e)
-        case Left(scanamoError) =>
-          val exception = new RuntimeException(
-            s"Failed to create ingest ${scanamoError.toString}")
-          warn(s"Failed to update Dynamo record: ${ingest.id}", exception)
-          throw exception
-        case Right(a) =>
-          debug(s"Successfully updated Dynamo record: ${ingest.id} $a")
-      }
-      ingest
-    }
-  }
-
-  def update(update: IngestUpdate): Try[Ingest] = {
-    debug(s"Updating record:${update.id} with:$update")
-
-    val eventsUpdate = appendAll('events -> update.events.toList)
-
-    val mergedUpdate = update match {
-      case _: IngestEventUpdate =>
-        eventsUpdate
-      case statusUpdate: IngestStatusUpdate =>
-        val bagUpdate = statusUpdate.affectedBag
-          .map(
-            bag =>
-              set('bag -> bag) and set(
-                'bagIdIndex -> bag.toString
-            ))
-          .toList
-
-        (List(
-          eventsUpdate,
-          set('status -> statusUpdate.status)
-        ) ++ bagUpdate)
-          .reduce(_ and _)
-
-      case callbackStatusUpdate: IngestCallbackStatusUpdate =>
-        eventsUpdate and set(
-          'callback \ 'status -> callbackStatusUpdate.callbackStatus)
-    }
-
-    val ingestTable = Table[Ingest](dynamoConfig.table)
-    val ops = ingestTable
-      .given(attributeExists('id))
-      .update('id -> update.id, mergedUpdate)
-
-    Scanamo.exec(dynamoDbClient)(ops) match {
-      case Left(ConditionNotMet(e: ConditionalCheckFailedException)) => {
-        val idConstraintError =
-          IdConstraintError(
-            s"Ingest does not exist for id:${update.id}",
-            e
-          )
-
-        Failure(idConstraintError)
-      }
-      case Left(scanamoError) => {
-        val exception = new RuntimeException(scanamoError.toString)
-        warn(s"Failed to update Dynamo record: ${update.id}", exception)
-        Failure(exception)
-      }
-      case Right(ingest) => {
-        debug(s"Successfully updated Dynamo record: ${update.id}, got $ingest")
-        Success(ingest)
-      }
-    }
-  }
-
-  /** Find stored ingest given a bagId, uses the secondary index to link a bag to the ingest(s)
-    * that created it.
-    *
-    * This is intended to meet a particular use case for DLCS during migration and not as part of the
-    * public/documented API.  Consider either removing this functionality or enhancing it to be fully
-    * featured if a use case arises after migration.
-    *
-    * return a list of Either BagIngest or error querying DynamoDb
-    *
-    * Returns at most 30 associated ingests with most recent first -- to simplify the code by avoiding
-    * pagination, but still fulfilling DLCS's requirements.
-    */
-  def findByBagId(bagId: BagId): List[Either[DynamoReadError, BagIngest]] = {
-    val query = Table[BagIngest](dynamoConfig.table)
-      .index(dynamoConfig.index)
-      .limit(30)
-      .query(('bagIdIndex -> bagId.toString).descending)
-    Scanamo.exec(dynamoDbClient)(query)
-  }
+  def findByBagId(bagId: BagId): Try[Seq[BagIngest]]
 }
-
-final case class IdConstraintError(
-  private val message: String,
-  private val cause: Throwable
-) extends Exception(message, cause)

--- a/ingests_common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/monitor/IngestTracker.scala
+++ b/ingests_common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/monitor/IngestTracker.scala
@@ -2,7 +2,11 @@ package uk.ac.wellcome.platform.archive.common.ingests.monitor
 
 import uk.ac.wellcome.platform.archive.common.IngestID
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
-import uk.ac.wellcome.platform.archive.common.ingests.models.{BagIngest, Ingest, IngestUpdate}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  BagIngest,
+  Ingest,
+  IngestUpdate
+}
 
 import scala.util.Try
 

--- a/ingests_common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/monitor/MemoryIngestTracker.scala
+++ b/ingests_common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/monitor/MemoryIngestTracker.scala
@@ -1,0 +1,60 @@
+package uk.ac.wellcome.platform.archive.common.ingests.monitor
+import uk.ac.wellcome.platform.archive.common.IngestID
+import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
+import uk.ac.wellcome.platform.archive.common.ingests.models._
+
+import scala.util.{Failure, Success, Try}
+
+class MemoryIngestTracker extends IngestTracker {
+  var ingests: Map[IngestID, Ingest] = Map.empty
+
+  override def get(id: IngestID): Try[Option[Ingest]] = Success(ingests.get(id))
+
+  override def initialise(ingest: Ingest): Try[Ingest] =
+    ingests.get(ingest.id) match {
+      case Some(_) => Failure(new Throwable(s"Ingest with ID ${ingest.id} already exists"))
+      case None =>
+        ingests = ingests ++ Map(ingest.id -> ingest)
+        Success(ingest)
+    }
+
+  override def update(update: IngestUpdate): Try[Ingest] =
+    ingests.get(update.id) match {
+      case Some(existing: Ingest) =>
+        val updatedIngest = existing.copy(events = existing.events ++ update.events)
+
+        val newIngest = update match {
+          case eventUpdate: IngestEventUpdate =>
+            updatedIngest
+          case statusUpdate: IngestStatusUpdate =>
+            updatedIngest.copy(
+              bag = statusUpdate.affectedBag,
+              status = statusUpdate.status
+            )
+          case callbackStatusUpdate: IngestCallbackStatusUpdate =>
+            updatedIngest.copy(
+              callback = updatedIngest.callback.map { c =>
+                c.copy(status = callbackStatusUpdate.callbackStatus)
+              }
+            )
+        }
+
+        ingests = ingests ++ Map(update.id -> newIngest)
+        Success(newIngest)
+      case None =>
+        Failure(new Throwable(s"Can't find an existing ingest with ID ${update.id}"))
+    }
+
+  override def findByBagId(bagId: BagId): Try[Seq[BagIngest]] = Success(
+    ingests.values
+      .filter { _.bag.contains(bagId) }
+      .zipWithIndex.map { case (ingest, index) =>
+        BagIngest(
+          id = ingest.id,
+          bagIdIndex = index.toString,
+          createdDate = ingest.createdDate
+        )
+      }
+      .toSeq
+  )
+}

--- a/ingests_common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/monitor/MemoryIngestTracker.scala
+++ b/ingests_common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/monitor/MemoryIngestTracker.scala
@@ -12,7 +12,8 @@ class MemoryIngestTracker extends IngestTracker {
 
   override def initialise(ingest: Ingest): Try[Ingest] =
     ingests.get(ingest.id) match {
-      case Some(_) => Failure(new Throwable(s"Ingest with ID ${ingest.id} already exists"))
+      case Some(_) =>
+        Failure(new Throwable(s"Ingest with ID ${ingest.id} already exists"))
       case None =>
         ingests = ingests ++ Map(ingest.id -> ingest)
         Success(ingest)
@@ -21,7 +22,8 @@ class MemoryIngestTracker extends IngestTracker {
   override def update(update: IngestUpdate): Try[Ingest] =
     ingests.get(update.id) match {
       case Some(existing: Ingest) =>
-        val updatedIngest = existing.copy(events = existing.events ++ update.events)
+        val updatedIngest =
+          existing.copy(events = existing.events ++ update.events)
 
         val newIngest = update match {
           case eventUpdate: IngestEventUpdate =>
@@ -42,18 +44,21 @@ class MemoryIngestTracker extends IngestTracker {
         ingests = ingests ++ Map(update.id -> newIngest)
         Success(newIngest)
       case None =>
-        Failure(new Throwable(s"Can't find an existing ingest with ID ${update.id}"))
+        Failure(
+          new Throwable(s"Can't find an existing ingest with ID ${update.id}"))
     }
 
   override def findByBagId(bagId: BagId): Try[Seq[BagIngest]] = Success(
     ingests.values
       .filter { _.bag.contains(bagId) }
-      .zipWithIndex.map { case (ingest, index) =>
-        BagIngest(
-          id = ingest.id,
-          bagIdIndex = index.toString,
-          createdDate = ingest.createdDate
-        )
+      .zipWithIndex
+      .map {
+        case (ingest, index) =>
+          BagIngest(
+            id = ingest.id,
+            bagIdIndex = index.toString,
+            createdDate = ingest.createdDate
+          )
       }
       .toSeq
   )

--- a/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/DynamoIngestTrackerTest.scala
+++ b/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/DynamoIngestTrackerTest.scala
@@ -3,7 +3,12 @@ package uk.ac.wellcome.platform.archive.common.ingests
 import java.time.Instant
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
-import com.amazonaws.services.dynamodbv2.model.{ConditionalCheckFailedException, GetItemRequest, PutItemRequest, UpdateItemRequest}
+import com.amazonaws.services.dynamodbv2.model.{
+  ConditionalCheckFailedException,
+  GetItemRequest,
+  PutItemRequest,
+  UpdateItemRequest
+}
 import org.mockito.Matchers.any
 import org.mockito.Mockito.when
 import org.scalatest.FunSpec
@@ -136,8 +141,7 @@ class DynamoIngestTrackerTest
           assertRecent(storedIngest.lastModifiedDate)
           storedIngest.events.map(_.description) should contain theSameElementsAs ingestUpdate.events
             .map(_.description)
-          storedIngest.events.foreach(event =>
-            assertRecent(event.createdDate))
+          storedIngest.events.foreach(event => assertRecent(event.createdDate))
 
           storedIngest.bag shouldBe ingestUpdate.affectedBag
         }
@@ -297,9 +301,14 @@ class DynamoIngestTrackerTest
           val time = Instant.parse("2018-12-01T12:00:00.00Z")
           val afterTime = Instant.parse("2018-12-01T12:10:00.00Z")
 
-          val ingestA = ingestTracker.initialise(createIngestWith(createdDate = beforeTime)).get
-          val ingestB = ingestTracker.initialise(createIngestWith(createdDate = time)).get
-          val ingestC = ingestTracker.initialise(createIngestWith(createdDate = afterTime)).get
+          val ingestA = ingestTracker
+            .initialise(createIngestWith(createdDate = beforeTime))
+            .get
+          val ingestB =
+            ingestTracker.initialise(createIngestWith(createdDate = time)).get
+          val ingestC = ingestTracker
+            .initialise(createIngestWith(createdDate = afterTime))
+            .get
 
           val bagId = createBagId
 
@@ -341,16 +350,17 @@ class DynamoIngestTrackerTest
         withIngestTracker(table) { ingestTracker =>
           val start = Instant.parse("2018-12-01T12:00:00.00Z")
           val eventualIngests: immutable.Seq[Ingest] = (0 to 33).map { i =>
-            ingestTracker.initialise(
-              createIngestWith(createdDate = start.plusSeconds(i))).get
+            ingestTracker
+              .initialise(createIngestWith(createdDate = start.plusSeconds(i)))
+              .get
           }
 
           val bagId = createBagId
 
           eventualIngests.map { ingest =>
-              val ingestUpdate =
-                createIngestUpdateWith(ingest.id, bagId)
-              ingestTracker.update(ingestUpdate)
+            val ingestUpdate =
+              createIngestUpdateWith(ingest.id, bagId)
+            ingestTracker.update(ingestUpdate)
           }
 
           eventually {

--- a/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/DynamoIngestTrackerTest.scala
+++ b/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/DynamoIngestTrackerTest.scala
@@ -7,25 +7,21 @@ import com.amazonaws.services.dynamodbv2.model.{ConditionalCheckFailedException,
 import org.mockito.Matchers.any
 import org.mockito.Mockito.when
 import org.scalatest.FunSpec
-import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.mockito.MockitoSugar
 import uk.ac.wellcome.platform.archive.common.IngestID
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestTrackerFixture
 import uk.ac.wellcome.platform.archive.common.ingests.models._
-import uk.ac.wellcome.storage.fixtures.LocalDynamoDb
 
 import scala.collection.immutable
 import scala.util.{Failure, Success}
 
 class DynamoIngestTrackerTest
     extends FunSpec
-    with LocalDynamoDb
     with MockitoSugar
     with IngestTrackerFixture
-    with IngestGenerators
-    with ScalaFutures {
+    with IngestGenerators {
 
   describe("create") {
     it("creates an ingest") {
@@ -148,7 +144,7 @@ class DynamoIngestTrackerTest
       }
     }
 
-    it("adds a single event to a monitor with no events") {
+    it("adds a single event to an Ingest with no events") {
       withIngestTrackerTable { table =>
         withIngestTracker(table) { ingestTracker =>
           val ingest = ingestTracker.initialise(createIngest).get
@@ -170,7 +166,7 @@ class DynamoIngestTrackerTest
       }
     }
 
-    it("adds a status update to a monitor with no events") {
+    it("adds a status update to an Ingest with no events") {
       withIngestTrackerTable { table =>
         withIngestTracker(table) { ingestTracker =>
           val ingest = ingestTracker.initialise(createIngest).get
@@ -200,7 +196,7 @@ class DynamoIngestTrackerTest
       }
     }
 
-    it("adds a callback status update to a monitor with no events") {
+    it("adds a callback status update to an Ingest with no events") {
       withIngestTrackerTable { table =>
         withIngestTracker(table) { ingestTracker =>
           val ingest = ingestTracker.initialise(createIngest).get
@@ -249,7 +245,7 @@ class DynamoIngestTrackerTest
       }
     }
 
-    it("adds multiple events to a monitor") {
+    it("adds multiple events to an Ingest") {
       withIngestTrackerTable { table =>
         withIngestTracker(table) { ingestTracker =>
           val ingest = ingestTracker.initialise(createIngest).get

--- a/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/DynamoIngestTrackerTest.scala
+++ b/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/DynamoIngestTrackerTest.scala
@@ -25,7 +25,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.util.Try
 
-class IngestTrackerTest
+class DynamoIngestTrackerTest
     extends FunSpec
     with LocalDynamoDb
     with MockitoSugar

--- a/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/fixtures/IngestTrackerFixture.scala
+++ b/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/fixtures/IngestTrackerFixture.scala
@@ -7,7 +7,7 @@ import uk.ac.wellcome.platform.archive.common.IngestID._
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
 import uk.ac.wellcome.platform.archive.common.ingest.fixtures.TimeTestFixture
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
-import uk.ac.wellcome.platform.archive.common.ingests.monitor.IngestTracker
+import uk.ac.wellcome.platform.archive.common.ingests.monitor.DynamoIngestTracker
 import uk.ac.wellcome.storage.dynamo._
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDb
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
@@ -23,8 +23,8 @@ trait IngestTrackerFixture
 
   def withIngestTracker[R](table: Table,
                            dynamoDbClient: AmazonDynamoDB = dynamoDbClient)(
-    testWith: TestWith[IngestTracker, R]): R = {
-    val ingestTracker = new IngestTracker(
+    testWith: TestWith[DynamoIngestTracker, R]): R = {
+    val ingestTracker = new DynamoIngestTracker(
       dynamoDbClient = dynamoDbClient,
       dynamoConfig = createDynamoConfigWith(table)
     )

--- a/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/fixtures/IngestTrackerFixture.scala
+++ b/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/fixtures/IngestTrackerFixture.scala
@@ -7,7 +7,10 @@ import uk.ac.wellcome.platform.archive.common.IngestID
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
 import uk.ac.wellcome.platform.archive.common.ingest.fixtures.TimeTestFixture
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
-import uk.ac.wellcome.platform.archive.common.ingests.monitor.{DynamoIngestTracker, MemoryIngestTracker}
+import uk.ac.wellcome.platform.archive.common.ingests.monitor.{
+  DynamoIngestTracker,
+  MemoryIngestTracker
+}
 import uk.ac.wellcome.storage.dynamo._
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDb
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
@@ -32,7 +35,8 @@ trait IngestTrackerFixture
   def getStoredIngest(ingest: Ingest, table: Table): Ingest =
     getExistingTableItem[Ingest](ingest.id.toString, table)
 
-  def assertIngestCreated(tracker: MemoryIngestTracker)(ingest: Ingest): Assertion = {
+  def assertIngestCreated(tracker: MemoryIngestTracker)(
+    ingest: Ingest): Assertion = {
     val storedIngest = tracker.ingests(ingest.id)
 
     storedIngest.sourceLocation shouldBe ingest.sourceLocation
@@ -59,8 +63,9 @@ trait IngestTrackerFixture
       assertRecent(event.createdDate, recentSeconds = 45))
   }
 
-  def assertIngestRecordedRecentEvents(tracker: MemoryIngestTracker)(id: IngestID,
-                                       expectedEventDescriptions: Seq[String]): Unit = {
+  def assertIngestRecordedRecentEvents(tracker: MemoryIngestTracker)(
+    id: IngestID,
+    expectedEventDescriptions: Seq[String]): Unit = {
     val ingest = tracker.ingests(id)
 
     ingest.events.map(_.description) should contain theSameElementsAs expectedEventDescriptions

--- a/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/fixtures/IngestTrackerFixture.scala
+++ b/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/fixtures/IngestTrackerFixture.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.archive.common.ingests.fixtures
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.common.IngestID
-import uk.ac.wellcome.platform.archive.common.IngestID._
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
 import uk.ac.wellcome.platform.archive.common.ingest.fixtures.TimeTestFixture
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
@@ -11,8 +10,6 @@ import uk.ac.wellcome.platform.archive.common.ingests.monitor.DynamoIngestTracke
 import uk.ac.wellcome.storage.dynamo._
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDb
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
-
-import scala.concurrent.ExecutionContext.Implicits.global
 
 trait IngestTrackerFixture
     extends IngestTrackerDynamoDb

--- a/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/fixtures/IngestTrackerFixture.scala
+++ b/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/fixtures/IngestTrackerFixture.scala
@@ -22,7 +22,7 @@ trait IngestTrackerFixture
                            dynamoDbClient: AmazonDynamoDB = dynamoDbClient)(
     testWith: TestWith[DynamoIngestTracker, R]): R = {
     val ingestTracker = new DynamoIngestTracker(
-      dynamoDbClient = dynamoDbClient,
+      dynamoClient = dynamoDbClient,
       dynamoConfig = createDynamoConfigWith(table)
     )
     testWith(ingestTracker)

--- a/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/fixtures/IngestTrackerFixture.scala
+++ b/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/fixtures/IngestTrackerFixture.scala
@@ -1,12 +1,13 @@
 package uk.ac.wellcome.platform.archive.common.ingests.fixtures
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
+import org.scalatest.Assertion
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.common.IngestID
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
 import uk.ac.wellcome.platform.archive.common.ingest.fixtures.TimeTestFixture
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
-import uk.ac.wellcome.platform.archive.common.ingests.monitor.DynamoIngestTracker
+import uk.ac.wellcome.platform.archive.common.ingests.monitor.{DynamoIngestTracker, MemoryIngestTracker}
 import uk.ac.wellcome.storage.dynamo._
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDb
 import uk.ac.wellcome.storage.fixtures.LocalDynamoDb.Table
@@ -31,6 +32,14 @@ trait IngestTrackerFixture
   def getStoredIngest(ingest: Ingest, table: Table): Ingest =
     getExistingTableItem[Ingest](ingest.id.toString, table)
 
+  def assertIngestCreated(tracker: MemoryIngestTracker)(ingest: Ingest): Assertion = {
+    val storedIngest = tracker.ingests(ingest.id)
+
+    storedIngest.sourceLocation shouldBe ingest.sourceLocation
+    assertRecent(storedIngest.createdDate, recentSeconds = 45)
+    assertRecent(storedIngest.lastModifiedDate, recentSeconds = 45)
+  }
+
   def assertIngestCreated(ingest: Ingest, table: Table): Ingest = {
     val storedIngest = getStoredIngest(ingest, table)
     storedIngest.sourceLocation shouldBe ingest.sourceLocation
@@ -50,4 +59,12 @@ trait IngestTrackerFixture
       assertRecent(event.createdDate, recentSeconds = 45))
   }
 
+  def assertIngestRecordedRecentEvents(tracker: MemoryIngestTracker)(id: IngestID,
+                                       expectedEventDescriptions: Seq[String]): Unit = {
+    val ingest = tracker.ingests(id)
+
+    ingest.events.map(_.description) should contain theSameElementsAs expectedEventDescriptions
+    ingest.events.foreach(event =>
+      assertRecent(event.createdDate, recentSeconds = 45))
+  }
 }

--- a/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/monitor/MemoryIngestTrackerTest.scala
+++ b/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/monitor/MemoryIngestTrackerTest.scala
@@ -6,7 +6,10 @@ import uk.ac.wellcome.platform.archive.common.ingests.models._
 
 import scala.util.{Failure, Success}
 
-class MemoryIngestTrackerTest extends FunSpec with Matchers with IngestGenerators {
+class MemoryIngestTrackerTest
+    extends FunSpec
+    with Matchers
+    with IngestGenerators {
   describe("create") {
     it("creates an ingest") {
       val tracker = new MemoryIngestTracker()
@@ -53,13 +56,13 @@ class MemoryIngestTrackerTest extends FunSpec with Matchers with IngestGenerator
 
       tracker.ingests(ingest.id).bag shouldBe None
 
-          val bagId = createBagId
+      val bagId = createBagId
 
-          val ingestUpdate = IngestStatusUpdate(
-            id = ingest.id,
-            status = Ingest.Processing,
-            affectedBag = Some(bagId)
-          )
+      val ingestUpdate = IngestStatusUpdate(
+        id = ingest.id,
+        status = Ingest.Processing,
+        affectedBag = Some(bagId)
+      )
 
       val result = tracker.update(ingestUpdate)
       result shouldBe a[Success[_]]
@@ -153,12 +156,12 @@ class MemoryIngestTrackerTest extends FunSpec with Matchers with IngestGenerator
       val ingest = createIngest
       tracker.initialise(ingest)
 
-          val updates = List(
-            createIngestEventUpdateWith(ingest.id),
-            createIngestEventUpdateWith(ingest.id)
-          )
+      val updates = List(
+        createIngestEventUpdateWith(ingest.id),
+        createIngestEventUpdateWith(ingest.id)
+      )
 
-          updates.foreach { tracker.update(_) }
+      updates.foreach { tracker.update(_) }
 
       val storedIngest: Ingest = tracker.ingests(ingest.id)
       storedIngest.events shouldBe updates(0).events ++ updates(1).events
@@ -166,8 +169,7 @@ class MemoryIngestTrackerTest extends FunSpec with Matchers with IngestGenerator
   }
 
   describe("find ingest by BagId") {
-    it(
-      "finds ingests with a matching bag ID") {
+    it("finds ingests with a matching bag ID") {
       val tracker = new MemoryIngestTracker()
 
       val bagId1 = createBagId
@@ -180,17 +182,23 @@ class MemoryIngestTrackerTest extends FunSpec with Matchers with IngestGenerator
       val ingest2A = createIngestWith(maybeBag = Some(bagId2))
       val ingest2B = createIngestWith(maybeBag = Some(bagId2))
 
-      Seq(ingest0, ingest1A, ingest1B, ingest1C, ingest2A, ingest2B).map { ingest =>
-        tracker.initialise(ingest)
+      Seq(ingest0, ingest1A, ingest1B, ingest1C, ingest2A, ingest2B).map {
+        ingest =>
+          tracker.initialise(ingest)
       }
 
       val result1 = tracker.findByBagId(bagId1)
       result1 shouldBe a[Success[_]]
-      result1.get.map { _.id } should contain theSameElementsAs Seq(ingest1A, ingest1B, ingest1C).map { _.id }
+      result1.get.map { _.id } should contain theSameElementsAs Seq(
+        ingest1A,
+        ingest1B,
+        ingest1C).map { _.id }
 
       val result2 = tracker.findByBagId(bagId2)
       result2 shouldBe a[Success[_]]
-      result2.get.map { _.id } should contain theSameElementsAs Seq(ingest2A, ingest2B).map { _.id }
+      result2.get.map { _.id } should contain theSameElementsAs Seq(
+        ingest2A,
+        ingest2B).map { _.id }
     }
   }
 }

--- a/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/monitor/MemoryIngestTrackerTest.scala
+++ b/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/monitor/MemoryIngestTrackerTest.scala
@@ -1,0 +1,196 @@
+package uk.ac.wellcome.platform.archive.common.ingests.monitor
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
+import uk.ac.wellcome.platform.archive.common.ingests.models._
+
+import scala.util.{Failure, Success}
+
+class MemoryIngestTrackerTest extends FunSpec with Matchers with IngestGenerators {
+  describe("create") {
+    it("creates an ingest") {
+      val tracker = new MemoryIngestTracker()
+
+      val ingest = createIngest
+      tracker.initialise(ingest) shouldBe Success(ingest)
+
+      tracker.ingests shouldBe Map(ingest.id -> ingest)
+    }
+
+    it("creates only one ingest for a given id") {
+      val tracker = new MemoryIngestTracker()
+
+      val ingest = createIngest
+      tracker.initialise(ingest) shouldBe Success(ingest)
+      tracker.initialise(ingest) shouldBe a[Failure[_]]
+
+      tracker.ingests shouldBe Map(ingest.id -> ingest)
+    }
+  }
+
+  describe("read") {
+    it("retrieves ingest by id") {
+      val tracker = new MemoryIngestTracker()
+
+      val ingest = createIngest
+      tracker.initialise(ingest)
+
+      tracker.get(ingest.id) shouldBe Success(Some(ingest))
+    }
+
+    it("returns None when no ingest matches id") {
+      val tracker = new MemoryIngestTracker()
+      tracker.get(createIngestID) shouldBe Success(None)
+    }
+  }
+
+  describe("update") {
+    it("updates the bag ID on an ingest that didn't have one") {
+      val tracker = new MemoryIngestTracker()
+
+      val ingest = createIngest
+      tracker.initialise(ingest)
+
+      tracker.ingests(ingest.id).bag shouldBe None
+
+          val bagId = createBagId
+
+          val ingestUpdate = IngestStatusUpdate(
+            id = ingest.id,
+            status = Ingest.Processing,
+            affectedBag = Some(bagId)
+          )
+
+      val result = tracker.update(ingestUpdate)
+      result shouldBe a[Success[_]]
+      val storedIngest = result.get
+
+      tracker.ingests shouldBe Map(ingest.id -> storedIngest)
+      storedIngest.bag shouldBe Some(bagId)
+    }
+
+    it("adds a single event to an Ingest with no events") {
+      val tracker = new MemoryIngestTracker()
+
+      val ingest = createIngest
+      tracker.initialise(ingest)
+
+      val ingestUpdate = IngestEventUpdate(
+        id = ingest.id,
+        events = List(createIngestEvent)
+      )
+
+      tracker.update(ingestUpdate) shouldBe a[Success[_]]
+
+      val storedIngest: Ingest = tracker.ingests(ingest.id)
+      storedIngest.events shouldBe ingestUpdate.events
+    }
+
+    it("adds a status update to an Ingest with no events") {
+      val tracker = new MemoryIngestTracker()
+
+      val ingest = createIngest
+      tracker.initialise(ingest)
+
+      val someBagId = Some(createBagId)
+      val ingestUpdate = IngestStatusUpdate(
+        id = ingest.id,
+        status = Ingest.Completed,
+        affectedBag = someBagId,
+        events = List(createIngestEvent)
+      )
+
+      tracker.update(ingestUpdate) shouldBe a[Success[_]]
+
+      val storedIngest: Ingest = tracker.ingests(ingest.id)
+      storedIngest.status shouldBe Ingest.Completed
+      storedIngest.bag shouldBe someBagId
+
+      storedIngest.events shouldBe ingestUpdate.events
+    }
+
+    it("adds a callback status update to an Ingest with no events") {
+      val tracker = new MemoryIngestTracker()
+
+      val ingest = createIngest
+      tracker.initialise(ingest)
+
+      val ingestUpdate = IngestCallbackStatusUpdate(
+        id = ingest.id,
+        callbackStatus = Callback.Succeeded,
+        events = List(createIngestEvent)
+      )
+
+      tracker.update(ingestUpdate) shouldBe a[Success[_]]
+
+      val storedIngest: Ingest = tracker.ingests(ingest.id)
+
+      storedIngest.callback shouldBe defined
+      storedIngest.callback.get.status shouldBe Callback.Succeeded
+      storedIngest.events shouldBe ingestUpdate.events
+    }
+
+    it("adds an update with multiple events") {
+      val tracker = new MemoryIngestTracker()
+
+      val ingest = createIngest
+      tracker.initialise(ingest)
+
+      val ingestUpdate = IngestEventUpdate(
+        ingest.id,
+        List(createIngestEvent, createIngestEvent)
+      )
+
+      tracker.update(ingestUpdate) shouldBe a[Success[_]]
+
+      val storedIngest: Ingest = tracker.ingests(ingest.id)
+      storedIngest.events shouldBe ingestUpdate.events
+    }
+
+    it("adds multiple events to an Ingest") {
+      val tracker = new MemoryIngestTracker()
+
+      val ingest = createIngest
+      tracker.initialise(ingest)
+
+          val updates = List(
+            createIngestEventUpdateWith(ingest.id),
+            createIngestEventUpdateWith(ingest.id)
+          )
+
+          updates.foreach { tracker.update(_) }
+
+      val storedIngest: Ingest = tracker.ingests(ingest.id)
+      storedIngest.events shouldBe updates(0).events ++ updates(1).events
+    }
+  }
+
+  describe("find ingest by BagId") {
+    it(
+      "finds ingests with a matching bag ID") {
+      val tracker = new MemoryIngestTracker()
+
+      val bagId1 = createBagId
+      val bagId2 = createBagId
+
+      val ingest0 = createIngest
+      val ingest1A = createIngestWith(maybeBag = Some(bagId1))
+      val ingest1B = createIngestWith(maybeBag = Some(bagId1))
+      val ingest1C = createIngestWith(maybeBag = Some(bagId1))
+      val ingest2A = createIngestWith(maybeBag = Some(bagId2))
+      val ingest2B = createIngestWith(maybeBag = Some(bagId2))
+
+      Seq(ingest0, ingest1A, ingest1B, ingest1C, ingest2A, ingest2B).map { ingest =>
+        tracker.initialise(ingest)
+      }
+
+      val result1 = tracker.findByBagId(bagId1)
+      result1 shouldBe a[Success[_]]
+      result1.get.map { _.id } should contain theSameElementsAs Seq(ingest1A, ingest1B, ingest1C).map { _.id }
+
+      val result2 = tracker.findByBagId(bagId2)
+      result2 shouldBe a[Success[_]]
+      result2.get.map { _.id } should contain theSameElementsAs Seq(ingest2A, ingest2B).map { _.id }
+    }
+  }
+}

--- a/makefiles/functions.Makefile
+++ b/makefiles/functions.Makefile
@@ -172,6 +172,21 @@ $(1)-publish: $(1)-build
 endef
 
 
+
+define __sbt_no_docker_ssm_target_template
+$(1)-test:
+	$(call sbt_test_no_docker,$(1))
+
+$(1)-build:
+	$(call sbt_build,$(1))
+	$(call build_image,$(1),$(2)/Dockerfile)
+
+$(1)-publish: $(1)-build
+	$(call publish_service_ssm,$(1),$(3),$(4),$(5))
+endef
+
+
+
 # Define a series of Make tasks for a Scala libraries that use docker-compose for tests.
 #
 # Args:
@@ -295,6 +310,7 @@ define stack_setup
 # whitespace, but that's the general idea.
 
 $(foreach proj,$(SBT_APPS),$(eval $(call __sbt_ssm_target_template,$(proj),$(STACK_ROOT)/$(proj),$(PROJECT_ID),$(ACCOUNT_ID))))
+$(foreach proj,$(SBT_NO_DOCKER_APPS),$(eval $(call __sbt_no_docker_ssm_target_template,$(proj),$(STACK_ROOT)/$(proj),$(PROJECT_ID),$(ACCOUNT_ID))))
 $(foreach library,$(SBT_DOCKER_LIBRARIES),$(eval $(call __sbt_library_docker_template,$(library),$(STACK_ROOT)/$(library))))
 $(foreach library,$(SBT_NO_DOCKER_LIBRARIES),$(eval $(call __sbt_library_template,$(library))))
 $(foreach task,$(PYTHON_APPS),$(eval $(call __python_ssm_target,$(task),$(STACK_ROOT)/$(task)/Dockerfile,$(PROJECT_ID),$(ACCOUNT_ID))))

--- a/notifier/docker-compose.yml
+++ b/notifier/docker-compose.yml
@@ -1,16 +1,8 @@
-sns:
-  image: wellcome/fake-sns
-  ports:
-    - "9292:9292"
 sqs:
   image: s12v/elasticmq
   ports:
     - "9324:9324"
     - "4789:9324"
-dynamodb:
-  image: peopleperhour/dynamodb
-  ports:
-    - "45678:8000"
 wiremock:
   image: rodolpheche/wiremock
   ports:

--- a/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/Main.scala
+++ b/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/Main.scala
@@ -5,10 +5,18 @@ import akka.stream.ActorMaterializer
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.typesafe.config.Config
 import uk.ac.wellcome.messaging.sns.SNSConfig
-import uk.ac.wellcome.messaging.typesafe.{AlpakkaSqsWorkerConfigBuilder, CloudwatchMonitoringClientBuilder, SNSBuilder, SQSBuilder}
+import uk.ac.wellcome.messaging.typesafe.{
+  AlpakkaSqsWorkerConfigBuilder,
+  CloudwatchMonitoringClientBuilder,
+  SNSBuilder,
+  SQSBuilder
+}
 import uk.ac.wellcome.messaging.worker.monitoring.CloudwatchMonitoringClient
 import uk.ac.wellcome.platform.archive.common.config.builders.HTTPServerBuilder
-import uk.ac.wellcome.platform.archive.notifier.services.{CallbackUrlService, NotifierWorker}
+import uk.ac.wellcome.platform.archive.notifier.services.{
+  CallbackUrlService,
+  NotifierWorker
+}
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 
@@ -36,7 +44,8 @@ object Main extends WellcomeTypesafeApp {
     new NotifierWorker[SNSConfig](
       alpakkaSQSWorkerConfig = AlpakkaSqsWorkerConfigBuilder.build(config),
       callbackUrlService = callbackUrlService,
-      messageSender = SNSBuilder.buildSNSMessageSender(config, subject = "Sent from the notifier")
+      messageSender = SNSBuilder
+        .buildSNSMessageSender(config, subject = "Sent from the notifier")
     )
   }
 }

--- a/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/Main.scala
+++ b/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/Main.scala
@@ -4,18 +4,11 @@ import akka.actor.ActorSystem
 import akka.stream.ActorMaterializer
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.typesafe.config.Config
-import uk.ac.wellcome.messaging.typesafe.{
-  AlpakkaSqsWorkerConfigBuilder,
-  CloudwatchMonitoringClientBuilder,
-  SNSBuilder,
-  SQSBuilder
-}
+import uk.ac.wellcome.messaging.sns.SNSConfig
+import uk.ac.wellcome.messaging.typesafe.{AlpakkaSqsWorkerConfigBuilder, CloudwatchMonitoringClientBuilder, SNSBuilder, SQSBuilder}
 import uk.ac.wellcome.messaging.worker.monitoring.CloudwatchMonitoringClient
 import uk.ac.wellcome.platform.archive.common.config.builders.HTTPServerBuilder
-import uk.ac.wellcome.platform.archive.notifier.services.{
-  CallbackUrlService,
-  NotifierWorker
-}
+import uk.ac.wellcome.platform.archive.notifier.services.{CallbackUrlService, NotifierWorker}
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 
@@ -40,10 +33,10 @@ object Main extends WellcomeTypesafeApp {
       contextUrl = HTTPServerBuilder.buildContextURL(config)
     )
 
-    new NotifierWorker(
+    new NotifierWorker[SNSConfig](
       alpakkaSQSWorkerConfig = AlpakkaSqsWorkerConfigBuilder.build(config),
       callbackUrlService = callbackUrlService,
-      snsWriter = SNSBuilder.buildSNSWriter(config)
+      messageSender = SNSBuilder.buildSNSMessageSender(config, subject = "Sent from the notifier")
     )
   }
 }

--- a/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/services/NotifierWorker.scala
+++ b/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/services/NotifierWorker.scala
@@ -5,10 +5,21 @@ import com.amazonaws.services.sqs.AmazonSQSAsync
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.MessageSender
-import uk.ac.wellcome.messaging.sqsworker.alpakka.{AlpakkaSQSWorker, AlpakkaSQSWorkerConfig}
-import uk.ac.wellcome.messaging.worker.models.{DeterministicFailure, Result, Successful}
+import uk.ac.wellcome.messaging.sqsworker.alpakka.{
+  AlpakkaSQSWorker,
+  AlpakkaSQSWorkerConfig
+}
+import uk.ac.wellcome.messaging.worker.models.{
+  DeterministicFailure,
+  Result,
+  Successful
+}
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
-import uk.ac.wellcome.platform.archive.common.ingests.models.{CallbackNotification, IngestCallbackStatusUpdate, IngestUpdate}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  CallbackNotification,
+  IngestCallbackStatusUpdate,
+  IngestUpdate
+}
 import uk.ac.wellcome.typesafe.Runnable
 
 import scala.concurrent.{ExecutionContext, Future}

--- a/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/services/NotifierWorker.scala
+++ b/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/services/NotifierWorker.scala
@@ -4,30 +4,19 @@ import akka.actor.ActorSystem
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.sns.SNSWriter
-import uk.ac.wellcome.messaging.sqsworker.alpakka.{
-  AlpakkaSQSWorker,
-  AlpakkaSQSWorkerConfig
-}
-import uk.ac.wellcome.messaging.worker.models.{
-  DeterministicFailure,
-  Result,
-  Successful
-}
+import uk.ac.wellcome.messaging.MessageSender
+import uk.ac.wellcome.messaging.sqsworker.alpakka.{AlpakkaSQSWorker, AlpakkaSQSWorkerConfig}
+import uk.ac.wellcome.messaging.worker.models.{DeterministicFailure, Result, Successful}
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  CallbackNotification,
-  IngestCallbackStatusUpdate,
-  IngestUpdate
-}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{CallbackNotification, IngestCallbackStatusUpdate, IngestUpdate}
 import uk.ac.wellcome.typesafe.Runnable
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class NotifierWorker(
+class NotifierWorker[Destination](
   alpakkaSQSWorkerConfig: AlpakkaSQSWorkerConfig,
   callbackUrlService: CallbackUrlService,
-  snsWriter: SNSWriter
+  messageSender: MessageSender[Destination]
 )(implicit actorSystem: ActorSystem,
   ec: ExecutionContext,
   mc: MonitoringClient,
@@ -52,10 +41,9 @@ class NotifierWorker(
         httpResponse = httpResponse
       )
 
-      _ <- snsWriter.writeMessage[IngestUpdate](
-        ingestUpdate,
-        subject = s"Sent by ${this.getClass.getName}"
-      )
+      _ <- Future.fromTry {
+        messageSender.sendT[IngestUpdate](ingestUpdate)
+      }
     } yield ingestUpdate
 
     future

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
@@ -186,13 +186,13 @@ class NotifierFeatureTest
             CallbackNotification(ingestId, callbackUri, ingest)
           )
 
-          val sentMessages = messageSender.messages
-            .map { _.body }
-            .map { fromJson[IngestUpdate](_).get }
-
-          sentMessages should have size 1
-
           eventually {
+            val sentMessages = messageSender.messages
+              .map { _.body }
+              .map { fromJson[IngestUpdate](_).get }
+
+            sentMessages should have size 1
+
             inside(sentMessages.head) {
               case IngestCallbackStatusUpdate(
                   id,

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
@@ -2,7 +2,12 @@ package uk.ac.wellcome.platform.archive.notifier
 
 import java.net.URI
 
-import com.github.tomakehurst.wiremock.client.WireMock.{equalToJson, postRequestedFor, urlPathEqualTo, _}
+import com.github.tomakehurst.wiremock.client.WireMock.{
+  equalToJson,
+  postRequestedFor,
+  urlPathEqualTo,
+  _
+}
 import org.apache.http.HttpStatus
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.{FunSpec, Inside, Matchers}
@@ -10,9 +15,17 @@ import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
 import uk.ac.wellcome.platform.archive.common.ingest.fixtures.TimeTestFixture
-import uk.ac.wellcome.platform.archive.common.ingests.models.{Callback, CallbackNotification, IngestCallbackStatusUpdate, IngestUpdate}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  Callback,
+  CallbackNotification,
+  IngestCallbackStatusUpdate,
+  IngestUpdate
+}
 import uk.ac.wellcome.platform.archive.display._
-import uk.ac.wellcome.platform.archive.notifier.fixtures.{LocalWireMockFixture, NotifierFixtures}
+import uk.ac.wellcome.platform.archive.notifier.fixtures.{
+  LocalWireMockFixture,
+  NotifierFixtures
+}
 
 class NotifierFeatureTest
     extends FunSpec

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
@@ -144,9 +144,7 @@ class NotifierFeatureTest
                     )).get))
                 )
 
-                val sentMessages = messageSender.messages
-                  .map { _.body }
-                  .map { fromJson[IngestUpdate](_).get }
+                val sentMessages = messageSender.getMessages[IngestUpdate]()
 
                 sentMessages should have size 1
 
@@ -187,9 +185,7 @@ class NotifierFeatureTest
           )
 
           eventually {
-            val sentMessages = messageSender.messages
-              .map { _.body }
-              .map { fromJson[IngestUpdate](_).get }
+            val sentMessages = messageSender.getMessages[IngestUpdate]()
 
             sentMessages should have size 1
 

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/fixtures/NotifierFixtures.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/fixtures/NotifierFixtures.scala
@@ -4,18 +4,12 @@ import java.net.URL
 
 import akka.actor.ActorSystem
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.messaging.fixtures.SNS
-import uk.ac.wellcome.messaging.fixtures.SNS.Topic
+import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
-import uk.ac.wellcome.platform.archive.common.fixtures.{
-  BagIt,
-  MonitoringClientFixture
-}
-import uk.ac.wellcome.platform.archive.notifier.services.{
-  CallbackUrlService,
-  NotifierWorker
-}
+import uk.ac.wellcome.messaging.memory.MemoryMessageSender
+import uk.ac.wellcome.platform.archive.common.fixtures.{BagIt, MonitoringClientFixture, OperationFixtures}
+import uk.ac.wellcome.platform.archive.notifier.services.{CallbackUrlService, NotifierWorker}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -23,7 +17,7 @@ trait NotifierFixtures
     extends BagIt
     with AlpakkaSQSWorkerFixtures
     with MonitoringClientFixture
-    with SNS {
+    with OperationFixtures {
 
   def withCallbackUrlService[R](testWith: TestWith[CallbackUrlService, R])(
     implicit actorSystem: ActorSystem): R = {
@@ -33,34 +27,31 @@ trait NotifierFixtures
     testWith(callbackUrlService)
   }
 
-  private def withApp[R](queue: Queue, topic: Topic)(
-    testWith: TestWith[NotifierWorker, R]): R =
+  private def withApp[R](queue: Queue, messageSender: MessageSender[String])(
+    testWith: TestWith[NotifierWorker[String], R]): R =
     withMonitoringClient { implicit monitoringClient =>
       withActorSystem { implicit actorSystem =>
         withMaterializer(actorSystem) { implicit materializer =>
           withCallbackUrlService { callbackUrlService =>
-            withSNSWriter(topic) { snsWriter =>
-              val workerService = new NotifierWorker(
-                alpakkaSQSWorkerConfig = createAlpakkaSQSWorkerConfig(queue),
-                callbackUrlService = callbackUrlService,
-                snsWriter = snsWriter
-              )
+            val workerService = new NotifierWorker(
+              alpakkaSQSWorkerConfig = createAlpakkaSQSWorkerConfig(queue),
+              callbackUrlService = callbackUrlService,
+              messageSender = messageSender
+            )
 
-              workerService.run()
+            workerService.run()
 
-              testWith(workerService)
-            }
+            testWith(workerService)
           }
         }
       }
     }
 
-  def withNotifier[R](testWith: TestWith[(Queue, Topic), R]): R =
+  def withNotifier[R](testWith: TestWith[(Queue, MemoryMessageSender), R]): R =
     withLocalSqsQueueAndDlqAndTimeout(visibilityTimeout = 15) { queuePair =>
-      withLocalSnsTopic { topic =>
-        withApp(queue = queuePair.queue, topic = topic) { _ =>
-          testWith((queuePair.queue, topic))
-        }
+      val messageSender = createMessageSender
+      withApp(queuePair.queue, messageSender) { _ =>
+        testWith((queuePair.queue, messageSender))
       }
     }
 }

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/fixtures/NotifierFixtures.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/fixtures/NotifierFixtures.scala
@@ -8,8 +8,15 @@ import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
-import uk.ac.wellcome.platform.archive.common.fixtures.{BagIt, MonitoringClientFixture, OperationFixtures}
-import uk.ac.wellcome.platform.archive.notifier.services.{CallbackUrlService, NotifierWorker}
+import uk.ac.wellcome.platform.archive.common.fixtures.{
+  BagIt,
+  MonitoringClientFixture,
+  OperationFixtures
+}
+import uk.ac.wellcome.platform.archive.notifier.services.{
+  CallbackUrlService,
+  NotifierWorker
+}
 
 import scala.concurrent.ExecutionContext.Implicits.global
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object WellcomeDependencies {
   lazy val versions = new {
     val fixtures   = "1.0.0"
     val json       = "1.1.1"
-    val messaging  = "5.0.0"
+    val messaging  = "5.1.0"
     val monitoring = "2.2.0"
     val storage    = "5.0.0"
     val typesafe   = "1.0.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,9 +4,9 @@ object WellcomeDependencies {
   lazy val versions = new {
     val fixtures   = "1.0.0"
     val json       = "1.1.1"
-    val messaging  = "4.4.0"
+    val messaging  = "5.0.0"
     val monitoring = "2.2.0"
-    val storage    = "4.6.0"
+    val storage    = "5.0.0"
     val typesafe   = "1.0.0"
   }
 


### PR DESCRIPTION
Closes https://github.com/wellcometrust/platform/issues/3629

Now we can run lots of stuff in-memory, so it's faster and easier to debug. Major changes:

* Common lib is mostly sans-IO, including the IngestUpdater and OperationPublisher
* IngestTracker has a trait underneath it, so we can use an in-memory implementation in the tests

And we run less containers in CI:

* bags_api: no S3 or DynamoDB
* bag_auditor: no SNS
* bag_register: no S3, SNS or DynamoDB
* bag_replicator: no SNS
* bag_unpacker: no SNS
* bag_verifier: no SNS
* common: no SNS
* ingests_api: no SNS or DynamoDB
* ingests_common: no SNS
* ingests: no SNS or DynamoDB
* notifier: no SNS or DynamoDB

Rough edges are being documented in https://github.com/wellcometrust/platform/issues/3630