### PR TITLE
Pass around Json objects for payloads

### DIFF
--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/models/BagUnpackerPayload.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/models/BagUnpackerPayload.scala
@@ -1,0 +1,11 @@
+package uk.ac.wellcome.platform.archive.bagunpacker.models
+
+import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
+import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
+import uk.ac.wellcome.storage.ObjectLocation
+
+case class BagUnpackerPayload(
+  ingestId: IngestID,
+  sourceLocation: ObjectLocation,
+  storageSpace: StorageSpace
+)

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
@@ -61,18 +61,9 @@ case class BagUnpackerWorker[IngestDestination, OutgoingDestination](
         dstLocation = unpackedBagLocation
       )
 
-<<<<<<< HEAD
       _ <- ingestUpdater.send(payload.ingestId, stepResult)
 
       outgoingPayload = addField(json)("unpackedBagLocation", unpackedBagLocation)
-=======
-      _ <- Future.fromTry {
-        ingestUpdater.send(payload.ingestId, stepResult)
-      }
-      outgoingPayload = addField(json)(
-        "unpackedBagLocation",
-        unpackedBagLocation)
->>>>>>> Apply auto-formatting rules
 
       _ <- outgoingPublisher.sendIfSuccessful(stepResult, outgoingPayload)
     } yield toResult(stepResult)

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
@@ -9,23 +9,16 @@ import uk.ac.wellcome.messaging.worker.models.Result
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
 import uk.ac.wellcome.platform.archive.bagunpacker.builders.BagLocationBuilder
 import uk.ac.wellcome.platform.archive.bagunpacker.config.models.BagUnpackerWorkerConfig
-import uk.ac.wellcome.platform.archive.bagunpacker.models.UnpackSummary
+import uk.ac.wellcome.platform.archive.bagunpacker.models.{BagUnpackerPayload, UnpackSummary}
 import uk.ac.wellcome.platform.archive.common.JsonPayloadWorker
-import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services._
-import uk.ac.wellcome.platform.archive.common.storage.models.{IngestStepWorker, StorageSpace}
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.platform.archive.common.storage.models.IngestStepWorker
 import uk.ac.wellcome.typesafe.Runnable
 
 import scala.concurrent.Future
 import scala.util.Try
 
