### PR TITLE
Expunge the use of Future from the unpacker

### DIFF
--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
@@ -15,7 +15,10 @@ import uk.ac.wellcome.platform.archive.bagunpacker.models.UnpackSummary
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services._
 import uk.ac.wellcome.platform.archive.common.storage.models.IngestStepWorker
-import uk.ac.wellcome.platform.archive.common.{IngestRequestPayload, UnpackedBagPayload}
+import uk.ac.wellcome.platform.archive.common.{
+  IngestRequestPayload,
+  UnpackedBagPayload
+}
 import uk.ac.wellcome.typesafe.Runnable
 
 import scala.concurrent.Future
@@ -34,8 +37,8 @@ case class BagUnpackerWorker[IngestDestination, OutgoingDestination](
     with IngestStepWorker {
   private val worker =
     AlpakkaSQSWorker[IngestRequestPayload, UnpackSummary](
-      alpakkaSQSWorkerConfig) {
-      msg => Future.fromTry { processMessage(msg) }
+      alpakkaSQSWorkerConfig) { msg =>
+      Future.fromTry { processMessage(msg) }
     }
 
   def processMessage(

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
@@ -7,10 +7,17 @@ import java.time.Instant
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.AmazonS3Exception
 import org.apache.commons.compress.archivers.ArchiveEntry
-import uk.ac.wellcome.platform.archive.bagunpacker.exceptions.{ArchiveLocationException, UnpackerArchiveEntryUploadException}
+import uk.ac.wellcome.platform.archive.bagunpacker.exceptions.{
+  ArchiveLocationException,
+  UnpackerArchiveEntryUploadException
+}
 import uk.ac.wellcome.platform.archive.bagunpacker.models.UnpackSummary
 import uk.ac.wellcome.platform.archive.bagunpacker.storage.Archive
-import uk.ac.wellcome.platform.archive.common.storage.models.{IngestFailed, IngestStepResult, IngestStepSucceeded}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  IngestFailed,
+  IngestStepResult,
+  IngestStepSucceeded
+}
 import uk.ac.wellcome.platform.archive.common.storage.services.S3StreamableInstances._
 import uk.ac.wellcome.storage.ObjectLocation
 

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/storage/Archive.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/storage/Archive.scala
@@ -3,16 +3,11 @@ package uk.ac.wellcome.platform.archive.bagunpacker.storage
 import java.io.{BufferedInputStream, InputStream}
 
 import grizzled.slf4j.Logging
-import org.apache.commons.compress.archivers.{
-  ArchiveEntry,
-  ArchiveInputStream,
-  ArchiveStreamFactory
-}
+import org.apache.commons.compress.archivers.{ArchiveEntry, ArchiveInputStream, ArchiveStreamFactory}
 import org.apache.commons.compress.compressors.CompressorStreamFactory
 import org.apache.commons.io.input.CloseShieldInputStream
 
 import scala.annotation.tailrec
-import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
 object Archive extends Logging {
@@ -20,8 +15,7 @@ object Archive extends Logging {
     inputStream: InputStream
   )(init: T)(
     f: (T, InputStream, ArchiveEntry) => T
-  )(implicit ec: ExecutionContext): Future[T] = Future {
-
+  ): Try[T] = Try {
     val archiveReader = new ArchiveReader[T](inputStream)
 
     @tailrec

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/storage/Archive.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/storage/Archive.scala
@@ -3,7 +3,11 @@ package uk.ac.wellcome.platform.archive.bagunpacker.storage
 import java.io.{BufferedInputStream, InputStream}
 
 import grizzled.slf4j.Logging
-import org.apache.commons.compress.archivers.{ArchiveEntry, ArchiveInputStream, ArchiveStreamFactory}
+import org.apache.commons.compress.archivers.{
+  ArchiveEntry,
+  ArchiveInputStream,
+  ArchiveStreamFactory
+}
 import org.apache.commons.compress.compressors.CompressorStreamFactory
 import org.apache.commons.io.input.CloseShieldInputStream
 

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/BagUnpackerFixtures.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/fixtures/BagUnpackerFixtures.scala
@@ -18,8 +18,6 @@ import uk.ac.wellcome.platform.archive.common.fixtures.{
 }
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
 
-import scala.concurrent.ExecutionContext.Implicits.global
-
 trait BagUnpackerFixtures
     extends SQS
     with BagLocationFixtures

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTest.scala
@@ -4,31 +4,22 @@ import java.io.{File, FileInputStream}
 import java.nio.file.Paths
 
 import org.apache.commons.io.IOUtils
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.platform.archive.bagunpacker.exceptions.{
-  ArchiveLocationException,
-  UnpackerArchiveEntryUploadException
-}
+import org.scalatest.{FunSpec, Matchers, TryValues}
+import uk.ac.wellcome.platform.archive.bagunpacker.exceptions.{ArchiveLocationException, UnpackerArchiveEntryUploadException}
 import uk.ac.wellcome.platform.archive.bagunpacker.fixtures.CompressFixture
 import uk.ac.wellcome.platform.archive.bagunpacker.models.UnpackSummary
 import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
-import uk.ac.wellcome.platform.archive.common.storage.models.{
-  IngestFailed,
-  IngestStepSucceeded
-}
+import uk.ac.wellcome.platform.archive.common.storage.models.{IngestFailed, IngestStepSucceeded}
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.fixtures.S3
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
 
-import scala.concurrent.ExecutionContext.Implicits.global
-
 class UnpackerTest
     extends FunSpec
     with Matchers
-    with ScalaFutures
     with CompressFixture
     with RandomThings
+    with TryValues
     with S3 {
 
   val unpacker = Unpacker(
@@ -51,15 +42,14 @@ class UnpackerTest
               dstLocation
             )
 
-          whenReady(summaryResult) { unpacked =>
-            unpacked shouldBe a[IngestStepSucceeded[_]]
+          val unpacked = summaryResult.success.value
+          unpacked shouldBe a[IngestStepSucceeded[_]]
 
-            val summary = unpacked.summary
-            summary.fileCount shouldBe filesInArchive.size
-            summary.bytesUnpacked shouldBe totalBytes(filesInArchive)
+          val summary = unpacked.summary
+          summary.fileCount shouldBe filesInArchive.size
+          summary.bytesUnpacked shouldBe totalBytes(filesInArchive)
 
-            assertBucketContentsMatchFiles(dstBucket, dstKey, filesInArchive)
-          }
+          assertBucketContentsMatchFiles(dstBucket, dstKey, filesInArchive)
         }
       }
     }
@@ -82,15 +72,14 @@ class UnpackerTest
               ObjectLocation(dstBucket.name, dstKey)
             )
 
-          whenReady(summaryResult) { unpacked =>
-            unpacked shouldBe a[IngestStepSucceeded[_]]
+          val unpacked = summaryResult.success.value
+          unpacked shouldBe a[IngestStepSucceeded[_]]
 
-            val summary = unpacked.summary
-            summary.fileCount shouldBe filesInArchive.size
-            summary.bytesUnpacked shouldBe totalBytes(filesInArchive)
+          val summary = unpacked.summary
+          summary.fileCount shouldBe filesInArchive.size
+          summary.bytesUnpacked shouldBe totalBytes(filesInArchive)
 
-            assertBucketContentsMatchFiles(dstBucket, dstKey, filesInArchive)
-          }
+          assertBucketContentsMatchFiles(dstBucket, dstKey, filesInArchive)
         }
       }
     }
