### PR TITLE
Expunge use of Future from the unpacker core

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelineMessage.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelineMessage.scala
@@ -1,11 +1,20 @@
 package uk.ac.wellcome.platform.archive.common
 
 import io.circe.{Decoder, Encoder, HCursor, Json}
+import io.circe.syntax._
 
 case class PipelineMessage[T](
   json: Json,
   payload: T
-)
+) {
+  def addField[V](key: String, value: V)(implicit encoder: Encoder[V]): PipelineMessage[T] =
+    PipelineMessage(
+      json = json.deepMerge(
+        Json.obj((key, value.asJson))
+      ),
+      payload = payload
+    )
+}
 
 object PipelineMessage {
   implicit def decoder[T](implicit circeDecoder: Decoder[T]): Decoder[PipelineMessage[T]] =

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelineMessage.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelineMessage.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.archive.common
 
-import io.circe.{Decoder, Encoder, HCursor, Json}
+import io.circe._
 import io.circe.syntax._
 
 case class PipelineMessage[T](
@@ -16,13 +16,10 @@ case class PipelineMessage[T](
     )
 }
 
-object PipelineMessage {
-  implicit def decoder[T](implicit circeDecoder: Decoder[T]): Decoder[PipelineMessage[T]] =
-    (cursor: HCursor) => for {
-      json <- cursor.as[Json]
+case object PipelineMessage {
+  def fromJson[T](json: Json)(implicit decoder: Decoder[T]): Either[DecodingFailure, PipelineMessage[T]] =
+    for {
       payload <- json.as[T]
     } yield PipelineMessage(json, payload)
-
-  implicit def encoder[T]: Encoder[PipelineMessage[T]] =
-    (message: PipelineMessage[T]) => message.json
 }
+

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelineMessage.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelineMessage.scala
@@ -1,0 +1,19 @@
+package uk.ac.wellcome.platform.archive.common
+
+import io.circe.{Decoder, Encoder, HCursor, Json}
+
+case class PipelineMessage[T](
+  json: Json,
+  payload: T
+)
+
+object PipelineMessage {
+  implicit def decoder[T](implicit circeDecoder: Decoder[T]): Decoder[PipelineMessage[T]] =
+    (cursor: HCursor) => for {
+      json <- cursor.as[Json]
+      payload <- json.as[T]
+    } yield PipelineMessage(json, payload)
+
+  implicit def encoder[T]: Encoder[PipelineMessage[T]] =
+    (message: PipelineMessage[T]) => message.json
+}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/PipelineMessageTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/PipelineMessageTest.scala
@@ -1,0 +1,51 @@
+package uk.ac.wellcome.platform.archive.common
+
+import org.scalatest.{FunSpec, Matchers, TryValues}
+import PipelineMessage._
+import io.circe.Json
+import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.json.utils.JsonAssertions
+
+class PipelineMessageTest extends FunSpec with Matchers with TryValues with JsonAssertions {
+  case class Person(name: String)
+
+  it("can decode a PipelineMessage for a case class") {
+    val jsonString =
+      s"""
+         |{
+         |  "name": "henry",
+         |  "age": 82
+         |}
+       """.stripMargin
+
+    val result = fromJson[PipelineMessage[Person]](jsonString)
+
+    val message = result.success.value
+    message.payload shouldBe Person(name = "henry")
+    message.json shouldBe Json.obj(
+      ("name", Json.fromString("henry")),
+      ("age", Json.fromInt(82))
+    )
+  }
+
+  it("encodes a PipelineMessage as the underlying JSON") {
+    val message = PipelineMessage(
+      json = Json.obj(
+        ("name", Json.fromString("silas")),
+        ("age", Json.fromInt(48))
+      ),
+      payload = Person(name = "silas")
+    )
+
+    val jsonString = toJson(message).success.value
+    assertJsonStringsAreEqual(
+      jsonString,
+      """
+        |{
+        |  "name": "silas",
+        |  "age": 48
+        |}
+      """.stripMargin
+    )
+  }
+}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/PipelineMessageTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/PipelineMessageTest.scala
@@ -1,12 +1,12 @@
 package uk.ac.wellcome.platform.archive.common
 
-import org.scalatest.{FunSpec, Matchers, TryValues}
-import PipelineMessage._
 import io.circe.Json
+import io.circe.parser.parse
+import org.scalatest.{EitherValues, FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.json.utils.JsonAssertions
 
-class PipelineMessageTest extends FunSpec with Matchers with TryValues with JsonAssertions {
+class PipelineMessageTest extends FunSpec with Matchers with EitherValues with JsonAssertions {
   case class Person(name: String)
 
   it("can decode a PipelineMessage for a case class") {
@@ -18,34 +18,13 @@ class PipelineMessageTest extends FunSpec with Matchers with TryValues with Json
          |}
        """.stripMargin
 
-    val result = fromJson[PipelineMessage[Person]](jsonString)
+    val result = PipelineMessage.fromJson[Person](parse(jsonString).right.value)
 
-    val message = result.success.value
+    val message = result.right.value
     message.payload shouldBe Person(name = "henry")
     message.json shouldBe Json.obj(
       ("name", Json.fromString("henry")),
       ("age", Json.fromInt(82))
-    )
-  }
-
-  it("encodes a PipelineMessage as the underlying JSON") {
-    val message = PipelineMessage(
-      json = Json.obj(
-        ("name", Json.fromString("silas")),
-        ("age", Json.fromInt(48))
-      ),
-      payload = Person(name = "silas")
-    )
-
-    val jsonString = toJson(message).success.value
-    assertJsonStringsAreEqual(
-      jsonString,
-      """
-        |{
-        |  "name": "silas",
-        |  "age": 48
-        |}
-      """.stripMargin
     )
   }
 
@@ -60,7 +39,7 @@ class PipelineMessageTest extends FunSpec with Matchers with TryValues with Json
 
     val updatedMessage = message.addField("birthplace", "new york")
 
-    val jsonString = toJson(updatedMessage).success.value
+    val jsonString = updatedMessage.json.noSpaces
     assertJsonStringsAreEqual(
       jsonString,
       """

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/PipelineMessageTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/PipelineMessageTest.scala
@@ -48,4 +48,28 @@ class PipelineMessageTest extends FunSpec with Matchers with TryValues with Json
       """.stripMargin
     )
   }
+
+  it("puts added fields in the new JSON") {
+    val message = PipelineMessage(
+      json = Json.obj(
+        ("name", Json.fromString("silas")),
+        ("age", Json.fromInt(48))
+      ),
+      payload = Person(name = "silas")
+    )
+
+    val updatedMessage = message.addField("birthplace", "new york")
+
+    val jsonString = toJson(updatedMessage).success.value
+    assertJsonStringsAreEqual(
+      jsonString,
+      """
+        |{
+        |  "name": "silas",
+        |  "age": 48,
+        |  "birthplace": "new york"
+        |}
+      """.stripMargin
+    )
+  }
 }


### PR DESCRIPTION
There's a whole pile of `Future.fromTry { ... }` having to wrap a single Future that doesn't need to be a Future, so ditch it all.