-case class BagUnpackerPayload(
-  ingestId: IngestID,
-  sourceLocation: ObjectLocation,
-  storageSpace: StorageSpace
-)
 
 case class BagUnpackerWorker[IngestDestination, OutgoingDestination](
   alpakkaSQSWorkerConfig: AlpakkaSQSWorkerConfig,

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
@@ -4,12 +4,18 @@ import akka.actor.ActorSystem
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import io.circe.Json
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.sqsworker.alpakka.{AlpakkaSQSWorker, AlpakkaSQSWorkerConfig}
+import uk.ac.wellcome.messaging.sqsworker.alpakka.{
+  AlpakkaSQSWorker,
+  AlpakkaSQSWorkerConfig
+}
 import uk.ac.wellcome.messaging.worker.models.Result
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
 import uk.ac.wellcome.platform.archive.bagunpacker.builders.BagLocationBuilder
 import uk.ac.wellcome.platform.archive.bagunpacker.config.models.BagUnpackerWorkerConfig
-import uk.ac.wellcome.platform.archive.bagunpacker.models.{BagUnpackerPayload, UnpackSummary}
+import uk.ac.wellcome.platform.archive.bagunpacker.models.{
+  BagUnpackerPayload,
+  UnpackSummary
+}
 import uk.ac.wellcome.platform.archive.common.JsonPayloadWorker
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services._
@@ -18,7 +24,6 @@ import uk.ac.wellcome.typesafe.Runnable
 
 import scala.concurrent.Future
 import scala.util.Try
-
 
 case class BagUnpackerWorker[IngestDestination, OutgoingDestination](
   alpakkaSQSWorkerConfig: AlpakkaSQSWorkerConfig,
@@ -35,7 +40,7 @@ case class BagUnpackerWorker[IngestDestination, OutgoingDestination](
   private val worker =
     AlpakkaSQSWorker[Json, UnpackSummary](
       alpakkaSQSWorkerConfig) {
-      msg => Future.fromTry { processMessage(msg) }
+      json => Future.fromTry { processMessage(json) }
     }
 
   def processMessage(json: Json): Try[Result[UnpackSummary]] =
@@ -56,9 +61,18 @@ case class BagUnpackerWorker[IngestDestination, OutgoingDestination](
         dstLocation = unpackedBagLocation
       )
 
+<<<<<<< HEAD
       _ <- ingestUpdater.send(payload.ingestId, stepResult)
 
       outgoingPayload = addField(json)("unpackedBagLocation", unpackedBagLocation)
+=======
+      _ <- Future.fromTry {
+        ingestUpdater.send(payload.ingestId, stepResult)
+      }
+      outgoingPayload = addField(json)(
+        "unpackedBagLocation",
+        unpackedBagLocation)
+>>>>>>> Apply auto-formatting rules
 
       _ <- outgoingPublisher.sendIfSuccessful(stepResult, outgoingPayload)
     } yield toResult(stepResult)

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.archive.bagunpacker.services
 import akka.actor.ActorSystem
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import io.circe.Json
-import io.circe.syntax._
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.sqsworker.alpakka.{AlpakkaSQSWorker, AlpakkaSQSWorkerConfig}
 import uk.ac.wellcome.messaging.worker.models.Result
@@ -66,8 +65,7 @@ case class BagUnpackerWorker[IngestDestination, OutgoingDestination](
 
       _ <- ingestUpdater.send(payload.ingestId, stepResult)
 
-      outgoingPayload =
-        json.deepMerge(Json.obj(("unpackedBagLocation", unpackedBagLocation.asJson)))
+      outgoingPayload = addField(json)("unpackedBagLocation", unpackedBagLocation)
 
       _ <- outgoingPublisher.sendIfSuccessful(stepResult, outgoingPayload)
     } yield toResult(stepResult)

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
@@ -38,9 +38,8 @@ case class BagUnpackerWorker[IngestDestination, OutgoingDestination](
     with IngestStepWorker
     with JsonPayloadWorker {
   private val worker =
-    AlpakkaSQSWorker[Json, UnpackSummary](
-      alpakkaSQSWorkerConfig) {
-      json => Future.fromTry { processMessage(json) }
+    AlpakkaSQSWorker[Json, UnpackSummary](alpakkaSQSWorkerConfig) { json =>
+      Future.fromTry { processMessage(json) }
     }
 
   def processMessage(json: Json): Try[Result[UnpackSummary]] =
@@ -63,7 +62,9 @@ case class BagUnpackerWorker[IngestDestination, OutgoingDestination](
 
       _ <- ingestUpdater.send(payload.ingestId, stepResult)
 
-      outgoingPayload = addField(json)("unpackedBagLocation", unpackedBagLocation)
+      outgoingPayload = addField(json)(
+        "unpackedBagLocation",
+        unpackedBagLocation)
 
       _ <- outgoingPublisher.sendIfSuccessful(stepResult, outgoingPayload)
     } yield toResult(stepResult)

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
@@ -5,17 +5,11 @@ import java.nio.file.Paths
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.platform.archive.bagunpacker.fixtures.{
-  BagUnpackerFixtures,
-  CompressFixture
-}
-import uk.ac.wellcome.platform.archive.common.UnpackedBagPayload
+import uk.ac.wellcome.platform.archive.bagunpacker.fixtures.{BagUnpackerFixtures, CompressFixture}
+import uk.ac.wellcome.platform.archive.bagunpacker.models.UnpackerOutput
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  Ingest,
-  IngestStatusUpdate
-}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestStatusUpdate}
 
 class UnpackerFeatureTest
     extends FunSpec
@@ -37,7 +31,7 @@ class UnpackerFeatureTest
           sendNotificationToSQS(queue, ingestRequestPayload)
 
           eventually {
-            val expectedPayload = UnpackedBagPayload(
+            val expectedPayload = UnpackerOutput(
               ingestRequestPayload = ingestRequestPayload,
               unpackedBagLocation = createObjectLocationWith(
                 bucket = srcBucket,
@@ -50,7 +44,7 @@ class UnpackerFeatureTest
               )
             )
 
-            outgoing.getMessages[UnpackedBagPayload] shouldBe Seq(
+            outgoing.getMessages[UnpackerOutput] shouldBe Seq(
               expectedPayload)
 
             assertTopicReceivesIngestEvents(

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
@@ -5,11 +5,17 @@ import java.nio.file.Paths
 import org.scalatest.concurrent.{Eventually, IntegrationPatience}
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.platform.archive.bagunpacker.fixtures.{BagUnpackerFixtures, CompressFixture}
+import uk.ac.wellcome.platform.archive.bagunpacker.fixtures.{
+  BagUnpackerFixtures,
+  CompressFixture
+}
 import uk.ac.wellcome.platform.archive.bagunpacker.models.UnpackerOutput
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestStatusUpdate}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  Ingest,
+  IngestStatusUpdate
+}
 
 class UnpackerFeatureTest
     extends FunSpec
@@ -44,8 +50,7 @@ class UnpackerFeatureTest
               )
             )
 
-            outgoing.getMessages[UnpackerOutput] shouldBe Seq(
-              expectedPayload)
+            outgoing.getMessages[UnpackerOutput] shouldBe Seq(expectedPayload)
 
             assertTopicReceivesIngestEvents(
               ingestRequestPayload.ingestId,

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/models/UnpackerOutput.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/models/UnpackerOutput.scala
@@ -1,0 +1,26 @@
+package uk.ac.wellcome.platform.archive.bagunpacker.models
+
+import java.time.Instant
+
+import uk.ac.wellcome.platform.archive.common.IngestRequestPayload
+import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
+import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
+import uk.ac.wellcome.storage.ObjectLocation
+
+case class UnpackerOutput(
+  ingestId: IngestID,
+  ingestDate: Instant,
+  storageSpace: StorageSpace,
+  unpackedBagLocation: ObjectLocation
+)
+
+case object UnpackerOutput {
+  def apply(ingestRequestPayload: IngestRequestPayload,
+            unpackedBagLocation: ObjectLocation): UnpackerOutput =
+    UnpackerOutput(
+      ingestId = ingestRequestPayload.ingestId,
+      ingestDate = ingestRequestPayload.ingestDate,
+      storageSpace = ingestRequestPayload.storageSpace,
+      unpackedBagLocation = unpackedBagLocation
+    )
+}

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/JsonPayloadWorker.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/JsonPayloadWorker.scala
@@ -6,12 +6,14 @@ import io.circe.syntax._
 import scala.util.{Failure, Success, Try}
 
 trait JsonPayloadWorker {
-  def asPayload[Payload](json: Json)(implicit decoder: Decoder[Payload]): Try[Payload] =
+  def asPayload[Payload](json: Json)(
+    implicit decoder: Decoder[Payload]): Try[Payload] =
     json.as[Payload] match {
       case Right(payload) => Success(payload)
       case Left(err)      => Failure(err)
     }
 
-  def addField[V](json: Json)(key: String, value: V)(implicit encoder: Encoder[V]): Json =
+  def addField[V](json: Json)(key: String, value: V)(
+    implicit encoder: Encoder[V]): Json =
     json.deepMerge(Json.obj((key, value.asJson)))
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/JsonPayloadWorker.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/JsonPayloadWorker.scala
@@ -1,0 +1,13 @@
+package uk.ac.wellcome.platform.archive.common
+
+import io.circe.{Decoder, Json}
+
+import scala.util.{Failure, Success, Try}
+
+trait JsonPayloadWorker {
+  def asPayload[Payload](json: Json)(implicit decoder: Decoder[Payload]): Try[Payload] =
+    json.as[Payload] match {
+      case Right(payload) => Success(payload)
+      case Left(err)      => Failure(err)
+    }
+}

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/JsonPayloadWorker.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/JsonPayloadWorker.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.platform.archive.common
 
-import io.circe.{Decoder, Json}
+import io.circe.{Decoder, Encoder, Json}
+import io.circe.syntax._
 
 import scala.util.{Failure, Success, Try}
 
@@ -10,4 +11,7 @@ trait JsonPayloadWorker {
       case Right(payload) => Success(payload)
       case Left(err)      => Failure(err)
     }
+
+  def addField[V](json: Json)(key: String, value: V)(implicit encoder: Encoder[V]): Json =
+    json.deepMerge(Json.obj((key, value.asJson)))
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/operation/services/OutgoingPublisher.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/operation/services/OutgoingPublisher.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.archive.common.operation.services
 
-import io.circe.Json
+import io.circe.Encoder
 import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.platform.archive.common.storage.models._
 
@@ -9,8 +9,8 @@ import scala.util.{Success, Try}
 class OutgoingPublisher[Destination](
   messageSender: MessageSender[Destination]
 ) {
-  def sendIfSuccessful[R](result: IngestStepResult[R],
-                          outgoing: Json): Try[Unit] = {
+  def sendIfSuccessful[R, O](result: IngestStepResult[R],
+                             outgoing: => O)(implicit encoder: Encoder[O]): Try[Unit] = {
     result match {
       case IngestStepSucceeded(_) | IngestCompleted(_) =>
         messageSender.sendT(outgoing)

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/operation/services/OutgoingPublisher.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/operation/services/OutgoingPublisher.scala
@@ -9,8 +9,8 @@ import scala.util.{Success, Try}
 class OutgoingPublisher[Destination](
   messageSender: MessageSender[Destination]
 ) {
-  def sendIfSuccessful[R, O](result: IngestStepResult[R],
-                             outgoing: => O)(implicit encoder: Encoder[O]): Try[Unit] = {
+  def sendIfSuccessful[R, O](result: IngestStepResult[R], outgoing: => O)(
+    implicit encoder: Encoder[O]): Try[Unit] = {
     result match {
       case IngestStepSucceeded(_) | IngestCompleted(_) =>
         messageSender.sendT(outgoing)

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/operation/services/OutgoingPublisher.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/operation/services/OutgoingPublisher.scala
@@ -9,7 +9,8 @@ import scala.util.{Success, Try}
 class OutgoingPublisher[Destination](
   messageSender: MessageSender[Destination]
 ) {
-  def sendIfSuccessful[R](result: IngestStepResult[R], outgoing: Json): Try[Unit] = {
+  def sendIfSuccessful[R](result: IngestStepResult[R],
+                          outgoing: Json): Try[Unit] = {
     result match {
       case IngestStepSucceeded(_) | IngestCompleted(_) =>
         messageSender.sendT(outgoing)

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/operation/services/OutgoingPublisher.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/operation/services/OutgoingPublisher.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.archive.common.operation.services
 
-import io.circe.Encoder
+import io.circe.Json
 import uk.ac.wellcome.messaging.MessageSender
 import uk.ac.wellcome.platform.archive.common.storage.models._
 
@@ -9,8 +9,7 @@ import scala.util.{Success, Try}
 class OutgoingPublisher[Destination](
   messageSender: MessageSender[Destination]
 ) {
-  def sendIfSuccessful[R, O](result: IngestStepResult[R], outgoing: => O)(
-    implicit enc: Encoder[O]): Try[Unit] = {
+  def sendIfSuccessful[R](result: IngestStepResult[R], outgoing: Json): Try[Unit] = {
     result match {
       case IngestStepSucceeded(_) | IngestCompleted(_) =>
         messageSender.sendT(outgoing)

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/operation/services/OutgoingPublisherTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/operation/services/OutgoingPublisherTest.scala
@@ -1,15 +1,12 @@
 package uk.ac.wellcome.platform.archive.common.operation.services
 
+import io.circe.Json
+import io.circe.syntax._
 import org.scalatest.FunSpec
 import org.scalatest.prop.TableDrivenPropertyChecks._
-import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
-import uk.ac.wellcome.platform.archive.common.IngestRequestPayload
 import uk.ac.wellcome.platform.archive.common.fixtures.OperationFixtures
-import uk.ac.wellcome.platform.archive.common.generators.{
-  IngestOperationGenerators,
-  PayloadGenerators
-}
+import uk.ac.wellcome.platform.archive.common.generators.{IngestOperationGenerators, PayloadGenerators}
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
 
 import scala.util.Success
@@ -27,23 +24,31 @@ class OutgoingPublisherTest
     forAll(successfulOperations) { operation =>
       val messageSender = new MemoryMessageSender()
       val outgoingPublisher = createOutgoingPublisherWith(messageSender)
-      val outgoing = createIngestRequestPayload
 
-      val notice = outgoingPublisher.sendIfSuccessful(operation, outgoing)
+      val json = Json.obj(
+        ("color", "red".asJson),
+        ("number", 5.asJson)
+      )
+
+      val notice = outgoingPublisher.sendIfSuccessful(operation, json)
 
       notice shouldBe a[Success[_]]
 
-      messageSender.getMessages[IngestRequestPayload] shouldBe Seq(outgoing)
+      messageSender.getMessages[Json] shouldBe Seq(json)
     }
   }
 
   it("does not send outgoing if operation failed") {
     val messageSender = new MemoryMessageSender()
     val outgoingPublisher = createOutgoingPublisherWith(messageSender)
-    val outgoing = createIngestRequestPayload
+
+    val json = Json.obj(
+      ("color", "red".asJson),
+      ("number", 5.asJson)
+    )
 
     val notice =
-      outgoingPublisher.sendIfSuccessful(createOperationFailure(), outgoing)
+      outgoingPublisher.sendIfSuccessful(createOperationFailure(), json)
 
     notice shouldBe a[Success[_]]
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/operation/services/OutgoingPublisherTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/operation/services/OutgoingPublisherTest.scala
@@ -6,7 +6,10 @@ import org.scalatest.FunSpec
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.common.fixtures.OperationFixtures
-import uk.ac.wellcome.platform.archive.common.generators.{IngestOperationGenerators, PayloadGenerators}
+import uk.ac.wellcome.platform.archive.common.generators.{
+  IngestOperationGenerators,
+  PayloadGenerators
+}
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
 
 import scala.util.Success


### PR DESCRIPTION
We want two things from the internal messaging:

* Type safety inside the apps
* Apps have to pass along information they don’t actually care about (e.g. the unpacker doesn't need to know the ingest date, but downstream apps do)

I did a bunch of poking, and I’m musing about this approach.

* Pass around Json objects at the edges (so extra information is handled transparently)
* Convert to a concrete case class as the first step (so we get type safety)
* Edit the Json with the data we want to add at each step

Thoughts, @kenoir?