@@ -98,24 +87,24 @@ class UnpackerTest
 
   it("returns an IngestFailed if it cannot open the input stream") {
     val srcLocation = createObjectLocation
-    val future =
+    val result =
       unpacker.unpack(
         randomUUID.toString,
         srcLocation = srcLocation,
         dstLocation = createObjectLocation
       )
 
-    whenReady(future) { result =>
-      result shouldBe a[IngestFailed[_]]
-      result.summary.fileCount shouldBe 0
-      result.summary.bytesUnpacked shouldBe 0
-      val actualResult = result.asInstanceOf[IngestFailed[UnpackSummary]]
-      actualResult.e shouldBe a[ArchiveLocationException]
-      actualResult.e.getMessage should
-        startWith(
-          s"Error getting input stream for s3://$srcLocation: " +
-            "The specified bucket is not valid")
-    }
+    val ingestResult = result.success.value
+    ingestResult shouldBe a[IngestFailed[_]]
+    ingestResult.summary.fileCount shouldBe 0
+    ingestResult.summary.bytesUnpacked shouldBe 0
+
+    val underlyingError = ingestResult.asInstanceOf[IngestFailed[UnpackSummary]]
+    underlyingError.e shouldBe a[ArchiveLocationException]
+    underlyingError.e.getMessage should
+      startWith(
+        s"Error getting input stream for s3://$srcLocation: " +
+          "The specified bucket is not valid")
   }
 
   it("returns an IngestFailed if it cannot write to the destination") {
@@ -123,21 +112,21 @@ class UnpackerTest
       val (archiveFile, _, _) = createTgzArchiveWithRandomFiles()
       withArchive(srcBucket, archiveFile) { testArchive =>
         val dstLocation = createObjectLocation
-        val future =
+        val result =
           unpacker.unpack(
             randomUUID.toString,
             srcLocation = testArchive,
             dstLocation = dstLocation
           )
 
-        whenReady(future) { result =>
-          result shouldBe a[IngestFailed[_]]
-          result.summary.fileCount shouldBe 0
-          result.summary.bytesUnpacked shouldBe 0
-          val actualResult = result.asInstanceOf[IngestFailed[UnpackSummary]]
-          actualResult.e shouldBe a[UnpackerArchiveEntryUploadException]
-          actualResult.e.getMessage should startWith("upload failed")
-        }
+        val ingestResult = result.success.value
+        ingestResult shouldBe a[IngestFailed[_]]
+        ingestResult.summary.fileCount shouldBe 0
+        ingestResult.summary.bytesUnpacked shouldBe 0
+
+        val underlyingError = ingestResult.asInstanceOf[IngestFailed[UnpackSummary]]
+        underlyingError.e shouldBe a[UnpackerArchiveEntryUploadException]
+        underlyingError.e.getMessage should startWith("upload failed")
       }
     }
   }

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTest.scala
@@ -5,11 +5,17 @@ import java.nio.file.Paths
 
 import org.apache.commons.io.IOUtils
 import org.scalatest.{FunSpec, Matchers, TryValues}
