### PR TITLE
Add a context to PipelinePayload

### DIFF
--- a/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestStarter.scala
+++ b/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestStarter.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.storage.ingests.api
 
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.MessageSender
-import uk.ac.wellcome.platform.archive.common.IngestRequestPayload
+import uk.ac.wellcome.platform.archive.common.SourceLocationPayload
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
 import uk.ac.wellcome.platform.archive.common.ingests.monitor.IngestTracker
 
@@ -15,6 +15,6 @@ class IngestStarter[UnpackerDestination](
   def initialise(ingest: Ingest): Try[Ingest] =
     for {
       ingest <- ingestTracker.initialise(ingest)
-      _ <- unpackerMessageSender.sendT(IngestRequestPayload(ingest))
+      _ <- unpackerMessageSender.sendT(SourceLocationPayload(ingest))
     } yield ingest
 }

--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestStarterTest.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestStarterTest.scala
@@ -4,7 +4,7 @@ import io.circe.Encoder
 import org.scalatest.{FunSpec, Matchers, TryValues}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
-import uk.ac.wellcome.platform.archive.common.IngestRequestPayload
+import uk.ac.wellcome.platform.archive.common.SourceLocationPayload
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
 import uk.ac.wellcome.platform.storage.ingests.api.fixtures.IngestStarterFixture
@@ -31,8 +31,8 @@ class IngestStarterTest
 
         assertTableOnlyHasItem(ingest, table)
 
-        val expectedPayload = IngestRequestPayload(ingest)
-        messageSender.getMessages[IngestRequestPayload] shouldBe Seq(
+        val expectedPayload = SourceLocationPayload(ingest)
+        messageSender.getMessages[SourceLocationPayload] shouldBe Seq(
           expectedPayload)
       }
     }

--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
@@ -15,7 +15,7 @@ import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.platform.archive.common.http.HttpMetricResults
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestTrackerFixture
 import uk.ac.wellcome.platform.archive.common.ingests.models._
-import uk.ac.wellcome.platform.archive.common.IngestRequestPayload
+import uk.ac.wellcome.platform.archive.common.SourceLocationPayload
 import uk.ac.wellcome.platform.archive.display._
 import uk.ac.wellcome.platform.storage.ingests.api.fixtures.IngestsApiFixture
 import uk.ac.wellcome.storage.ObjectLocation
@@ -293,9 +293,9 @@ class IngestsApiFeatureTest
 
                     assertTableOnlyHasItem[Ingest](expectedIngest, table)
 
-                    val expectedPayload = IngestRequestPayload(expectedIngest)
+                    val expectedPayload = SourceLocationPayload(expectedIngest)
                     messageSender
