### PR TITLE
Make the verifier be more agnostic about the payload type

### DIFF
--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
@@ -18,7 +18,7 @@ import uk.ac.wellcome.platform.archive.common.storage.models.{
   IngestStepWorker
 }
 import uk.ac.wellcome.platform.archive.common.{
-  BagInformationPayload,
+  EnrichedBagInformationPayload,
   UnpackedBagPayload
 }
 import uk.ac.wellcome.platform.storage.bagauditor.models.{
@@ -85,7 +85,7 @@ class BagAuditorWorker[IngestDestination, OutgoingDestination](
       case IngestStepSucceeded(summary: AuditSuccessSummary) =>
         outgoingPublisher.sendIfSuccessful(
           step,
-          BagInformationPayload(
+          EnrichedBagInformationPayload(
             ingestId = payload.ingestId,
             storageSpace = payload.storageSpace,
             bagRootLocation = summary.audit.root,

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
@@ -28,7 +28,7 @@ class BagAuditorFeatureTest
             storageSpace = storageSpace
           )
 
-          val expectedPayload = createBagInformationPayloadWith(
+          val expectedPayload = createEnrichedBagInformationPayload(
             ingestId = payload.ingestId,
             bagRootLocation = bagRootLocation,
             storageSpace = storageSpace,
@@ -81,7 +81,7 @@ class BagAuditorFeatureTest
             storageSpace = storageSpace
           )
 
-          val expectedPayload = createBagInformationPayloadWith(
+          val expectedPayload = createEnrichedBagInformationPayload(
             ingestId = payload.ingestId,
             bagRootLocation = bagRootLocation,
             storageSpace = storageSpace,

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.storage.bagauditor
 import org.scalatest.FunSpec
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
-import uk.ac.wellcome.platform.archive.common.BagInformationPayload
+import uk.ac.wellcome.platform.archive.common.EnrichedBagInformationPayload
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
 import uk.ac.wellcome.platform.archive.common.ingests.models.{
@@ -48,7 +48,7 @@ class BagAuditorFeatureTest
               eventually {
                 assertQueueEmpty(queue)
 
-                outgoing.getMessages[BagInformationPayload] shouldBe Seq(
+                outgoing.getMessages[EnrichedBagInformationPayload] shouldBe Seq(
                   expectedPayload)
 
                 assertTopicReceivesIngestEvents(
@@ -101,7 +101,7 @@ class BagAuditorFeatureTest
               eventually {
                 assertQueueEmpty(queue)
 
-                outgoing.getMessages[BagInformationPayload] shouldBe Seq(
+                outgoing.getMessages[EnrichedBagInformationPayload] shouldBe Seq(
                   expectedPayload)
 
                 assertTopicReceivesIngestEvents(

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
@@ -48,7 +48,8 @@ class BagAuditorFeatureTest
               eventually {
                 assertQueueEmpty(queue)
 
-                outgoing.getMessages[EnrichedBagInformationPayload] shouldBe Seq(
+                outgoing
+                  .getMessages[EnrichedBagInformationPayload] shouldBe Seq(
                   expectedPayload)
 
                 assertTopicReceivesIngestEvents(
@@ -101,7 +102,8 @@ class BagAuditorFeatureTest
               eventually {
                 assertQueueEmpty(queue)
 
-                outgoing.getMessages[EnrichedBagInformationPayload] shouldBe Seq(
+                outgoing
+                  .getMessages[EnrichedBagInformationPayload] shouldBe Seq(
                   expectedPayload)
 
                 assertTopicReceivesIngestEvents(

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorker.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorker.scala
@@ -34,9 +34,9 @@ class BagRegisterWorker[IngestDestination, OutgoingDestination](
     with IngestStepWorker {
 
   private val worker =
-    AlpakkaSQSWorker[EnrichedBagInformationPayload, RegistrationSummary](workerConfig) {
-      payload =>
-        Future.fromTry(processMessage(payload))
+    AlpakkaSQSWorker[EnrichedBagInformationPayload, RegistrationSummary](
+      workerConfig) { payload =>
+      Future.fromTry(processMessage(payload))
     }
 
   def processMessage(

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorker.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorker.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.messaging.sqsworker.alpakka.{
 import uk.ac.wellcome.messaging.worker.models.Result
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
 import uk.ac.wellcome.platform.archive.bag_register.models.RegistrationSummary
-import uk.ac.wellcome.platform.archive.common.BagInformationPayload
+import uk.ac.wellcome.platform.archive.common.EnrichedBagInformationPayload
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services.OutgoingPublisher
 import uk.ac.wellcome.platform.archive.common.storage.models.IngestStepWorker
@@ -34,13 +34,13 @@ class BagRegisterWorker[IngestDestination, OutgoingDestination](
     with IngestStepWorker {
 
   private val worker =
-    AlpakkaSQSWorker[BagInformationPayload, RegistrationSummary](workerConfig) {
+    AlpakkaSQSWorker[EnrichedBagInformationPayload, RegistrationSummary](workerConfig) {
       payload =>
         Future.fromTry(processMessage(payload))
     }
 
   def processMessage(
-    payload: BagInformationPayload): Try[Result[RegistrationSummary]] =
+    payload: EnrichedBagInformationPayload): Try[Result[RegistrationSummary]] =
     for {
       _ <- ingestUpdater.start(payload.ingestId)
 

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/BagRegisterFeatureTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/BagRegisterFeatureTest.scala
@@ -34,7 +34,7 @@ class BagRegisterFeatureTest
                 externalIdentifier = bagInfo.externalIdentifier
               )
 
-              val payload = createBagInformationPayloadWith(
+              val payload = createEnrichedBagInformationPayload(
                 bagRootLocation = bagRootLocation,
                 storageSpace = storageSpace
               )
@@ -73,7 +73,7 @@ class BagRegisterFeatureTest
   it("sends a failed update and discards the work on error") {
     withBagRegisterWorker {
       case (_, _, _, ingests, _, queuePair) =>
-        val payload = createBagInformationPayloadWith(
+        val payload = createEnrichedBagInformationPayload(
           bagRootLocation = createObjectLocation,
           storageSpace = createStorageSpace
         )

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
@@ -36,7 +36,7 @@ class BagRegisterWorkerTest
         withLocalS3Bucket { bucket =>
           withBag(bucket, bagInfo = bagInfo) {
             case (bagRootLocation, storageSpace) =>
-              val payload = createBagInformationPayloadWith(
+              val payload = createEnrichedBagInformationPayload(
                 bagRootLocation = bagRootLocation,
                 storageSpace = storageSpace
               )
@@ -76,7 +76,7 @@ class BagRegisterWorkerTest
   it("sends a failed IngestUpdate if storing fails") {
     withBagRegisterWorker {
       case (service, _, _, ingests, _, _) =>
-        val payload = createBagInformationPayloadWith(
+        val payload = createEnrichedBagInformationPayload(
           bagRootLocation = createObjectLocation,
           storageSpace = createStorageSpace
         )

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
@@ -17,7 +17,7 @@ import uk.ac.wellcome.messaging.worker.models.{NonDeterministicFailure, Result}
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
 import uk.ac.wellcome.platform.archive.bagreplicator.config.ReplicatorDestinationConfig
 import uk.ac.wellcome.platform.archive.bagreplicator.models.ReplicationSummary
-import uk.ac.wellcome.platform.archive.common.BagInformationPayload
+import uk.ac.wellcome.platform.archive.common.EnrichedBagInformationPayload
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services._
 import uk.ac.wellcome.platform.archive.common.storage.models.IngestStepWorker
@@ -45,7 +45,7 @@ class BagReplicatorWorker[IngestDestination, OutgoingDestination](
     with IngestStepWorker {
   private val worker =
     new AlpakkaSQSWorker[
-      BagInformationPayload,
+      EnrichedBagInformationPayload,
       ReplicationSummary,
       MonitoringClient](alpakkaSQSWorkerConfig)(
       payload => Future.fromTry { processMessage(payload) }
@@ -64,7 +64,7 @@ class BagReplicatorWorker[IngestDestination, OutgoingDestination](
   )
 
   def processMessage(
-    payload: BagInformationPayload,
+    payload: EnrichedBagInformationPayload,
   ): Try[Result[ReplicationSummary]] =
     for {
       _ <- ingestUpdater.start(payload.ingestId)
@@ -78,7 +78,7 @@ class BagReplicatorWorker[IngestDestination, OutgoingDestination](
       result <- replicate(payload, destination)
     } yield result
 
-  def replicate(payload: BagInformationPayload,
+  def replicate(payload: EnrichedBagInformationPayload,
                 destination: ObjectLocation): Try[Result[ReplicationSummary]] =
     lockingService
       .withLock(destination.toString) {

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
@@ -7,7 +7,7 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.bagreplicator.fixtures.BagReplicatorFixtures
-import uk.ac.wellcome.platform.archive.common.BagInformationPayload
+import uk.ac.wellcome.platform.archive.common.EnrichedBagInformationPayload
 import uk.ac.wellcome.platform.archive.common.fixtures.BagLocationFixtures
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
@@ -62,7 +62,7 @@ class BagReplicatorFeatureTest
                     bagRootLocation = expectedDst
                   )
 
-                  outgoing.getMessages[BagInformationPayload] shouldBe Seq(
+                  outgoing.getMessages[EnrichedBagInformationPayload] shouldBe Seq(
                     expectedPayload)
 
                   verifyBagCopied(

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
@@ -39,7 +39,7 @@ class BagReplicatorFeatureTest
             stepName = "replicating") { _ =>
             withBag(ingestsBucket) {
               case (srcBagRootLocation, _) =>
-                val payload = createBagInformationPayloadWith(
+                val payload = createEnrichedBagInformationPayload(
                   bagRootLocation = srcBagRootLocation
                 )
 

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
@@ -62,7 +62,8 @@ class BagReplicatorFeatureTest
                     bagRootLocation = expectedDst
                   )
 
-                  outgoing.getMessages[EnrichedBagInformationPayload] shouldBe Seq(
+                  outgoing
+                    .getMessages[EnrichedBagInformationPayload] shouldBe Seq(
                     expectedPayload)
 
                   verifyBagCopied(

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
@@ -48,7 +48,7 @@ class BagReplicatorWorkerTest
           stepName = "replicating") { service =>
           withBag(ingestsBucket) {
             case (srcBagRootLocation, storageSpace) =>
-              val payload = createBagInformationPayloadWith(
+              val payload = createEnrichedBagInformationPayload(
                 bagRootLocation = srcBagRootLocation,
                 storageSpace = storageSpace
               )
@@ -91,7 +91,7 @@ class BagReplicatorWorkerTest
           withBagReplicatorWorker(bucket = archiveBucket) { worker =>
             withBag(ingestsBucket) {
               case (bagRootLocation, _) =>
-                val payload = createBagInformationPayloadWith(
+                val payload = createEnrichedBagInformationPayload(
                   bagRootLocation = bagRootLocation
                 )
 
@@ -116,7 +116,7 @@ class BagReplicatorWorkerTest
             val bagInfo = createBagInfo
             withBag(ingestsBucket, bagInfo = bagInfo) {
               case (bagRootLocation, _) =>
-                val payload = createBagInformationPayloadWith(
+                val payload = createEnrichedBagInformationPayload(
                   bagRootLocation = bagRootLocation
                 )
 
@@ -146,7 +146,7 @@ class BagReplicatorWorkerTest
           withBagReplicatorWorker(bucket = archiveBucket) { worker =>
             withBag(ingestsBucket) {
               case (bagRootLocation, _) =>
-                val payload = createBagInformationPayloadWith(
+                val payload = createEnrichedBagInformationPayload(
                   bagRootLocation = bagRootLocation,
                   version = 3
                 )
@@ -169,7 +169,7 @@ class BagReplicatorWorkerTest
           withBagReplicatorWorker(bucket = archiveBucket) { worker =>
             withBag(ingestsBucket) {
               case (bagRootLocation, _) =>
-                val payload = createBagInformationPayloadWith(
+                val payload = createEnrichedBagInformationPayload(
                   bagRootLocation = bagRootLocation
                 )
 
@@ -193,7 +193,7 @@ class BagReplicatorWorkerTest
             rootPath = Some("rootprefix")) { worker =>
             withBag(ingestsBucket) {
               case (bagRootLocation, _) =>
-                val payload = createBagInformationPayloadWith(
+                val payload = createEnrichedBagInformationPayload(
                   bagRootLocation = bagRootLocation
                 )
 
@@ -217,7 +217,7 @@ class BagReplicatorWorkerTest
         service =>
           withBag(bucket) {
             case (bagRootLocation, _) =>
-              val payload = createBagInformationPayloadWith(
+              val payload = createEnrichedBagInformationPayload(
                 bagRootLocation = bagRootLocation
               )
 
@@ -245,7 +245,7 @@ class BagReplicatorWorkerTest
           withBagReplicatorWorker(
             bucket = bucket,
             lockServiceDao = lockServiceDao) { worker =>
-            val payload = createBagInformationPayloadWith(
+            val payload = createEnrichedBagInformationPayload(
               bagRootLocation = bagRootLocation
             )
 
@@ -293,7 +293,7 @@ class BagReplicatorWorkerTest
               ingests = ingests,
               outgoing = outgoing,
               lockServiceDao = neverAllowLockDao) { _ =>
-              val payload = createBagInformationPayloadWith(
+              val payload = createEnrichedBagInformationPayload(
                 bagRootLocation = bagRootLocation
               )
 

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
@@ -14,7 +14,7 @@ import uk.ac.wellcome.messaging.worker.models.{
 }
 import uk.ac.wellcome.platform.archive.bagreplicator.fixtures.BagReplicatorFixtures
 import uk.ac.wellcome.platform.archive.bagreplicator.models.ReplicationSummary
-import uk.ac.wellcome.platform.archive.common.BagInformationPayload
+import uk.ac.wellcome.platform.archive.common.EnrichedBagInformationPayload
 import uk.ac.wellcome.platform.archive.common.fixtures.BagLocationFixtures
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
@@ -57,7 +57,7 @@ class BagReplicatorWorkerTest
               serviceResult.success.value shouldBe a[Successful[_]]
 
               val receivedMessages =
-                outgoing.getMessages[BagInformationPayload]
+                outgoing.getMessages[EnrichedBagInformationPayload]
               receivedMessages.size shouldBe 1
 
               val result = receivedMessages.head

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorker.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.messaging.sqsworker.alpakka.{
 import uk.ac.wellcome.messaging.worker.models.Result
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
 import uk.ac.wellcome.platform.archive.bagverifier.models.VerificationSummary
-import uk.ac.wellcome.platform.archive.common.BagInformationPayload
+import uk.ac.wellcome.platform.archive.common.EnrichedBagInformationPayload
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services.OutgoingPublisher
 import uk.ac.wellcome.platform.archive.common.storage.models.IngestStepWorker
@@ -35,7 +35,7 @@ class BagVerifierWorker[IngestDestination, OutgoingDestination](
     with IngestStepWorker {
 
   private val worker =
-    AlpakkaSQSWorker[BagInformationPayload, VerificationSummary](
+    AlpakkaSQSWorker[EnrichedBagInformationPayload, VerificationSummary](
       alpakkaSQSWorkerConfig) { payload =>
       Future.fromTry { processMessage(payload) }
     }
@@ -43,7 +43,7 @@ class BagVerifierWorker[IngestDestination, OutgoingDestination](
   val algorithm: String = MessageDigestAlgorithms.SHA_256
 
   def processMessage(
-    payload: BagInformationPayload): Try[Result[VerificationSummary]] =
+    payload: EnrichedBagInformationPayload): Try[Result[VerificationSummary]] =
     for {
       _ <- ingestUpdater.start(payload.ingestId)
       summary <- verifier.verify(payload.bagRootLocation)

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorker.scala
@@ -12,7 +12,7 @@ import uk.ac.wellcome.messaging.sqsworker.alpakka.{
 import uk.ac.wellcome.messaging.worker.models.Result
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
 import uk.ac.wellcome.platform.archive.bagverifier.models.VerificationSummary
-import uk.ac.wellcome.platform.archive.common.EnrichedBagInformationPayload
+import uk.ac.wellcome.platform.archive.common.BagRootPayload
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services.OutgoingPublisher
 import uk.ac.wellcome.platform.archive.common.storage.models.IngestStepWorker
@@ -35,15 +35,14 @@ class BagVerifierWorker[IngestDestination, OutgoingDestination](
     with IngestStepWorker {
 
   private val worker =
-    AlpakkaSQSWorker[EnrichedBagInformationPayload, VerificationSummary](
+    AlpakkaSQSWorker[BagRootPayload, VerificationSummary](
       alpakkaSQSWorkerConfig) { payload =>
       Future.fromTry { processMessage(payload) }
     }
 
   val algorithm: String = MessageDigestAlgorithms.SHA_256
 
-  def processMessage(
-    payload: EnrichedBagInformationPayload): Try[Result[VerificationSummary]] =
+  def processMessage(payload: BagRootPayload): Try[Result[VerificationSummary]] =
     for {
       _ <- ingestUpdater.start(payload.ingestId)
       summary <- verifier.verify(payload.bagRootLocation)

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorker.scala
@@ -42,7 +42,8 @@ class BagVerifierWorker[IngestDestination, OutgoingDestination](
 
   val algorithm: String = MessageDigestAlgorithms.SHA_256
 
-  def processMessage(payload: BagRootPayload): Try[Result[VerificationSummary]] =
+  def processMessage(
+    payload: BagRootPayload): Try[Result[VerificationSummary]] =
     for {
       _ <- ingestUpdater.start(payload.ingestId)
       summary <- verifier.verify(payload.bagRootLocation)

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
@@ -56,7 +56,8 @@ class BagVerifierFeatureTest
                     )
                   )
 
-                  outgoing.getMessages[EnrichedBagInformationPayload] shouldBe Seq(
+                  outgoing
+                    .getMessages[EnrichedBagInformationPayload] shouldBe Seq(
                     payload)
 
                   assertQueueEmpty(queue)

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
@@ -40,7 +40,7 @@ class BagVerifierFeatureTest
           withLocalS3Bucket { bucket =>
             withBag(bucket) {
               case (bagRootLocation, _) =>
-                val payload = createBagInformationPayloadWith(
+                val payload = createEnrichedBagInformationPayload(
                   bagRootLocation = bagRootLocation
                 )
 
@@ -82,7 +82,7 @@ class BagVerifierFeatureTest
           withLocalS3Bucket { bucket =>
             withBag(bucket, createDataManifest = dataManifestWithWrongChecksum) {
               case (bagRootLocation, _) =>
-                val payload = createBagInformationPayloadWith(
+                val payload = createEnrichedBagInformationPayload(
                   bagRootLocation = bagRootLocation
                 )
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
@@ -6,7 +6,10 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.bagverifier.fixtures.BagVerifierFixtures
-import uk.ac.wellcome.platform.archive.common.{BagRootPayload, EnrichedBagInformationPayload}
+import uk.ac.wellcome.platform.archive.common.{
+  BagRootPayload,
+  EnrichedBagInformationPayload
+}
 import uk.ac.wellcome.platform.archive.common.fixtures.BagLocationFixtures
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
@@ -6,7 +6,7 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.bagverifier.fixtures.BagVerifierFixtures
-import uk.ac.wellcome.platform.archive.common.EnrichedBagInformationPayload
+import uk.ac.wellcome.platform.archive.common.{BagRootPayload, EnrichedBagInformationPayload}
 import uk.ac.wellcome.platform.archive.common.fixtures.BagLocationFixtures
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
@@ -44,7 +44,7 @@ class BagVerifierFeatureTest
                   bagRootLocation = bagRootLocation
                 )
 
-                sendNotificationToSQS(queue, payload)
+                sendNotificationToSQS[BagRootPayload](queue, payload)
 
                 eventually {
                   assertTopicReceivesIngestEvents(
@@ -87,7 +87,7 @@ class BagVerifierFeatureTest
                   bagRootLocation = bagRootLocation
                 )
 
-                sendNotificationToSQS(queue, payload)
+                sendNotificationToSQS[BagRootPayload](queue, payload)
 
                 eventually {
                   assertTopicReceivesIngestUpdates(payload.ingestId, ingests) {

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
@@ -6,7 +6,7 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.bagverifier.fixtures.BagVerifierFixtures
-import uk.ac.wellcome.platform.archive.common.BagInformationPayload
+import uk.ac.wellcome.platform.archive.common.EnrichedBagInformationPayload
 import uk.ac.wellcome.platform.archive.common.fixtures.BagLocationFixtures
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
@@ -56,7 +56,7 @@ class BagVerifierFeatureTest
                     )
                   )
 
-                  outgoing.getMessages[BagInformationPayload] shouldBe Seq(
+                  outgoing.getMessages[EnrichedBagInformationPayload] shouldBe Seq(
                     payload)
 
                   assertQueueEmpty(queue)

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
@@ -36,7 +36,7 @@ class BagVerifierWorkerTest
         withLocalS3Bucket { bucket =>
           withBag(bucket) {
             case (bagRootLocation, _) =>
-              val payload = createBagInformationPayloadWith(
+              val payload = createEnrichedBagInformationPayload(
                 bagRootLocation = bagRootLocation
               )
 
@@ -66,7 +66,7 @@ class BagVerifierWorkerTest
         withLocalS3Bucket { bucket =>
           withBag(bucket, createDataManifest = dataManifestWithWrongChecksum) {
             case (bagRootLocation, _) =>
-              val payload = createBagInformationPayloadWith(
+              val payload = createEnrichedBagInformationPayload(
                 bagRootLocation = bagRootLocation
               )
 
@@ -101,7 +101,7 @@ class BagVerifierWorkerTest
         withLocalS3Bucket { bucket =>
           withBag(bucket, createDataManifest = dontCreateTheDataManifest) {
             case (bagRootLocation, _) =>
-              val payload = createBagInformationPayloadWith(
+              val payload = createEnrichedBagInformationPayload(
                 bagRootLocation = bagRootLocation
               )
 
@@ -137,7 +137,7 @@ class BagVerifierWorkerTest
         withLocalS3Bucket { bucket =>
           withBag(bucket) {
             case (bagRootLocation, _) =>
-              val payload = createBagInformationPayloadWith(
+              val payload = createEnrichedBagInformationPayload(
                 bagRootLocation = bagRootLocation
               )
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
@@ -54,7 +54,8 @@ class BagVerifierWorkerTest
                 )
               )
 
-              outgoing.getMessages[EnrichedBagInformationPayload] shouldBe Seq(payload)
+              outgoing.getMessages[EnrichedBagInformationPayload] shouldBe Seq(
+                payload)
           }
         }
     }
@@ -67,14 +68,16 @@ class BagVerifierWorkerTest
 
       withBagVerifierWorker(ingests, outgoing) { service =>
         withLocalS3Bucket { bucket =>
-          withBag(bucket) { case (bagRootLocation, _) =>
-            val payload = createEnrichedBagInformationPayload(
-              bagRootLocation = bagRootLocation
-            )
+          withBag(bucket) {
+            case (bagRootLocation, _) =>
+              val payload = createEnrichedBagInformationPayload(
+                bagRootLocation = bagRootLocation
+              )
 
-            service.processMessage(payload) shouldBe a[Success[_]]
+              service.processMessage(payload) shouldBe a[Success[_]]
 
-            outgoing.getMessages[EnrichedBagInformationPayload] shouldBe Seq(payload)
+              outgoing.getMessages[EnrichedBagInformationPayload] shouldBe Seq(
+                payload)
           }
         }
       }
@@ -86,12 +89,13 @@ class BagVerifierWorkerTest
 
       withBagVerifierWorker(ingests, outgoing) { service =>
         withLocalS3Bucket { bucket =>
-          withBag(bucket) { case (bagRootLocation, _) =>
-            val payload = createBagInformationPayloadWith(bagRootLocation)
+          withBag(bucket) {
+            case (bagRootLocation, _) =>
+              val payload = createBagInformationPayloadWith(bagRootLocation)
 
-            service.processMessage(payload) shouldBe a[Success[_]]
+              service.processMessage(payload) shouldBe a[Success[_]]
 
-            outgoing.getMessages[BagInformationPayload] shouldBe Seq(payload)
+              outgoing.getMessages[BagInformationPayload] shouldBe Seq(payload)
           }
         }
       }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
@@ -6,7 +6,7 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.bagverifier.fixtures.BagVerifierFixtures
-import uk.ac.wellcome.platform.archive.common.BagInformationPayload
+import uk.ac.wellcome.platform.archive.common.EnrichedBagInformationPayload
 import uk.ac.wellcome.platform.archive.common.fixtures.{
   BagLocationFixtures,
   FileEntry
@@ -51,7 +51,7 @@ class BagVerifierWorkerTest
                 )
               )
 
-              outgoing.getMessages[BagInformationPayload] shouldBe Seq(payload)
+              outgoing.getMessages[EnrichedBagInformationPayload] shouldBe Seq(payload)
           }
         }
     }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
@@ -50,6 +50,12 @@ trait BagRootPayload extends PipelinePayload {
   val bagRootLocation: ObjectLocation
 }
 
+case class BagInformationPayload(
+  ingestId: IngestID,
+  storageSpace: StorageSpace,
+  bagRootLocation: ObjectLocation
+) extends PipelinePayload
+
 case class EnrichedBagInformationPayload(
   ingestId: IngestID,
   storageSpace: StorageSpace,

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
@@ -50,7 +50,7 @@ trait BagRootPayload extends PipelinePayload {
   val bagRootLocation: ObjectLocation
 }
 
-case class BagInformationPayload(
+case class EnrichedBagInformationPayload(
   ingestId: IngestID,
   storageSpace: StorageSpace,
   bagRootLocation: ObjectLocation,

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
@@ -46,10 +46,14 @@ case object UnpackedBagPayload {
     )
 }
 
+trait BagRootPayload extends PipelinePayload {
+  val bagRootLocation: ObjectLocation
+}
+
 case class BagInformationPayload(
   ingestId: IngestID,
   storageSpace: StorageSpace,
   bagRootLocation: ObjectLocation,
   externalIdentifier: ExternalIdentifier,
   version: Int
-)
+) extends BagRootPayload

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
@@ -46,7 +46,7 @@ case object UnpackedBagPayload {
     )
 }
 
-trait BagRootPayload extends PipelinePayload {
+sealed trait BagRootPayload extends PipelinePayload {
   val bagRootLocation: ObjectLocation
 }
 
@@ -54,7 +54,7 @@ case class BagInformationPayload(
   ingestId: IngestID,
   storageSpace: StorageSpace,
   bagRootLocation: ObjectLocation
-) extends PipelinePayload
+) extends BagRootPayload
 
 case class EnrichedBagInformationPayload(
   ingestId: IngestID,

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -43,8 +43,8 @@ trait PayloadGenerators
     bagRootLocation: ObjectLocation = createObjectLocation,
     storageSpace: StorageSpace = createStorageSpace,
     externalIdentifier: ExternalIdentifier = createExternalIdentifier,
-    version: Int = 1): BagInformationPayload =
-    BagInformationPayload(
+    version: Int = 1): EnrichedBagInformationPayload =
+    EnrichedBagInformationPayload(
       ingestId = ingestId,
       storageSpace = storageSpace,
       bagRootLocation = bagRootLocation,
@@ -52,6 +52,6 @@ trait PayloadGenerators
       version = version
     )
 
-  def createBagInformationPayload: BagInformationPayload =
+  def createBagInformationPayload: EnrichedBagInformationPayload =
     createBagInformationPayloadWith()
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -38,7 +38,7 @@ trait PayloadGenerators
       unpackedBagLocation = unpackedBagLocation
     )
 
-  def createBagInformationPayloadWith(
+  def createEnrichedBagInformationPayload(
     ingestId: IngestID = createIngestID,
     bagRootLocation: ObjectLocation = createObjectLocation,
     storageSpace: StorageSpace = createStorageSpace,
@@ -52,6 +52,6 @@ trait PayloadGenerators
       version = version
     )
 
-  def createBagInformationPayload: EnrichedBagInformationPayload =
-    createBagInformationPayloadWith()
+  def createEnrichedBagInformationPayload: EnrichedBagInformationPayload =
+    createEnrichedBagInformationPayload()
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -54,4 +54,11 @@ trait PayloadGenerators
 
   def createEnrichedBagInformationPayload: EnrichedBagInformationPayload =
     createEnrichedBagInformationPayload()
+
+  def createBagInformationPayloadWith(bagRootLocation: ObjectLocation): BagInformationPayload =
+    BagInformationPayload(
+      ingestId = createIngestID,
+      storageSpace = createStorageSpace,
+      bagRootLocation = bagRootLocation
+    )
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -55,7 +55,8 @@ trait PayloadGenerators
   def createEnrichedBagInformationPayload: EnrichedBagInformationPayload =
     createEnrichedBagInformationPayload()
 
-  def createBagInformationPayloadWith(bagRootLocation: ObjectLocation): BagInformationPayload =
+  def createBagInformationPayloadWith(
+    bagRootLocation: ObjectLocation): BagInformationPayload =
     BagInformationPayload(
       ingestId = createIngestID,
       storageSpace = createStorageSpace,


### PR DESCRIPTION
Closes wellcometrust/platform#3658.

The verifier only cares that it gets a payload with an ingest ID and a root location; it doesn't care about whether it has a version, external identifier, ingest date, etc… So the new `BagRootPayload` trait has everything the verifier cares about, and nothing more.

This opens the door to verifying before we assign a version.