-import uk.ac.wellcome.platform.archive.bagunpacker.exceptions.{ArchiveLocationException, UnpackerArchiveEntryUploadException}
+import uk.ac.wellcome.platform.archive.bagunpacker.exceptions.{
+  ArchiveLocationException,
+  UnpackerArchiveEntryUploadException
+}
 import uk.ac.wellcome.platform.archive.bagunpacker.fixtures.CompressFixture
 import uk.ac.wellcome.platform.archive.bagunpacker.models.UnpackSummary
 import uk.ac.wellcome.platform.archive.common.fixtures.RandomThings
-import uk.ac.wellcome.platform.archive.common.storage.models.{IngestFailed, IngestStepSucceeded}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  IngestFailed,
+  IngestStepSucceeded
+}
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.fixtures.S3
 import uk.ac.wellcome.storage.fixtures.S3.Bucket
@@ -124,7 +130,8 @@ class UnpackerTest
         ingestResult.summary.fileCount shouldBe 0
         ingestResult.summary.bytesUnpacked shouldBe 0
 
-        val underlyingError = ingestResult.asInstanceOf[IngestFailed[UnpackSummary]]
+        val underlyingError =
+          ingestResult.asInstanceOf[IngestFailed[UnpackSummary]]
         underlyingError.e shouldBe a[UnpackerArchiveEntryUploadException]
         underlyingError.e.getMessage should startWith("upload failed")
       }


### PR DESCRIPTION
There's a whole pile of `Future.fromTry { ... }` having to wrap a single Future that doesn't need to be a Future, so ditch it all.