-                      .getMessages[IngestRequestPayload] shouldBe Seq(
+                      .getMessages[SourceLocationPayload] shouldBe Seq(
                       expectedPayload)
                 }
               }

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
@@ -19,7 +19,7 @@ import uk.ac.wellcome.platform.archive.common.storage.models.{
 }
 import uk.ac.wellcome.platform.archive.common.{
   EnrichedBagInformationPayload,
-  UnpackedBagPayload
+  UnpackedBagLocationPayload
 }
 import uk.ac.wellcome.platform.storage.bagauditor.models.{
   AuditSuccessSummary,
@@ -43,12 +43,12 @@ class BagAuditorWorker[IngestDestination, OutgoingDestination](
     with Logging
     with IngestStepWorker {
   private val worker =
-    AlpakkaSQSWorker[UnpackedBagPayload, AuditSummary](alpakkaSQSWorkerConfig) {
-      payload: UnpackedBagPayload =>
+    AlpakkaSQSWorker[UnpackedBagLocationPayload, AuditSummary](alpakkaSQSWorkerConfig) {
+      payload: UnpackedBagLocationPayload =>
         Future.fromTry { processMessage(payload) }
     }
 
-  def processMessage(payload: UnpackedBagPayload): Try[Result[AuditSummary]] =
+  def processMessage(payload: UnpackedBagLocationPayload): Try[Result[AuditSummary]] =
     for {
       _ <- ingestUpdater.start(ingestId = payload.ingestId)
 
@@ -64,7 +64,7 @@ class BagAuditorWorker[IngestDestination, OutgoingDestination](
       _ <- sendSuccessful(payload)(auditStep)
     } yield toResult(auditStep)
 
-  private def sendIngestInformation(payload: UnpackedBagPayload)(
+  private def sendIngestInformation(payload: UnpackedBagLocationPayload)(
     step: IngestStepResult[AuditSummary]): Try[Unit] =
     step match {
       case IngestStepSucceeded(summary: AuditSuccessSummary) =>
@@ -79,7 +79,7 @@ class BagAuditorWorker[IngestDestination, OutgoingDestination](
       case _ => Success(())
     }
 
-  private def sendSuccessful(payload: UnpackedBagPayload)(
+  private def sendSuccessful(payload: UnpackedBagLocationPayload)(
     step: IngestStepResult[AuditSummary]): Try[Unit] =
     step match {
       case IngestStepSucceeded(summary: AuditSuccessSummary) =>

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
@@ -43,12 +43,13 @@ class BagAuditorWorker[IngestDestination, OutgoingDestination](
     with Logging
     with IngestStepWorker {
   private val worker =
-    AlpakkaSQSWorker[UnpackedBagLocationPayload, AuditSummary](alpakkaSQSWorkerConfig) {
-      payload: UnpackedBagLocationPayload =>
-        Future.fromTry { processMessage(payload) }
+    AlpakkaSQSWorker[UnpackedBagLocationPayload, AuditSummary](
+      alpakkaSQSWorkerConfig) { payload: UnpackedBagLocationPayload =>
+      Future.fromTry { processMessage(payload) }
     }
 
-  def processMessage(payload: UnpackedBagLocationPayload): Try[Result[AuditSummary]] =
+  def processMessage(
+    payload: UnpackedBagLocationPayload): Try[Result[AuditSummary]] =
     for {
       _ <- ingestUpdater.start(ingestId = payload.ingestId)
 

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
@@ -86,8 +86,7 @@ class BagAuditorWorker[IngestDestination, OutgoingDestination](
         outgoingPublisher.sendIfSuccessful(
           step,
           EnrichedBagInformationPayload(
-            ingestId = payload.ingestId,
-            storageSpace = payload.storageSpace,
+            context = payload.context,
             bagRootLocation = summary.audit.root,
             externalIdentifier = summary.audit.externalIdentifier,
             version = summary.audit.version

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
@@ -128,7 +128,8 @@ class BagAuditorFeatureTest
     withLocalS3Bucket { bucket =>
       withBag(bucket, bagRootDirectory = Some("subdir1/subdir2/subdir3")) {
         case (unpackedBagLocation, _) =>
-          val payload = createUnpackedBagLocationPayloadWith(unpackedBagLocation)
+          val payload =
+            createUnpackedBagLocationPayloadWith(unpackedBagLocation)
 
           withLocalSqsQueue { queue =>
             val ingests = new MemoryMessageSender()

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
@@ -23,7 +23,7 @@ class BagAuditorFeatureTest
       val bagInfo = createBagInfo
       withBag(bucket, bagInfo = bagInfo) {
         case (bagRootLocation, storageSpace) =>
-          val payload = createUnpackedBagPayloadWith(
+          val payload = createUnpackedBagLocationPayloadWith(
             unpackedBagLocation = bagRootLocation,
             storageSpace = storageSpace
           )
@@ -77,7 +77,7 @@ class BagAuditorFeatureTest
         case (unpackedBagLocation, storageSpace) =>
           val bagRootLocation = unpackedBagLocation.join("subdir")
 
-          val payload = createUnpackedBagPayloadWith(
+          val payload = createUnpackedBagLocationPayloadWith(
             unpackedBagLocation = unpackedBagLocation,
             storageSpace = storageSpace
           )
@@ -128,7 +128,7 @@ class BagAuditorFeatureTest
     withLocalS3Bucket { bucket =>
       withBag(bucket, bagRootDirectory = Some("subdir1/subdir2/subdir3")) {
         case (unpackedBagLocation, _) =>
-          val payload = createUnpackedBagPayloadWith(unpackedBagLocation)
+          val payload = createUnpackedBagLocationPayloadWith(unpackedBagLocation)
 
           withLocalSqsQueue { queue =>
             val ingests = new MemoryMessageSender()
@@ -167,7 +167,7 @@ class BagAuditorFeatureTest
   it("errors if it cannot find the bag") {
     withLocalS3Bucket { bucket =>
       val unpackedBagLocation = createObjectLocation
-      val payload = createUnpackedBagPayloadWith(unpackedBagLocation)
+      val payload = createUnpackedBagLocationPayloadWith(unpackedBagLocation)
 
       withLocalSqsQueue { queue =>
         val ingests = new MemoryMessageSender()
@@ -201,7 +201,7 @@ class BagAuditorFeatureTest
 
   it("errors if it gets an error from S3") {
     val unpackedBagLocation = createObjectLocation
-    val payload = createUnpackedBagPayloadWith(unpackedBagLocation)
+    val payload = createUnpackedBagLocationPayloadWith(unpackedBagLocation)
 
     withLocalSqsQueue { queue =>
       val ingests = new MemoryMessageSender()

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
@@ -30,6 +30,7 @@ class BagAuditorFeatureTest
 
           val expectedPayload = createEnrichedBagInformationPayload(
             ingestId = payload.ingestId,
+            ingestDate = payload.ingestDate,
             bagRootLocation = bagRootLocation,
             storageSpace = storageSpace,
             externalIdentifier = bagInfo.externalIdentifier

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
@@ -16,7 +16,7 @@ import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services._
 import uk.ac.wellcome.platform.archive.common.storage.models.IngestStepWorker
 import uk.ac.wellcome.platform.archive.common.{
-  IngestRequestPayload,
+  SourceLocationPayload,
   UnpackedBagPayload
 }
 import uk.ac.wellcome.typesafe.Runnable
@@ -36,13 +36,13 @@ case class BagUnpackerWorker[IngestDestination, OutgoingDestination](
     extends Runnable
     with IngestStepWorker {
   private val worker =
-    AlpakkaSQSWorker[IngestRequestPayload, UnpackSummary](
+    AlpakkaSQSWorker[SourceLocationPayload, UnpackSummary](
       alpakkaSQSWorkerConfig) { msg =>
       Future.fromTry { processMessage(msg) }
     }
 
   def processMessage(
-    payload: IngestRequestPayload): Try[Result[UnpackSummary]] =
+    payload: SourceLocationPayload): Try[Result[UnpackSummary]] =
     for {
       _ <- ingestUpdater.start(payload.ingestId)
 

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
@@ -17,7 +17,7 @@ import uk.ac.wellcome.platform.archive.common.operation.services._
 import uk.ac.wellcome.platform.archive.common.storage.models.IngestStepWorker
 import uk.ac.wellcome.platform.archive.common.{
   SourceLocationPayload,
-  UnpackedBagPayload
+  UnpackedBagLocationPayload
 }
 import uk.ac.wellcome.typesafe.Runnable
 
@@ -60,7 +60,7 @@ case class BagUnpackerWorker[IngestDestination, OutgoingDestination](
 
       _ <- ingestUpdater.send(payload.ingestId, stepResult)
 
-      outgoingPayload = UnpackedBagPayload(
+      outgoingPayload = UnpackedBagLocationPayload(
         sourceLocationPayload = payload,
         unpackedBagLocation = unpackedBagLocation
       )

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
@@ -61,7 +61,7 @@ case class BagUnpackerWorker[IngestDestination, OutgoingDestination](
       _ <- ingestUpdater.send(payload.ingestId, stepResult)
 
       outgoingPayload = UnpackedBagLocationPayload(
-        sourceLocationPayload = payload,
+        payload = payload,
         unpackedBagLocation = unpackedBagLocation
       )
       _ <- outgoingPublisher.sendIfSuccessful(stepResult, outgoingPayload)

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
@@ -61,7 +61,7 @@ case class BagUnpackerWorker[IngestDestination, OutgoingDestination](
       _ <- ingestUpdater.send(payload.ingestId, stepResult)
 
       outgoingPayload = UnpackedBagPayload(
-        ingestRequestPayload = payload,
+        sourceLocationPayload = payload,
         unpackedBagLocation = unpackedBagLocation
       )
       _ <- outgoingPublisher.sendIfSuccessful(stepResult, outgoingPayload)

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.platform.archive.bagunpacker.fixtures.{
   BagUnpackerFixtures,
   CompressFixture
 }
-import uk.ac.wellcome.platform.archive.common.UnpackedBagPayload
+import uk.ac.wellcome.platform.archive.common.UnpackedBagLocationPayload
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
 import uk.ac.wellcome.platform.archive.common.ingests.models.{
@@ -37,7 +37,7 @@ class UnpackerFeatureTest
           sendNotificationToSQS(queue, ingestRequestPayload)
 
           eventually {
-            val expectedPayload = UnpackedBagPayload(
+            val expectedPayload = UnpackedBagLocationPayload(
               sourceLocationPayload = ingestRequestPayload,
               unpackedBagLocation = createObjectLocationWith(
                 bucket = srcBucket,
@@ -50,7 +50,7 @@ class UnpackerFeatureTest
               )
             )
 
-            outgoing.getMessages[UnpackedBagPayload] shouldBe Seq(
+            outgoing.getMessages[UnpackedBagLocationPayload] shouldBe Seq(
               expectedPayload)
 
             assertTopicReceivesIngestEvents(

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
@@ -38,7 +38,7 @@ class UnpackerFeatureTest
 
           eventually {
             val expectedPayload = UnpackedBagPayload(
-              ingestRequestPayload = ingestRequestPayload,
+              sourceLocationPayload = ingestRequestPayload,
               unpackedBagLocation = createObjectLocationWith(
                 bucket = srcBucket,
                 key = Paths

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
@@ -33,7 +33,7 @@ class UnpackerFeatureTest
       case (_, srcBucket, queue, ingests, outgoing) =>
         withArchive(srcBucket, archiveFile) { archiveLocation =>
           val ingestRequestPayload =
-            createIngestRequestPayloadWith(archiveLocation)
+            createSourceLocationPayloadWith(archiveLocation)
           sendNotificationToSQS(queue, ingestRequestPayload)
 
           eventually {
@@ -69,7 +69,7 @@ class UnpackerFeatureTest
   it("sends a failed Ingest update if it cannot read the bag") {
     withBagUnpackerApp(stepName = "unpacker") {
       case (_, _, queue, ingests, outgoing) =>
-        val payload = createIngestRequestPayload
+        val payload = createSourceLocation
         sendNotificationToSQS(queue, payload)
 
         eventually {

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
@@ -32,19 +32,19 @@ class UnpackerFeatureTest
     withBagUnpackerApp(stepName = "unpacker") {
       case (_, srcBucket, queue, ingests, outgoing) =>
         withArchive(srcBucket, archiveFile) { archiveLocation =>
-          val ingestRequestPayload =
+          val sourceLocationPayload =
             createSourceLocationPayloadWith(archiveLocation)
-          sendNotificationToSQS(queue, ingestRequestPayload)
+          sendNotificationToSQS(queue, sourceLocationPayload)
 
           eventually {
             val expectedPayload = UnpackedBagLocationPayload(
-              sourceLocationPayload = ingestRequestPayload,
+              payload = sourceLocationPayload,
               unpackedBagLocation = createObjectLocationWith(
                 bucket = srcBucket,
                 key = Paths
                   .get(
-                    ingestRequestPayload.storageSpace.toString,
-                    ingestRequestPayload.ingestId.toString
+                    sourceLocationPayload.storageSpace.toString,
+                    sourceLocationPayload.ingestId.toString
                   )
                   .toString
               )
@@ -54,7 +54,7 @@ class UnpackerFeatureTest
               expectedPayload)
 
             assertTopicReceivesIngestEvents(
-              ingestRequestPayload.ingestId,
+              sourceLocationPayload.ingestId,
               ingests,
               expectedDescriptions = Seq(
                 "Unpacker started",

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
@@ -7,7 +7,7 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.bagverifier.fixtures.BagVerifierFixtures
 import uk.ac.wellcome.platform.archive.common.{
-  BagInformationPayload,
+  BagRootLocationPayload,
   EnrichedBagInformationPayload
 }
 import uk.ac.wellcome.platform.archive.common.fixtures.{
@@ -91,11 +91,11 @@ class BagVerifierWorkerTest
         withLocalS3Bucket { bucket =>
           withBag(bucket) {
             case (bagRootLocation, _) =>
-              val payload = createBagInformationPayloadWith(bagRootLocation)
+              val payload = createBagRootLocationPayloadWith(bagRootLocation)
 
               service.processMessage(payload) shouldBe a[Success[_]]
 
-              outgoing.getMessages[BagInformationPayload] shouldBe Seq(payload)
+              outgoing.getMessages[BagRootLocationPayload] shouldBe Seq(payload)
           }
         }
       }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelineContext.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelineContext.scala
@@ -1,0 +1,23 @@
+package uk.ac.wellcome.platform.archive.common
+
+import java.time.Instant
+
+import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestID, IngestType}
+import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
+
+case class PipelineContext(
+  ingestId: IngestID,
+  ingestType: IngestType,
+  storageSpace: StorageSpace,
+  ingestDate: Instant
+)
+
+case object PipelineContext {
+  def apply(ingest: Ingest): PipelineContext =
+    PipelineContext(
+      ingestId = ingest.id,
+      ingestType = ingest.ingestType,
+      storageSpace = StorageSpace(ingest.space.underlying),
+      ingestDate = ingest.createdDate
+    )
+}

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelineContext.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelineContext.scala
@@ -2,7 +2,11 @@ package uk.ac.wellcome.platform.archive.common
 
 import java.time.Instant
 
-import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestID, IngestType}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  Ingest,
+  IngestID,
+  IngestType
+}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 
 case class PipelineContext(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
@@ -47,19 +47,17 @@ case object UnpackedBagLocationPayload {
     )
 }
 
-sealed trait BagRootPayload extends PipelinePayload {
+sealed trait BagRootPayload extends BetterPipelinePayload {
   val bagRootLocation: ObjectLocation
 }
 
-case class BagInformationPayload(
-  ingestId: IngestID,
-  storageSpace: StorageSpace,
+case class BagRootLocationPayload(
+  context: PipelineContext,
   bagRootLocation: ObjectLocation
 ) extends BagRootPayload
 
 case class EnrichedBagInformationPayload(
-  ingestId: IngestID,
-  storageSpace: StorageSpace,
+  context: PipelineContext,
   bagRootLocation: ObjectLocation,
   externalIdentifier: ExternalIdentifier,
   version: Int

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
@@ -3,7 +3,11 @@ package uk.ac.wellcome.platform.archive.common
 import java.time.Instant
 
 import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
-import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestID, IngestType}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  Ingest,
+  IngestID,
+  IngestType
+}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.ObjectLocation
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
@@ -11,16 +11,16 @@ sealed trait PipelinePayload {
   val ingestId: IngestID
 }
 
-case class IngestRequestPayload(
+case class SourceLocationPayload(
   ingestId: IngestID,
   ingestDate: Instant,
   storageSpace: StorageSpace,
   sourceLocation: ObjectLocation
 ) extends PipelinePayload
 
-case object IngestRequestPayload {
-  def apply(ingest: Ingest): IngestRequestPayload =
-    IngestRequestPayload(
+case object SourceLocationPayload {
+  def apply(ingest: Ingest): SourceLocationPayload =
+    SourceLocationPayload(
       ingestId = ingest.id,
       ingestDate = ingest.createdDate,
       storageSpace = StorageSpace(ingest.space.underlying),
@@ -36,12 +36,12 @@ case class UnpackedBagPayload(
 ) extends PipelinePayload
 
 case object UnpackedBagPayload {
-  def apply(ingestRequestPayload: IngestRequestPayload,
+  def apply(sourceLocationPayload: SourceLocationPayload,
             unpackedBagLocation: ObjectLocation): UnpackedBagPayload =
     UnpackedBagPayload(
-      ingestId = ingestRequestPayload.ingestId,
-      ingestDate = ingestRequestPayload.ingestDate,
-      storageSpace = ingestRequestPayload.storageSpace,
+      ingestId = sourceLocationPayload.ingestId,
+      ingestDate = sourceLocationPayload.ingestDate,
+      storageSpace = sourceLocationPayload.storageSpace,
       unpackedBagLocation = unpackedBagLocation
     )
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
@@ -8,10 +8,6 @@ import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.ObjectLocation
 
 sealed trait PipelinePayload {
-  def ingestId: IngestID
-}
-
-sealed trait BetterPipelinePayload extends PipelinePayload {
   val context: PipelineContext
 
   def ingestId: IngestID = context.ingestId
@@ -23,7 +19,7 @@ sealed trait BetterPipelinePayload extends PipelinePayload {
 case class SourceLocationPayload(
   context: PipelineContext,
   sourceLocation: ObjectLocation
-) extends BetterPipelinePayload
+) extends PipelinePayload
 
 case object SourceLocationPayload {
   def apply(ingest: Ingest): SourceLocationPayload =
@@ -36,10 +32,10 @@ case object SourceLocationPayload {
 case class UnpackedBagLocationPayload(
   context: PipelineContext,
   unpackedBagLocation: ObjectLocation
-) extends BetterPipelinePayload
+) extends PipelinePayload
 
 case object UnpackedBagLocationPayload {
-  def apply(payload: BetterPipelinePayload,
+  def apply(payload: PipelinePayload,
             unpackedBagLocation: ObjectLocation): UnpackedBagLocationPayload =
     UnpackedBagLocationPayload(
       context = payload.context,
@@ -47,7 +43,7 @@ case object UnpackedBagLocationPayload {
     )
 }
 
-sealed trait BagRootPayload extends BetterPipelinePayload {
+sealed trait BagRootPayload extends PipelinePayload {
   val bagRootLocation: ObjectLocation
 }
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
@@ -38,18 +38,14 @@ sealed trait BetterPipelinePayload extends PipelinePayload {
 }
 
 case class SourceLocationPayload(
-  ingestId: IngestID,
-  ingestDate: Instant,
-  storageSpace: StorageSpace,
+  context: PipelineContext,
   sourceLocation: ObjectLocation
-) extends PipelinePayload
+) extends BetterPipelinePayload
 
 case object SourceLocationPayload {
   def apply(ingest: Ingest): SourceLocationPayload =
     SourceLocationPayload(
-      ingestId = ingest.id,
-      ingestDate = ingest.createdDate,
-      storageSpace = StorageSpace(ingest.space.underlying),
+      context = PipelineContext(ingest),
       sourceLocation = ingest.sourceLocation.location
     )
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
@@ -11,23 +11,6 @@ sealed trait PipelinePayload {
   def ingestId: IngestID
 }
 
-case class PipelineContext(
-  ingestId: IngestID,
-  ingestType: IngestType,
-  storageSpace: StorageSpace,
-  ingestDate: Instant
-)
-
-case object PipelineContext {
-  def apply(ingest: Ingest): PipelineContext =
-    PipelineContext(
-      ingestId = ingest.id,
-      ingestType = ingest.ingestType,
-      storageSpace = StorageSpace(ingest.space.underlying),
-      ingestDate = ingest.createdDate
-    )
-}
-
 sealed trait BetterPipelinePayload extends PipelinePayload {
   val context: PipelineContext
 
@@ -50,20 +33,16 @@ case object SourceLocationPayload {
     )
 }
 
-case class UnpackedBagPayload(
-  ingestId: IngestID,
-  ingestDate: Instant,
-  storageSpace: StorageSpace,
+case class UnpackedBagLocationPayload(
+  context: PipelineContext,
   unpackedBagLocation: ObjectLocation
-) extends PipelinePayload
+) extends BetterPipelinePayload
 
-case object UnpackedBagPayload {
-  def apply(sourceLocationPayload: SourceLocationPayload,
-            unpackedBagLocation: ObjectLocation): UnpackedBagPayload =
-    UnpackedBagPayload(
-      ingestId = sourceLocationPayload.ingestId,
-      ingestDate = sourceLocationPayload.ingestDate,
-      storageSpace = sourceLocationPayload.storageSpace,
+case object UnpackedBagLocationPayload {
+  def apply(payload: BetterPipelinePayload,
+            unpackedBagLocation: ObjectLocation): UnpackedBagLocationPayload =
+    UnpackedBagLocationPayload(
+      context = payload.context,
       unpackedBagLocation = unpackedBagLocation
     )
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
@@ -3,12 +3,38 @@ package uk.ac.wellcome.platform.archive.common
 import java.time.Instant
 
 import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
-import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestID}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestID, IngestType}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.ObjectLocation
 
 sealed trait PipelinePayload {
-  val ingestId: IngestID
+  def ingestId: IngestID
+}
+
+case class PipelineContext(
+  ingestId: IngestID,
+  ingestType: IngestType,
+  storageSpace: StorageSpace,
+  ingestDate: Instant
+)
+
+case object PipelineContext {
+  def apply(ingest: Ingest): PipelineContext =
+    PipelineContext(
+      ingestId = ingest.id,
+      ingestType = ingest.ingestType,
+      storageSpace = StorageSpace(ingest.space.underlying),
+      ingestDate = ingest.createdDate
+    )
+}
+
+sealed trait BetterPipelinePayload extends PipelinePayload {
+  val context: PipelineContext
+
+  def ingestId: IngestID = context.ingestId
+  def ingestType: IngestType = context.ingestType
+  def storageSpace: StorageSpace = context.storageSpace
+  def ingestDate: Instant = context.ingestDate
 }
 
 case class SourceLocationPayload(

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/SourceLocationPayloadTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/SourceLocationPayloadTest.scala
@@ -8,7 +8,7 @@ import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
 
-class IngestRequestPayloadTest
+class SourceLocationPayloadTest
     extends FunSpec
     with Matchers
     with RandomThings
@@ -31,13 +31,13 @@ class IngestRequestPayloadTest
       createdDate = ingestDate
     )
 
-    val expectedPayload = IngestRequestPayload(
+    val expectedPayload = SourceLocationPayload(
       ingestId = ingestId,
       ingestDate = ingestDate,
       storageSpace = StorageSpace(space),
       sourceLocation = sourceLocation
     )
 
-    IngestRequestPayload(ingest) shouldBe expectedPayload
+    SourceLocationPayload(ingest) shouldBe expectedPayload
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/SourceLocationPayloadTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/SourceLocationPayloadTest.scala
@@ -16,13 +16,14 @@ class SourceLocationPayloadTest
 
   it("creates a payload from an ingest") {
     val ingestId = createIngestID
+    val ingestType = CreateIngestType
     val sourceLocation = createObjectLocation
     val space = randomAlphanumeric()
     val ingestDate = Instant.now()
 
     val ingest = Ingest(
       id = ingestId,
-      ingestType = CreateIngestType,
+      ingestType = ingestType,
       sourceLocation = StorageLocation(
         provider = StandardStorageProvider,
         location = sourceLocation
@@ -32,9 +33,12 @@ class SourceLocationPayloadTest
     )
 
     val expectedPayload = SourceLocationPayload(
-      ingestId = ingestId,
-      ingestDate = ingestDate,
-      storageSpace = StorageSpace(space),
+      context = PipelineContext(
+        ingestId = ingestId,
+        ingestType = ingestType,
+        storageSpace = StorageSpace(space),
+        ingestDate = ingestDate
+      ),
       sourceLocation = sourceLocation
     )
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/UnpackedBagLocationPayloadTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/UnpackedBagLocationPayloadTest.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.archive.common
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 
-class UnpackedBagPayloadTest
+class UnpackedBagLocationPayloadTest
     extends FunSpec
     with Matchers
     with PayloadGenerators {
@@ -12,18 +12,21 @@ class UnpackedBagPayloadTest
     val unpackedBagLocation = createObjectLocation
     val storageSpace = createStorageSpace
 
-    val ingestRequestPayload = createSourceLocationPayloadWith(
+    val sourceLocationPayload = createSourceLocationPayloadWith(
       sourceLocation = sourceLocation,
       storageSpace = storageSpace
     )
 
-    val expectedPayload = UnpackedBagPayload(
-      ingestId = ingestRequestPayload.ingestId,
-      ingestDate = ingestRequestPayload.ingestDate,
-      storageSpace = storageSpace,
+    val expectedPayload = UnpackedBagLocationPayload(
+      context = PipelineContext(
+        ingestId = sourceLocationPayload.ingestId,
+        ingestType = sourceLocationPayload.ingestType,
+        storageSpace = storageSpace,
+        ingestDate = sourceLocationPayload.ingestDate
+      ),
       unpackedBagLocation = unpackedBagLocation
     )
 
-    UnpackedBagPayload(ingestRequestPayload, unpackedBagLocation) shouldBe expectedPayload
+    UnpackedBagLocationPayload(sourceLocationPayload, unpackedBagLocation) shouldBe expectedPayload
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/UnpackedBagPayloadTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/UnpackedBagPayloadTest.scala
@@ -12,7 +12,7 @@ class UnpackedBagPayloadTest
     val unpackedBagLocation = createObjectLocation
     val storageSpace = createStorageSpace
 
-    val ingestRequestPayload = createIngestRequestPayloadWith(
+    val ingestRequestPayload = createSourceLocationPayloadWith(
       sourceLocation = sourceLocation,
       storageSpace = storageSpace
     )

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -19,13 +19,14 @@ trait PayloadGenerators
 
   def createPipelineContextWith(
     ingestId: IngestID = createIngestID,
+    ingestDate: Instant = Instant.now(),
     storageSpace: StorageSpace = createStorageSpace
   ): PipelineContext =
     PipelineContext(
-      ingestId = createIngestID,
+      ingestId = ingestId,
       ingestType = CreateIngestType,
       storageSpace = storageSpace,
-      ingestDate = Instant.now()
+      ingestDate = ingestDate
     )
 
   def createPipelineContext: PipelineContext =
@@ -58,6 +59,7 @@ trait PayloadGenerators
 
   def createEnrichedBagInformationPayload(
     ingestId: IngestID = createIngestID,
+    ingestDate: Instant = Instant.now,
     bagRootLocation: ObjectLocation = createObjectLocation,
     storageSpace: StorageSpace = createStorageSpace,
     externalIdentifier: ExternalIdentifier = createExternalIdentifier,
@@ -65,6 +67,7 @@ trait PayloadGenerators
     EnrichedBagInformationPayload(
       context = createPipelineContextWith(
         ingestId = ingestId,
+        ingestDate = ingestDate,
         storageSpace = storageSpace
       ),
       bagRootLocation = bagRootLocation,

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -4,7 +4,7 @@ import java.time.Instant
 
 import uk.ac.wellcome.platform.archive.common._
 import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
-import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
+import uk.ac.wellcome.platform.archive.common.ingests.models.{CreateIngestType, IngestID}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
@@ -13,14 +13,25 @@ trait PayloadGenerators
     extends ExternalIdentifierGenerators
     with StorageSpaceGenerators
     with ObjectLocationGenerators {
+
+  def createPipelineContextWith(
+    storageSpace: StorageSpace = createStorageSpace
+  ): PipelineContext =
+    PipelineContext(
+      ingestId = createIngestID,
+      ingestType = CreateIngestType,
+      storageSpace = storageSpace,
+      ingestDate = Instant.now()
+    )
+
   def createSourceLocationPayloadWith(
     sourceLocation: ObjectLocation = createObjectLocation,
     storageSpace: StorageSpace = createStorageSpace
   ): SourceLocationPayload =
     SourceLocationPayload(
-      ingestId = createIngestID,
-      ingestDate = Instant.now(),
-      storageSpace = storageSpace,
+      context = createPipelineContextWith(
+        storageSpace = storageSpace
+      ),
       sourceLocation = sourceLocation
     )
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -13,19 +13,19 @@ trait PayloadGenerators
     extends ExternalIdentifierGenerators
     with StorageSpaceGenerators
     with ObjectLocationGenerators {
-  def createIngestRequestPayloadWith(
+  def createSourceLocationPayloadWith(
     sourceLocation: ObjectLocation = createObjectLocation,
     storageSpace: StorageSpace = createStorageSpace
-  ): IngestRequestPayload =
-    IngestRequestPayload(
+  ): SourceLocationPayload =
+    SourceLocationPayload(
       ingestId = createIngestID,
       ingestDate = Instant.now(),
       storageSpace = storageSpace,
       sourceLocation = sourceLocation
     )
 
-  def createIngestRequestPayload: IngestRequestPayload =
-    createIngestRequestPayloadWith()
+  def createSourceLocation: SourceLocationPayload =
+    createSourceLocationPayloadWith()
 
   def createUnpackedBagPayloadWith(
     unpackedBagLocation: ObjectLocation = createObjectLocation,

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -15,6 +15,7 @@ trait PayloadGenerators
     with ObjectLocationGenerators {
 
   def createPipelineContextWith(
+    ingestId: IngestID = createIngestID,
     storageSpace: StorageSpace = createStorageSpace
   ): PipelineContext =
     PipelineContext(
@@ -23,6 +24,9 @@ trait PayloadGenerators
       storageSpace = storageSpace,
       ingestDate = Instant.now()
     )
+
+  def createPipelineContext: PipelineContext =
+    createPipelineContextWith()
 
   def createSourceLocationPayloadWith(
     sourceLocation: ObjectLocation = createObjectLocation,
@@ -56,8 +60,10 @@ trait PayloadGenerators
     externalIdentifier: ExternalIdentifier = createExternalIdentifier,
     version: Int = 1): EnrichedBagInformationPayload =
     EnrichedBagInformationPayload(
-      ingestId = ingestId,
-      storageSpace = storageSpace,
+      context = createPipelineContextWith(
+        ingestId = ingestId,
+        storageSpace = storageSpace
+      ),
       bagRootLocation = bagRootLocation,
       externalIdentifier = externalIdentifier,
       version = version
@@ -66,11 +72,10 @@ trait PayloadGenerators
   def createEnrichedBagInformationPayload: EnrichedBagInformationPayload =
     createEnrichedBagInformationPayload()
 
-  def createBagInformationPayloadWith(
-    bagRootLocation: ObjectLocation): BagInformationPayload =
-    BagInformationPayload(
-      ingestId = createIngestID,
-      storageSpace = createStorageSpace,
+  def createBagRootLocationPayloadWith(
+    bagRootLocation: ObjectLocation): BagRootLocationPayload =
+    BagRootLocationPayload(
+      context = createPipelineContext,
       bagRootLocation = bagRootLocation
     )
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -4,7 +4,10 @@ import java.time.Instant
 
 import uk.ac.wellcome.platform.archive.common._
 import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
-import uk.ac.wellcome.platform.archive.common.ingests.models.{CreateIngestType, IngestID}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  CreateIngestType,
+  IngestID
+}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.generators.ObjectLocationGenerators

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -38,14 +38,14 @@ trait PayloadGenerators
   def createSourceLocation: SourceLocationPayload =
     createSourceLocationPayloadWith()
 
-  def createUnpackedBagPayloadWith(
+  def createUnpackedBagLocationPayloadWith(
     unpackedBagLocation: ObjectLocation = createObjectLocation,
     storageSpace: StorageSpace = createStorageSpace
-  ): UnpackedBagPayload =
-    UnpackedBagPayload(
-      ingestId = createIngestID,
-      ingestDate = Instant.now(),
-      storageSpace = storageSpace,
+  ): UnpackedBagLocationPayload =
+    UnpackedBagLocationPayload(
+      context = createPipelineContextWith(
+        storageSpace = storageSpace
+      ),
       unpackedBagLocation = unpackedBagLocation
     )
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/operation/services/OutgoingPublisherTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/operation/services/OutgoingPublisherTest.scala
@@ -4,7 +4,7 @@ import org.scalatest.FunSpec
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
-import uk.ac.wellcome.platform.archive.common.IngestRequestPayload
+import uk.ac.wellcome.platform.archive.common.SourceLocationPayload
 import uk.ac.wellcome.platform.archive.common.fixtures.OperationFixtures
 import uk.ac.wellcome.platform.archive.common.generators.{
   IngestOperationGenerators,
@@ -27,20 +27,20 @@ class OutgoingPublisherTest
     forAll(successfulOperations) { operation =>
       val messageSender = new MemoryMessageSender()
       val outgoingPublisher = createOutgoingPublisherWith(messageSender)
-      val outgoing = createIngestRequestPayload
+      val outgoing = createSourceLocation
 
       val notice = outgoingPublisher.sendIfSuccessful(operation, outgoing)
 
       notice shouldBe a[Success[_]]
 
-      messageSender.getMessages[IngestRequestPayload] shouldBe Seq(outgoing)
+      messageSender.getMessages[SourceLocationPayload] shouldBe Seq(outgoing)
     }
   }
 
   it("does not send outgoing if operation failed") {
     val messageSender = new MemoryMessageSender()
     val outgoingPublisher = createOutgoingPublisherWith(messageSender)
-    val outgoing = createIngestRequestPayload
+    val outgoing = createSourceLocation
 
     val notice =
       outgoingPublisher.sendIfSuccessful(createOperationFailure(), outgoing)


### PR DESCRIPTION
Allows us to pass around much more consistent information.

Closes https://github.com/wellcometrust/platform/issues/3656, closes #222