### PR TITLE
Check the length of entries referenced in fetch files

### DIFF
--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/VerifyFixtures.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/VerifyFixtures.scala
@@ -34,8 +34,9 @@ trait VerifyFixture extends S3 with RandomThings {
     checksum: Option[Checksum] = None
   ) = {
     VerifiableLocation(
-      location.getOrElse(randomObjectLocation).resolve,
-      checksum.getOrElse(randomChecksum)
+      uri = location.getOrElse(randomObjectLocation).resolve,
+      checksum = checksum.getOrElse(randomChecksum),
+      length = None
     )
   }
 }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/VerifyFixtures.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/VerifyFixtures.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.platform.archive.common.verify._
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.fixtures.S3
 
-trait VerifyFixture extends S3 with RandomThings {
+trait VerifyFixtures extends S3 with RandomThings {
 
   implicit val objectVerifier = new S3ObjectVerifier()
 
@@ -20,23 +20,18 @@ trait VerifyFixture extends S3 with RandomThings {
   def randomChecksum = Checksum(SHA256, randomChecksumValue)
   def badChecksum = Checksum(MD5, randomChecksumValue)
 
-  def randomObjectLocation = createObjectLocation
+  def createVerifiableLocation: VerifiableLocation =
+    createVerifiableLocationWith()
 
-  def verifiableLocationWith(location: ObjectLocation, checksum: Checksum) =
-    verifiableLocation(location = Some(location), checksum = Some(checksum))
-  def verifiableLocationWith(location: ObjectLocation) =
-    verifiableLocation(location = Some(location), checksum = None)
-  def verifiableLocationWith(checksum: Checksum) =
-    verifiableLocation(None, checksum = Some(checksum))
-
-  def verifiableLocation(
-    location: Option[ObjectLocation] = None,
-    checksum: Option[Checksum] = None
-  ) = {
+  def createVerifiableLocationWith(
+    location: ObjectLocation = createObjectLocation,
+    checksum: Checksum = randomChecksum,
+    length: Option[Int] = None
+  ): VerifiableLocation = {
     VerifiableLocation(
-      uri = location.getOrElse(randomObjectLocation).resolve,
-      checksum = checksum.getOrElse(randomChecksum),
-      length = None
+      uri = location.resolve,
+      checksum = checksum,
+      length = length
     )
   }
 }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/VerifyFixtures.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/VerifyFixtures.scala
@@ -26,7 +26,7 @@ trait VerifyFixtures extends S3 with RandomThings {
   def createVerifiableLocationWith(
     location: ObjectLocation = createObjectLocation,
     checksum: Checksum = randomChecksum,
-    length: Option[Int] = None
+    length: Option[Long] = None
   ): VerifiableLocation = {
     VerifiableLocation(
       uri = location.resolve,

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/S3ObjectVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/S3ObjectVerifierTest.scala
@@ -70,7 +70,7 @@ class S3ObjectVerifierTest
     withLocalS3Bucket { bucket =>
       val contentHashingAlgorithm = MD5
       val contentString = "HelloWorld"
-      // sha256("HelloWorld")
+      // md5("HelloWorld")
       val contentStringChecksum = ChecksumValue(
         "68e109f0f40ca72a15e05cc22786f8e6"
       )
@@ -94,11 +94,40 @@ class S3ObjectVerifierTest
     }
   }
 
+  it("succeeds if the checksum is correct and the lengths match") {
+    withLocalS3Bucket { bucket =>
+      val contentHashingAlgorithm = MD5
+      val contentString = "HelloWorld"
+      // md5("HelloWorld")
+      val contentStringChecksum = ChecksumValue(
+        "68e109f0f40ca72a15e05cc22786f8e6"
+      )
+
+      val objectLocation = createObjectLocationWith(bucket)
+      val checksum = Checksum(contentHashingAlgorithm, contentStringChecksum)
+
+      val verifiableLocation = createVerifiableLocationWith(
+        location = objectLocation,
+        checksum = checksum,
+        length = Some(contentString.getBytes().length)
+      )
+
+      createObject(objectLocation, content = contentString)
+
+      val verifiedLocation = objectVerifier.verify(verifiableLocation)
+
+      verifiedLocation shouldBe a[VerifiedSuccess]
+      val verifiedSuccess = verifiedLocation.asInstanceOf[VerifiedSuccess]
+
+      verifiedSuccess.location shouldBe verifiableLocation
+    }
+  }
+
   it("supports different checksum algorithms") {
     withLocalS3Bucket { bucket =>
       val contentHashingAlgorithm = SHA256
       val contentString = "HelloWorld"
-      // md5("HelloWorld")
+      // sha256("HelloWorld")
       val contentStringChecksum = ChecksumValue(
         "872e4e50ce9990d8b041330c47c9ddd11bec6b503ae9386a99da8584e9bb12c4"
       )

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/S3ObjectVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/S3ObjectVerifierTest.scala
@@ -2,7 +2,10 @@ package uk.ac.wellcome.platform.archive.bagverifier.services
 
 import org.scalatest.{EitherValues, FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.bagverifier.fixtures.VerifyFixtures
-import uk.ac.wellcome.platform.archive.common.storage.{LocationError, LocationNotFound}
+import uk.ac.wellcome.platform.archive.common.storage.{
+  LocationError,
+  LocationNotFound
+}
 import uk.ac.wellcome.platform.archive.common.verify._
 
 class S3ObjectVerifierTest
@@ -28,7 +31,8 @@ class S3ObjectVerifierTest
   it("returns a failure if the object doesn't exist") {
     withLocalS3Bucket { bucket =>
       val badLocation = createObjectLocationWith(bucket)
-      val verifiableLocation = createVerifiableLocationWith(location = badLocation)
+      val verifiableLocation =
+        createVerifiableLocationWith(location = badLocation)
 
       val verifiedLocation = objectVerifier.verify(verifiableLocation)
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/S3ObjectVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/S3ObjectVerifierTest.scala
@@ -92,9 +92,9 @@ class S3ObjectVerifierTest
       val verifiedFailure = verifiedLocation.asInstanceOf[VerifiedFailure]
 
       verifiedFailure.location shouldBe verifiableLocation
-      verifiedFailure.e shouldBe a[LocationNotFound[_]]
-      verifiedFailure.e.getMessage should include(
-        "Lengths do not match!"
+      verifiedFailure.e shouldBe a[Throwable]
+      verifiedFailure.e.getMessage should startWith(
+        "Lengths do not match:"
       )
     }
   }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/S3ObjectVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/S3ObjectVerifierTest.scala
@@ -1,7 +1,7 @@
 package uk.ac.wellcome.platform.archive.bagverifier.services
 
 import org.scalatest.{EitherValues, FunSpec, Matchers}
-import uk.ac.wellcome.platform.archive.bagverifier.fixtures.VerifyFixture
+import uk.ac.wellcome.platform.archive.bagverifier.fixtures.VerifyFixtures
 import uk.ac.wellcome.platform.archive.common.storage.{LocationError, LocationNotFound}
 import uk.ac.wellcome.platform.archive.common.verify._
 
@@ -9,10 +9,10 @@ class S3ObjectVerifierTest
     extends FunSpec
     with Matchers
     with EitherValues
-    with VerifyFixture {
+    with VerifyFixtures {
 
   it("returns a failure if the bucket doesn't exist") {
-    val badVerifiableLocation = verifiableLocation()
+    val badVerifiableLocation = createVerifiableLocation
     val verifiedLocation = objectVerifier.verify(badVerifiableLocation)
 
     verifiedLocation shouldBe a[VerifiedFailure]
@@ -28,7 +28,7 @@ class S3ObjectVerifierTest
   it("returns a failure if the object doesn't exist") {
     withLocalS3Bucket { bucket =>
       val badLocation = createObjectLocationWith(bucket)
-      val verifiableLocation = verifiableLocationWith(badLocation)
+      val verifiableLocation = createVerifiableLocationWith(location = badLocation)
 
       val verifiedLocation = objectVerifier.verify(verifiableLocation)
 
@@ -46,8 +46,10 @@ class S3ObjectVerifierTest
   it("returns a failure if the checksum is incorrect") {
     withLocalS3Bucket { bucket =>
       val objectLocation = createObjectLocationWith(bucket)
-      val verifiableLocation =
-        verifiableLocationWith(objectLocation, badChecksum)
+      val verifiableLocation = createVerifiableLocationWith(
+        location = objectLocation,
+        checksum = badChecksum
+      )
 
       createObject(objectLocation, content = "HelloWorld")
 
@@ -76,7 +78,10 @@ class S3ObjectVerifierTest
       val objectLocation = createObjectLocationWith(bucket)
       val checksum = Checksum(contentHashingAlgorithm, contentStringChecksum)
 
-      val verifiableLocation = verifiableLocationWith(objectLocation, checksum)
+      val verifiableLocation = createVerifiableLocationWith(
+        location = objectLocation,
+        checksum = checksum
+      )
 
       createObject(objectLocation, content = contentString)
 
@@ -101,7 +106,10 @@ class S3ObjectVerifierTest
       val objectLocation = createObjectLocationWith(bucket)
       val checksum = Checksum(contentHashingAlgorithm, contentStringChecksum)
 
-      val verifiableLocation = verifiableLocationWith(objectLocation, checksum)
+      val verifiableLocation = createVerifiableLocationWith(
+        location = objectLocation,
+        checksum = checksum
+      )
 
       createObject(objectLocation, content = contentString)
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/S3ObjectVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/S3ObjectVerifierTest.scala
@@ -1,14 +1,9 @@
 package uk.ac.wellcome.platform.archive.bagverifier.services
 
-import com.amazonaws.services.s3.model.PutObjectResult
 import org.scalatest.{EitherValues, FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.bagverifier.fixtures.VerifyFixture
-import uk.ac.wellcome.platform.archive.common.storage.{
-  LocationError,
-  LocationNotFound
-}
+import uk.ac.wellcome.platform.archive.common.storage.{LocationError, LocationNotFound}
 import uk.ac.wellcome.platform.archive.common.verify._
-import uk.ac.wellcome.storage.ObjectLocation
 
 class S3ObjectVerifierTest
     extends FunSpec
@@ -54,10 +49,7 @@ class S3ObjectVerifierTest
       val verifiableLocation =
         verifiableLocationWith(objectLocation, badChecksum)
 
-      put(
-        objectLocation,
-        contents = "HelloWorld"
-      )
+      createObject(objectLocation, content = "HelloWorld")
 
       val verifiedLocation = objectVerifier.verify(verifiableLocation)
 
@@ -86,10 +78,7 @@ class S3ObjectVerifierTest
 
       val verifiableLocation = verifiableLocationWith(objectLocation, checksum)
 
-      put(
-        objectLocation,
-        contents = contentString
-      )
+      createObject(objectLocation, content = contentString)
 
       val verifiedLocation = objectVerifier.verify(verifiableLocation)
 
@@ -114,10 +103,7 @@ class S3ObjectVerifierTest
 
       val verifiableLocation = verifiableLocationWith(objectLocation, checksum)
 
-      put(
-        objectLocation,
-        contents = contentString
-      )
+      createObject(objectLocation, content = contentString)
 
       val verifiedLocation = objectVerifier.verify(verifiableLocation)
 
@@ -127,9 +113,4 @@ class S3ObjectVerifierTest
       verifiedSuccess.location shouldBe verifiableLocation
     }
   }
-
-  def put(objectLocation: ObjectLocation,
-          contents: String = randomAlphanumeric()): PutObjectResult =
-    s3Client
-      .putObject(objectLocation.namespace, objectLocation.key, contents)
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/BagFetch.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/BagFetch.scala
@@ -71,14 +71,14 @@ object BagFetch {
       }
       .mkString("\n")
 
-  private def encodeLength(length: Option[Int]): String =
+  private def encodeLength(length: Option[Long]): String =
     length match {
       case Some(i) => i.toString
       case None    => "-"
     }
 
-  private def decodeLength(ls: String): Option[Int] =
-    if (ls == "-") None else Some(ls.toInt)
+  private def decodeLength(ls: String): Option[Long] =
+    if (ls == "-") None else Some(ls.toLong)
 
   private def encodeFilepath(path: String): String =
     path.replaceAll("\n", "%0A").replaceAll("\r", "%0D")

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/BagLocation.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/BagLocation.scala
@@ -18,8 +18,3 @@ case class BagFetchEntry(
   length: Option[Long],
   path: BagPath
 ) extends BagLocation
-
-object BagFetchEntry {
-  def create(url: URI, length: Option[Long], path: String) =
-    BagFetchEntry(url, length, BagPath(path))
-}

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/BagLocation.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/BagLocation.scala
@@ -15,11 +15,11 @@ case class BagFile(
 
 case class BagFetchEntry(
   uri: URI,
-  length: Option[Int],
+  length: Option[Long],
   path: BagPath
 ) extends BagLocation
 
 object BagFetchEntry {
-  def create(url: URI, length: Option[Int], path: String) =
+  def create(url: URI, length: Option[Long], path: String) =
     BagFetchEntry(url, length, BagPath(path))
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagVerifiable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagVerifiable.scala
@@ -105,7 +105,11 @@ class BagVerifiable(root: ObjectLocation)(
     matched: MatchedLocation): Either[Throwable, VerifiableLocation] =
     matched match {
       case MatchedLocation(bagFile: BagFile, Some(fetchEntry)) =>
-        Right(VerifiableLocation(fetchEntry.uri, bagFile.checksum))
+        Right(VerifiableLocation(
+          uri = fetchEntry.uri,
+          checksum = bagFile.checksum,
+          length = fetchEntry.length
+        ))
 
       case MatchedLocation(bagFile: BagFile, None) =>
         bagFile.locateWith(root) match {
@@ -114,7 +118,8 @@ class BagVerifiable(root: ObjectLocation)(
             Right(
               VerifiableLocation(
                 uri = resolvable.resolve(location),
-                checksum = bagFile.checksum
+                checksum = bagFile.checksum,
+                length = None
               ))
         }
     }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagVerifiable.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagVerifiable.scala
@@ -105,11 +105,12 @@ class BagVerifiable(root: ObjectLocation)(
     matched: MatchedLocation): Either[Throwable, VerifiableLocation] =
     matched match {
       case MatchedLocation(bagFile: BagFile, Some(fetchEntry)) =>
-        Right(VerifiableLocation(
-          uri = fetchEntry.uri,
-          checksum = bagFile.checksum,
-          length = fetchEntry.length
-        ))
+        Right(
+          VerifiableLocation(
+            uri = fetchEntry.uri,
+            checksum = bagFile.checksum,
+            length = fetchEntry.length
+          ))
 
       case MatchedLocation(bagFile: BagFile, None) =>
         bagFile.locateWith(root) match {

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3ObjectVerifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3ObjectVerifier.scala
@@ -1,5 +1,7 @@
 package uk.ac.wellcome.platform.archive.common.storage.services
 
+import java.io.InputStream
+
 import com.amazonaws.services.s3.AmazonS3
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.common.storage.{
@@ -16,8 +18,8 @@ class S3ObjectVerifier(implicit s3Client: AmazonS3)
     with Logging {
 
   import uk.ac.wellcome.platform.archive.common.storage.Locatable._
-  import uk.ac.wellcome.platform.archive.common.storage.services.S3StreamableInstances._
   import uk.ac.wellcome.platform.archive.common.storage.services.S3LocatableInstances._
+  import uk.ac.wellcome.platform.archive.common.storage.services.S3StreamableInstances._
 
   def verify(verifiableLocation: VerifiableLocation): VerifiedLocation = {
     debug(s"S3ObjectVerifier: Attempting to verify: $verifiableLocation")
@@ -55,31 +57,69 @@ class S3ObjectVerifier(implicit s3Client: AmazonS3)
         )
 
       case Right(Some(inputStream)) =>
-        Checksum.create(inputStream, algorithm) match {
-          // Failure to create a checksum (parsing/algorithm)
-          case Failure(e) =>
-            VerifiedFailure(
-              verifiableLocation,
-              FailedChecksumCreation(algorithm, e))
+        verifiableLocation.length match {
+          case Some(expectedLength) =>
+            debug("Location specifies an expected length, checking it's correct")
 
-          // Checksum does not match that provided
-          case Success(checksum) =>
-            if (checksum != verifiableLocation.checksum) {
-              VerifiedFailure(
-                verifiableLocation,
-                FailedChecksumNoMatch(
-                  checksum,
-                  verifiableLocation.checksum
-                )
+            // Note: I'm assuming that `.available()` returns the correct
+            // content-length for an S3 object input stream, even though I
+            // can't find mention of it anywhere in the docs...
+            //
+            // The alternative is getting an S3Object directly with `getObject()`
+            // and inspecting the Content-Length, but that's significantly
+            // more fiddly and bypasses our nice Streamable type classes.
+            //
+            // I'm going to leave this as-is for now, but we might need to
+            // revisit it if we start getting spurious verification failures.
+            //
+            if (expectedLength == inputStream.available()) {
+              verifyChecksum(
+                verifiableLocation = verifiableLocation,
+                inputStream = inputStream,
+                algorithm = algorithm
               )
             } else {
-              // Happy path!
-              VerifiedSuccess(verifiableLocation)
+              VerifiedFailure(
+                verifiableLocation,
+                new Throwable("" +
+                  s"Lengths do not match: $expectedLength != ${inputStream.available()}")
+              )
             }
+
+          case None =>
+            verifyChecksum(
+              verifiableLocation = verifiableLocation,
+              inputStream = inputStream,
+              algorithm = algorithm
+            )
         }
     }
 
     debug(s"Got: $result")
     result
   }
+
+  private def verifyChecksum(verifiableLocation: VerifiableLocation, inputStream: InputStream, algorithm: HashingAlgorithm): VerifiedLocation =
+    Checksum.create(inputStream, algorithm) match {
+      // Failure to create a checksum (parsing/algorithm)
+      case Failure(e) =>
+        VerifiedFailure(
+          verifiableLocation,
+          FailedChecksumCreation(algorithm, e))
+
+      // Checksum does not match that provided
+      case Success(checksum) =>
+        if (checksum != verifiableLocation.checksum) {
+          VerifiedFailure(
+            verifiableLocation,
+            FailedChecksumNoMatch(
+              checksum,
+              verifiableLocation.checksum
+            )
+          )
+        } else {
+          // Happy path!
+          VerifiedSuccess(verifiableLocation)
+        }
+    }
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3ObjectVerifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3ObjectVerifier.scala
@@ -62,18 +62,7 @@ class S3ObjectVerifier(implicit s3Client: AmazonS3)
             debug(
               "Location specifies an expected length, checking it's correct")
 
-            // Note: I'm assuming that `.available()` returns the correct
-            // content-length for an S3 object input stream, even though I
-            // can't find mention of it anywhere in the docs...
-            //
-            // The alternative is getting an S3Object directly with `getObject()`
-            // and inspecting the Content-Length, but that's significantly
-            // more fiddly and bypasses our nice Streamable type classes.
-            //
-            // I'm going to leave this as-is for now, but we might need to
-            // revisit it if we start getting spurious verification failures.
-            //
-            if (expectedLength == inputStream.available()) {
+            if (expectedLength == inputStream.getContentLength()) {
               verifyChecksum(
                 verifiableLocation = verifiableLocation,
                 inputStream = inputStream,

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3ObjectVerifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3ObjectVerifier.scala
@@ -59,7 +59,8 @@ class S3ObjectVerifier(implicit s3Client: AmazonS3)
       case Right(Some(inputStream)) =>
         verifiableLocation.length match {
           case Some(expectedLength) =>
-            debug("Location specifies an expected length, checking it's correct")
+            debug(
+              "Location specifies an expected length, checking it's correct")
 
             // Note: I'm assuming that `.available()` returns the correct
             // content-length for an S3 object input stream, even though I
@@ -99,7 +100,9 @@ class S3ObjectVerifier(implicit s3Client: AmazonS3)
     result
   }
 
-  private def verifyChecksum(verifiableLocation: VerifiableLocation, inputStream: InputStream, algorithm: HashingAlgorithm): VerifiedLocation =
+  private def verifyChecksum(verifiableLocation: VerifiableLocation,
+                             inputStream: InputStream,
+                             algorithm: HashingAlgorithm): VerifiedLocation =
     Checksum.create(inputStream, algorithm) match {
       // Failure to create a checksum (parsing/algorithm)
       case Failure(e) =>

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3ObjectVerifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3ObjectVerifier.scala
@@ -62,7 +62,7 @@ class S3ObjectVerifier(implicit s3Client: AmazonS3)
             debug(
               "Location specifies an expected length, checking it's correct")
 
-            if (expectedLength == inputStream.getContentLength()) {
+            if (expectedLength == inputStream.contentLength) {
               verifyChecksum(
                 verifiableLocation = verifiableLocation,
                 inputStream = inputStream,

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3StreamableInstances.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3StreamableInstances.scala
@@ -87,7 +87,7 @@ object S3StreamableInstances {
   implicit class S3StreamableOps[T](t: T)(implicit s3Client: AmazonS3,
                                           locator: Locatable[T])
       extends Logging {
-    private def locate(root: Option[ObjectLocation]) =
+    private def locate(root: Option[ObjectLocation]): Either[StreamUnavailable, Option[S3ObjectStream]] =
       for {
         located <- locator.locate(t)(root) match {
           case Left(f)         => Left(StreamUnavailable(f.msg))
@@ -107,13 +107,11 @@ object S3StreamableInstances {
       result
     }
 
-    def locateWith(root: ObjectLocation)
-      : Either[StreamUnavailable, Option[S3ObjectInputStream]] = {
+    def locateWith(root: ObjectLocation): Either[StreamUnavailable, Option[S3ObjectStream]] = {
       debug(s"Attempting to locate Locatable $t")
       val result = locate(Some(root))
       debug(s"Got: $result")
       result
     }
   }
-
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3StreamableInstances.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3StreamableInstances.scala
@@ -10,9 +10,8 @@ import uk.ac.wellcome.storage.ObjectLocation
 
 import scala.util.{Failure, Success, Try}
 
-trait S3ObjectStream extends FilterInputStream {
-  def contentLength: Long
-}
+class S3ObjectStream(inputStream: S3ObjectInputStream, val contentLength: Long)
+  extends FilterInputStream(inputStream)
 
 object S3StreamableInstances {
 
@@ -29,15 +28,13 @@ object S3StreamableInstances {
               location.key
             )
         }
-        objectLength <- Try {
+        contentLength <- Try {
           s3Object.getObjectMetadata.getContentLength
         }
         inputStream <- Try {
           s3Object.getObjectContent
         }
-        stream = new S3ObjectStream(inputStream) {
-          def contentLength: Long = objectLength
-        }
+        stream = new S3ObjectStream(inputStream, contentLength = contentLength)
       } yield stream
 
       result match {

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3StreamableInstances.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3StreamableInstances.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.storage.ObjectLocation
 import scala.util.{Failure, Success, Try}
 
 class S3ObjectStream(inputStream: S3ObjectInputStream, val contentLength: Long)
-  extends FilterInputStream(inputStream)
+    extends FilterInputStream(inputStream)
 
 object S3StreamableInstances {
 
@@ -19,7 +19,8 @@ object S3StreamableInstances {
       extends Streamable[ObjectLocation, S3ObjectStream]
       with Logging {
 
-    private def getObjectContent(location: ObjectLocation): Either[StreamUnavailable, Some[S3ObjectStream]] = {
+    private def getObjectContent(location: ObjectLocation)
+      : Either[StreamUnavailable, Some[S3ObjectStream]] = {
       val result = for {
         s3Object <- Try {
           s3Client
@@ -39,7 +40,7 @@ object S3StreamableInstances {
 
       result match {
         case Success(stream) => Right(Some(stream))
-        case Failure(err) => Left(StreamUnavailable(err.getMessage))
+        case Failure(err)    => Left(StreamUnavailable(err.getMessage))
       }
     }
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3StreamableInstances.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3StreamableInstances.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.storage.ObjectLocation
 import scala.util.{Failure, Success, Try}
 
 trait S3ObjectStream extends FilterInputStream {
-  def getContentLength(): Long
+  def contentLength: Long
 }
 
 object S3StreamableInstances {
@@ -36,7 +36,7 @@ object S3StreamableInstances {
           s3Object.getObjectContent
         }
         stream = new S3ObjectStream(inputStream) {
-          def getContentLength(): Long = objectLength
+          def contentLength: Long = objectLength
         }
       } yield stream
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3StreamableInstances.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3StreamableInstances.scala
@@ -87,7 +87,8 @@ object S3StreamableInstances {
   implicit class S3StreamableOps[T](t: T)(implicit s3Client: AmazonS3,
                                           locator: Locatable[T])
       extends Logging {
-    private def locate(root: Option[ObjectLocation]): Either[StreamUnavailable, Option[S3ObjectStream]] =
+    private def locate(root: Option[ObjectLocation])
+      : Either[StreamUnavailable, Option[S3ObjectStream]] =
       for {
         located <- locator.locate(t)(root) match {
           case Left(f)         => Left(StreamUnavailable(f.msg))
@@ -107,7 +108,8 @@ object S3StreamableInstances {
       result
     }
 
-    def locateWith(root: ObjectLocation): Either[StreamUnavailable, Option[S3ObjectStream]] = {
+    def locateWith(root: ObjectLocation)
+      : Either[StreamUnavailable, Option[S3ObjectStream]] = {
       debug(s"Attempting to locate Locatable $t")
       val result = locate(Some(root))
       debug(s"Got: $result")

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/VerifiableLocation.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/VerifiableLocation.scala
@@ -5,5 +5,5 @@ import java.net.URI
 case class VerifiableLocation(
   uri: URI,
   checksum: Checksum,
-  length: Option[Int]
+  length: Option[Long]
 )

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/VerifiableLocation.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/VerifiableLocation.scala
@@ -4,5 +4,6 @@ import java.net.URI
 
 case class VerifiableLocation(
   uri: URI,
-  checksum: Checksum
+  checksum: Checksum,
+  length: Option[Int]
 )

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/models/BagFetchTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/models/BagFetchTest.scala
@@ -11,14 +11,15 @@ class BagFetchTest extends FunSpec with Matchers {
   describe("write") {
     it("writes the lines of a fetch.txt") {
       val entries = Seq(
-        BagFetchEntry.create(
-          url = new URI("http://example.org/"),
-          length = Some(25),
-          path = "example.txt"),
-        BagFetchEntry.create(
-          url = new URI("https://wellcome.ac.uk/"),
-          length = None,
-          path = "logo.png")
+        createBagFetchEntryWith(
+          uri = "http://example.org/",
+          length = 25,
+          path = "example.txt"
+        ),
+        createBagFetchEntryWith(
+          uri = "https://wellcome.ac.uk/",
+          path = "logo.png"
+        )
       )
 
       val expected =
@@ -35,21 +36,21 @@ class BagFetchTest extends FunSpec with Matchers {
         "example\rnumber\r1.txt",
         "example\nnumber\n2.txt",
         "example\r\nnumber\r\n3.txt").map { path =>
-        BagFetchEntry.create(
-          url = new URI("http://example.org/"),
-          length = None,
-          path = path)
+        createBagFetchEntryWith(
+          uri = "http://example.org/",
+          path = path
+        )
       }
 
       Seq(
-        BagFetchEntry.create(
-          url = new URI("http://example.org/"),
-          length = None,
-          path = "example.txt"),
-        BagFetchEntry.create(
-          url = new URI("https://wellcome.ac.uk/"),
-          length = None,
-          path = "logo.png")
+        createBagFetchEntryWith(
+          uri = "http://example.org/",
+          path = "example.txt"
+        ),
+        createBagFetchEntryWith(
+          uri = "https://wellcome.ac.uk/",
+          path = "logo.png"
+        )
       )
 
       val expected =
@@ -71,14 +72,15 @@ class BagFetchTest extends FunSpec with Matchers {
        """.stripMargin)
 
       val expected = Seq(
-        BagFetchEntry.create(
-          url = new URI("http://example.org/"),
-          length = Some(25),
-          path = "example.txt"),
-        BagFetchEntry.create(
-          url = new URI("https://wellcome.ac.uk/"),
-          length = None,
-          path = "logo.png")
+        createBagFetchEntryWith(
+          uri = "http://example.org/",
+          length = 25,
+          path = "example.txt"
+        ),
+        createBagFetchEntryWith(
+          uri = "https://wellcome.ac.uk/",
+          path = "logo.png"
+        )
       )
 
       BagFetch.create(contents).get.files shouldBe expected
@@ -92,14 +94,15 @@ class BagFetchTest extends FunSpec with Matchers {
        """.stripMargin)
 
       val expected = Seq(
-        BagFetchEntry.create(
-          url = new URI("http://example.org/"),
-          length = Some(25),
-          path = "example.txt"),
-        BagFetchEntry.create(
-          url = new URI("https://wellcome.ac.uk/"),
-          length = None,
-          path = "logo.png")
+        createBagFetchEntryWith(
+          uri = "http://example.org/",
+          length = 25,
+          path = "example.txt"
+        ),
+        createBagFetchEntryWith(
+          uri = "https://wellcome.ac.uk/",
+          path = "logo.png"
+        )
       )
 
       BagFetch.create(contents).get.files shouldBe expected
@@ -111,10 +114,11 @@ class BagFetchTest extends FunSpec with Matchers {
        """.stripMargin)
 
       val expected = Seq(
-        BagFetchEntry.create(
-          url = new URI("http://example.org/"),
-          length = Some(Int.MaxValue.toLong * 10),
-          path = "example.txt")
+        createBagFetchEntryWith(
+          uri = "http://example.org/",
+          length = Int.MaxValue.toLong * 10,
+          path = "example.txt"
+        )
       )
 
       BagFetch.create(contents).get.files shouldBe expected
@@ -146,6 +150,20 @@ class BagFetchTest extends FunSpec with Matchers {
       exc.getMessage shouldBe "Line <<NO NO NO>> is incorrectly formatted!"
     }
   }
+
+  def createBagFetchEntryWith(uri: String, path: String) =
+    BagFetchEntry(
+      uri = new URI(uri),
+      length = None,
+      path = BagPath(path)
+    )
+
+  def createBagFetchEntryWith(uri: String, length: Long, path: String) =
+    BagFetchEntry(
+      uri = new URI(uri),
+      length = Some(length),
+      path = BagPath(path)
+    )
 
   private def toInputStream(s: String): InputStream =
     IOUtils.toInputStream(s.trim, "UTF-8")

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/models/BagFetchTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/models/BagFetchTest.scala
@@ -105,6 +105,21 @@ class BagFetchTest extends FunSpec with Matchers {
       BagFetch.create(contents).get.files shouldBe expected
     }
 
+    it("handles a file whose size is >Int.MaxValue") {
+      val contents = toInputStream(s"""
+           |http://example.org/ ${Int.MaxValue}0 example.txt
+       """.stripMargin)
+
+      val expected = Seq(
+        BagFetchEntry.create(
+          url = new URI("http://example.org/"),
+          length = Some(Int.MaxValue.toLong * 10),
+          path = "example.txt")
+      )
+
+      BagFetch.create(contents).get.files shouldBe expected
+    }
+
     it("correctly decodes a percent-encoded CR/LF/CRLF in the file path") {
       val contents = toInputStream(s"""
                                       |http://example.org/abc - example%0D1%0D.txt

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagVerifiableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagVerifiableTest.scala
@@ -294,7 +294,8 @@ class BagVerifiableTest extends FunSpec with Matchers with BagInfoGenerators {
       VerifiableLocation(
         uri = new URI(
           s"example://${root.namespace}/${root.key}/${mf.path.toString}"),
-        checksum = mf.checksum
+        checksum = mf.checksum,
+        length = None
       )
     }
 
@@ -305,7 +306,8 @@ class BagVerifiableTest extends FunSpec with Matchers with BagInfoGenerators {
       case (bagFile, fetchEntry) =>
         VerifiableLocation(
           uri = fetchEntry.uri,
-          checksum = bagFile.checksum
+          checksum = bagFile.checksum,
+          length = fetchEntry.length
         )
     }
 }


### PR DESCRIPTION
The fetch file tells us the length of the object it points to, but right now we don't check it anywhere.

This patch modifies the VerifiableLocation to carry the length specified by the fetch entry (if any), and the S3ObjectVerifier to check the length matches (if present).

You can’t get the length from a plain `S3ObjectInputStream`, so I’m wrapping it in our own class `S3ObjectStream`, which includes the Content-Length from the S3 headers.

Along the way, I discovered that those sizes can be large than Int.MaxValue, so I swapped it out for Long and added a test that we can parse fetch entries that point to files with large sizes.

Closes wellcometrust/platform#3638.