### PR TITLE
Bag auditor checks ingest type before assigning a version

### DIFF
--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/Main.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/Main.scala
@@ -6,13 +6,33 @@ import cats.Id
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.typesafe.config.Config
-import uk.ac.wellcome.messaging.typesafe.{AlpakkaSqsWorkerConfigBuilder, CloudwatchMonitoringClientBuilder, SQSBuilder}
+import uk.ac.wellcome.messaging.typesafe.{
+  AlpakkaSqsWorkerConfigBuilder,
+  CloudwatchMonitoringClientBuilder,
+  SQSBuilder
+}
 import uk.ac.wellcome.messaging.worker.monitoring.CloudwatchMonitoringClient
-import uk.ac.wellcome.platform.archive.common.config.builders.{IngestUpdaterBuilder, OperationNameBuilder, OutgoingPublisherBuilder}
-import uk.ac.wellcome.platform.archive.common.versioning.{DynamoIngestVersionManagerDao, IngestVersionManager, IngestVersionManagerDao, IngestVersionManagerError}
-import uk.ac.wellcome.platform.storage.bagauditor.services.{BagAuditor, BagAuditorWorker}
+import uk.ac.wellcome.platform.archive.common.config.builders.{
+  IngestUpdaterBuilder,
+  OperationNameBuilder,
+  OutgoingPublisherBuilder
+}
+import uk.ac.wellcome.platform.archive.common.versioning.{
+  DynamoIngestVersionManagerDao,
+  IngestVersionManager,
+  IngestVersionManagerDao,
+  IngestVersionManagerError
+}
+import uk.ac.wellcome.platform.storage.bagauditor.services.{
+  BagAuditor,
+  BagAuditorWorker
+}
 import uk.ac.wellcome.platform.storage.bagauditor.versioning.VersionPicker
-import uk.ac.wellcome.storage.typesafe.{DynamoBuilder, LockingBuilder, S3Builder}
+import uk.ac.wellcome.storage.typesafe.{
+  DynamoBuilder,
+  LockingBuilder,
+  S3Builder
+}
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 
@@ -38,7 +58,9 @@ object Main extends WellcomeTypesafeApp {
       .getName(config, default = "auditing bag")
 
     val lockingService =
-      LockingBuilder.buildDynamoLockingService[Either[IngestVersionManagerError, Int], Id](config)
+      LockingBuilder
+        .buildDynamoLockingService[Either[IngestVersionManagerError, Int], Id](
+          config)
 
     val ingestVersionManagerDao = new DynamoIngestVersionManagerDao(
       dynamoClient = DynamoBuilder.buildDynamoClient(config),

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/Audit.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/Audit.scala
@@ -9,4 +9,4 @@ case class AuditSuccess(
   version: Int
 ) extends Audit
 
-case class AuditFailure(e: Throwable) extends Audit
+case class AuditFailure(e: Throwable, userMessage: Option[String] = None) extends Audit

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/Audit.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/Audit.scala
@@ -9,4 +9,5 @@ case class AuditSuccess(
   version: Int
 ) extends Audit
 
-case class AuditFailure(e: Throwable, userMessage: Option[String] = None) extends Audit
+case class AuditFailure(e: Throwable, userMessage: Option[String] = None)
+    extends Audit

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/AuditError.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/AuditError.scala
@@ -1,5 +1,7 @@
 package uk.ac.wellcome.platform.storage.bagauditor.models
 
+import uk.ac.wellcome.platform.archive.common.versioning.IngestVersionManagerError
+
 sealed trait AuditError
 
 case class CannotFindExternalIdentifier(e: Throwable) extends AuditError
@@ -7,6 +9,8 @@ case class CannotFindExternalIdentifier(e: Throwable) extends AuditError
 sealed trait VersionPickerError extends AuditError
 
 case class InternalVersionPickerError(e: Throwable) extends VersionPickerError
+
+case class UnableToAssignVersion(e: IngestVersionManagerError) extends VersionPickerError
 
 case class IngestTypeCreateForExistingBag() extends VersionPickerError
 case class IngestTypeUpdateForNewBag() extends VersionPickerError

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/AuditError.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/AuditError.scala
@@ -10,7 +10,8 @@ sealed trait VersionPickerError extends AuditError
 
 case class InternalVersionPickerError(e: Throwable) extends VersionPickerError
 
-case class UnableToAssignVersion(e: IngestVersionManagerError) extends VersionPickerError
+case class UnableToAssignVersion(e: IngestVersionManagerError)
+    extends VersionPickerError
 
 case class IngestTypeCreateForExistingBag() extends VersionPickerError
 case class IngestTypeUpdateForNewBag() extends VersionPickerError

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/AuditError.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/AuditError.scala
@@ -1,0 +1,12 @@
+package uk.ac.wellcome.platform.storage.bagauditor.models
+
+sealed trait AuditError
+
+case class CannotFindExternalIdentifier(e: Throwable) extends AuditError
+
+sealed trait VersionPickerError extends AuditError
+
+case class InternalVersionPickerError(e: Throwable) extends VersionPickerError
+
+case class IngestTypeCreateForExistingBag() extends VersionPickerError
+case class IngestTypeUpdateForNewBag() extends VersionPickerError

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/AuditSuccess.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/AuditSuccess.scala
@@ -2,12 +2,7 @@ package uk.ac.wellcome.platform.storage.bagauditor.models
 
 import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
 
-sealed trait Audit
-
 case class AuditSuccess(
   externalIdentifier: ExternalIdentifier,
   version: Int
-) extends Audit
-
-case class AuditFailure(e: Throwable, userMessage: Option[String] = None)
-    extends Audit
+)

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/AuditSummary.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/AuditSummary.scala
@@ -26,28 +26,3 @@ case class AuditSuccessSummary(
   audit: AuditSuccess,
   endTime: Option[Instant]
 ) extends AuditSummary
-
-case object AuditSummary {
-  def create(
-    root: ObjectLocation,
-    space: StorageSpace,
-    audit: Audit,
-    t: Instant
-  ): AuditSummary = audit match {
-    case f @ AuditFailure(e) =>
-      AuditFailureSummary(
-        root = root,
-        space = space,
-        startTime = t,
-        endTime = Some(Instant.now())
-      )
-    case s @ AuditSuccess(_, _) =>
-      AuditSuccessSummary(
-        root = root,
-        space = space,
-        startTime = t,
-        audit = s,
-        endTime = Some(Instant.now())
-      )
-  }
-}

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/AuditSummary.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/models/AuditSummary.scala
@@ -12,14 +12,6 @@ sealed trait AuditSummary extends Summary {
   val startTime: Instant
 }
 
-case class AuditIncompleteSummary(
-  root: ObjectLocation,
-  space: StorageSpace,
-  e: Throwable,
-  startTime: Instant,
-  endTime: Option[Instant] = None
-) extends AuditSummary
-
 case class AuditFailureSummary(
   root: ObjectLocation,
   space: StorageSpace,
@@ -36,18 +28,6 @@ case class AuditSuccessSummary(
 ) extends AuditSummary
 
 case object AuditSummary {
-  def incomplete(root: ObjectLocation,
-                 space: StorageSpace,
-                 e: Throwable,
-                 t: Instant): AuditIncompleteSummary =
-    AuditIncompleteSummary(
-      root = root,
-      space = space,
-      e = e,
-      startTime = t,
-      endTime = None
-    )
-
   def create(
     root: ObjectLocation,
     space: StorageSpace,

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
@@ -5,13 +5,13 @@ import java.time.Instant
 import com.amazonaws.services.s3.AmazonS3
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.common.bagit.models.{BagInfo, ExternalIdentifier}
-import uk.ac.wellcome.platform.archive.common.ingests.models.{CreateIngestType, IngestID, IngestType}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{IngestID, IngestType}
 import uk.ac.wellcome.platform.archive.common.storage.StreamUnavailable
 import uk.ac.wellcome.platform.archive.common.storage.models.{IngestFailed, IngestStepResult, IngestStepSucceeded, StorageSpace}
-import uk.ac.wellcome.platform.storage.bagauditor.models._
 import uk.ac.wellcome.platform.archive.common.storage.services.S3BagLocator
 import uk.ac.wellcome.platform.archive.common.storage.services.S3StreamableInstances._
 import uk.ac.wellcome.platform.archive.common.versioning.{ExternalIdentifiersMismatch, InternalVersionManagerError, NewerIngestAlreadyExists}
+import uk.ac.wellcome.platform.storage.bagauditor.models._
 import uk.ac.wellcome.platform.storage.bagauditor.versioning.VersionPicker
 import uk.ac.wellcome.storage.ObjectLocation
 
@@ -24,7 +24,7 @@ class BagAuditor(versionPicker: VersionPicker)(implicit s3Client: AmazonS3) exte
 
   def getAuditSummary(ingestId: IngestID,
                       ingestDate: Instant,
-                      ingestType: IngestType = CreateIngestType,
+                      ingestType: IngestType,
                       root: ObjectLocation,
                       storageSpace: StorageSpace): IngestStep =
     Try {
@@ -75,7 +75,7 @@ class BagAuditor(versionPicker: VersionPicker)(implicit s3Client: AmazonS3) exte
       case CannotFindExternalIdentifier(e) => e
       case UnableToAssignVersion(internalError: InternalVersionManagerError)
                                            => internalError.e
-      case _                               => new Throwable()
+      case err                             => new Throwable(s"Unexpected error in the auditor: $err")
     }
 
   private def createUserFacingMessage(ingestId: IngestID, auditError: AuditError): Option[String] =

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.storage.bagauditor.services
 import java.time.Instant
 
 import com.amazonaws.services.s3.AmazonS3
-import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.common.bagit.models.{
   BagInfo,
   ExternalIdentifier
@@ -32,8 +31,7 @@ import uk.ac.wellcome.storage.ObjectLocation
 
 import scala.util.{Failure, Success, Try}
 
-class BagAuditor(versionPicker: VersionPicker)(implicit s3Client: AmazonS3)
-    extends Logging {
+class BagAuditor(versionPicker: VersionPicker)(implicit s3Client: AmazonS3) {
   val s3BagLocator = new S3BagLocator(s3Client)
 
   type IngestStep = Try[IngestStepResult[AuditSummary]]

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
@@ -20,11 +20,7 @@ import uk.ac.wellcome.platform.archive.common.storage.models.{
 }
 import uk.ac.wellcome.platform.archive.common.storage.services.S3BagLocator
 import uk.ac.wellcome.platform.archive.common.storage.services.S3StreamableInstances._
-import uk.ac.wellcome.platform.archive.common.versioning.{
-  ExternalIdentifiersMismatch,
-  InternalVersionManagerError,
-  NewerIngestAlreadyExists
-}
+import uk.ac.wellcome.platform.archive.common.versioning.InternalVersionManagerError
 import uk.ac.wellcome.platform.storage.bagauditor.models._
 import uk.ac.wellcome.platform.storage.bagauditor.versioning.VersionPicker
 import uk.ac.wellcome.storage.ObjectLocation

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
@@ -76,9 +76,10 @@ class BagAuditor(versionPicker: VersionPicker)(implicit s3Client: AmazonS3) {
 
   private def createUserFacingMessage(auditError: AuditError): Option[String] =
     auditError match {
-      case CannotFindExternalIdentifier(_) => Some("Unable to find an external identifier")
-      case IngestTypeUpdateForNewBag()     => Some("This bag has never been ingested before, but was sent with ingestType update")
-      case _                               => None
+      case CannotFindExternalIdentifier(_)  => Some("Unable to find an external identifier")
+      case IngestTypeUpdateForNewBag()      => Some("This bag has never been ingested before, but was sent with ingestType update")
+      case IngestTypeCreateForExistingBag() => Some("This bag has already been ingested, but was sent with ingestType create")
+      case _                                => None
     }
 
   private def getBagIdentifier(

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
@@ -48,23 +48,26 @@ class BagAuditor(versionPicker: VersionPicker)(implicit s3Client: AmazonS3) {
         )
       } yield auditSuccess
 
+
+
       auditTry match {
         case Success(auditSuccess) =>
           IngestStepSucceeded(
-            AuditSummary.create(
+            AuditSuccessSummary(
               root = root,
               space = storageSpace,
+              startTime = startTime,
               audit = auditSuccess,
-              t = startTime
+              endTime = Some(Instant.now())
             )
           )
         case Failure(err) =>
           IngestFailed(
-            summary = AuditSummary.create(
+            AuditFailureSummary(
               root = root,
               space = storageSpace,
-              audit = AuditFailure(err),
-              t = startTime
+              startTime = startTime,
+              endTime = Some(Instant.now())
             ),
             err
           )

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
@@ -56,6 +56,7 @@ class BagAuditorWorker[IngestDestination, OutgoingDestination](
       auditStep <- bagAuditor.getAuditSummary(
         ingestId = payload.ingestId,
         ingestDate = payload.ingestDate,
+        ingestType = payload.ingestType,
         root = payload.bagRootLocation,
         storageSpace = payload.storageSpace
       )

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/UserFacingMessages.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/UserFacingMessages.scala
@@ -2,11 +2,15 @@ package uk.ac.wellcome.platform.storage.bagauditor.services
 
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
-import uk.ac.wellcome.platform.archive.common.versioning.{ExternalIdentifiersMismatch, NewerIngestAlreadyExists}
+import uk.ac.wellcome.platform.archive.common.versioning.{
+  ExternalIdentifiersMismatch,
+  NewerIngestAlreadyExists
+}
 import uk.ac.wellcome.platform.storage.bagauditor.models._
 
 object UserFacingMessages extends Logging {
-  def createMessage(ingestId: IngestID, auditError: AuditError): Option[String] =
+  def createMessage(ingestId: IngestID,
+                    auditError: AuditError): Option[String] =
     auditError match {
       case CannotFindExternalIdentifier(err) =>
         info(

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/UserFacingMessages.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/UserFacingMessages.scala
@@ -1,0 +1,38 @@
+package uk.ac.wellcome.platform.storage.bagauditor.services
+
+import grizzled.slf4j.Logging
+import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
+import uk.ac.wellcome.platform.archive.common.versioning.{ExternalIdentifiersMismatch, NewerIngestAlreadyExists}
+import uk.ac.wellcome.platform.storage.bagauditor.models._
+
+object UserFacingMessages extends Logging {
+  def createMessage(ingestId: IngestID, auditError: AuditError): Option[String] =
+    auditError match {
+      case CannotFindExternalIdentifier(err) =>
+        info(
+          s"Unable to find an external identifier for $ingestId. Error: $err")
+        Some("An external identifier was not found in the bag info")
+
+      case IngestTypeUpdateForNewBag() =>
+        Some(
+          "Cannot update existing bag: a bag with the supplied external identifier does not exist in this space")
+
+      case IngestTypeCreateForExistingBag() =>
+        Some(
+          "Cannot create new bag: a bag with the supplied external identifier already exists in this space")
+
+      case UnableToAssignVersion(e: NewerIngestAlreadyExists) =>
+        Some(
+          s"Another version of this bag was ingested at ${e.stored}, which is newer than the current ingest ${e.request}")
+
+      // This should be impossible, and it strongly points to an error somewhere in
+      // the pipeline -- an ingest ID should be used once, and the underlying bag
+      // shouldn't change!  We don't bubble up an error because it's an internal failure,
+      // and there's nothing the user can do about it.
+      case UnableToAssignVersion(e: ExternalIdentifiersMismatch) =>
+        warn(s"External identifiers mismatch for $ingestId: $e")
+        None
+
+      case _ => None
+    }
+}

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/versioning/VersionPicker.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/versioning/VersionPicker.scala
@@ -19,7 +19,7 @@ class VersionPicker(
   def chooseVersion(
     externalIdentifier: ExternalIdentifier,
     ingestId: IngestID,
-    ingestType: IngestType = CreateIngestType,
+    ingestType: IngestType,
     ingestDate: Instant
   ): Either[VersionPickerError, Int] = {
     val tryVersion: Try[lockingService.Process] = lockingService

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/versioning/VersionPicker.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/versioning/VersionPicker.scala
@@ -65,8 +65,8 @@ class VersionPicker(
       Right(assignedVersion)
     }
 
-  // Annoyingly, cats doesn't seem to provide an Implicit for the Id monad, so we have
-  // to implement one ourselves.
+  // Annoyingly, cats doesn't provide an Implicit for MonadError[Id, Throwable],
+  // so we have to implement one ourselves.
   implicit def idMonad(implicit I: Monad[Id]): MonadError[Id, Throwable] =
     new MonadError[Id, Throwable] {
       override def raiseError[A](e: Throwable): Id[A] = throw e

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/versioning/VersionPicker.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/versioning/VersionPicker.scala
@@ -5,13 +5,23 @@ import java.util.UUID
 
 import cats.{Id, Monad, MonadError}
 import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
-import uk.ac.wellcome.platform.archive.common.ingests.models.{CreateIngestType, IngestID, IngestType, UpdateIngestType}
-import uk.ac.wellcome.platform.archive.common.versioning.{IngestVersionManager, IngestVersionManagerError}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  CreateIngestType,
+  IngestID,
+  IngestType,
+  UpdateIngestType
+}
+import uk.ac.wellcome.platform.archive.common.versioning.{
+  IngestVersionManager,
+  IngestVersionManagerError
+}
 import uk.ac.wellcome.platform.storage.bagauditor.models._
 import uk.ac.wellcome.storage.{FailedProcess, LockDao, LockingService}
 
 class VersionPicker(
-  lockingService: LockingService[Either[IngestVersionManagerError, Int], Id, LockDao[String, UUID]],
+  lockingService: LockingService[Either[IngestVersionManagerError, Int],
+                                 Id,
+                                 LockDao[String, UUID]],
   ingestVersionManager: IngestVersionManager
 ) {
   def chooseVersion(
@@ -32,18 +42,21 @@ class VersionPicker(
     // This is a double Either: the outer Either defines the result of the locking
     // service operation, the inner Either is the version assignment.
     assignedVersion match {
-      case Right(Right(version))       => checkVersionIsAllowed(ingestType, assignedVersion = version)
+      case Right(Right(version)) =>
+        checkVersionIsAllowed(ingestType, assignedVersion = version)
 
-      case Right(Left(ingestVersionManagerError))
-                                       => Left(UnableToAssignVersion(ingestVersionManagerError))
+      case Right(Left(ingestVersionManagerError)) =>
+        Left(UnableToAssignVersion(ingestVersionManagerError))
 
       case Left(FailedProcess(_, err)) => Left(InternalVersionPickerError(err))
-      case Left(err)                   => Left(InternalVersionPickerError(new Throwable(s"Locking error: $err")))
+      case Left(err) =>
+        Left(InternalVersionPickerError(new Throwable(s"Locking error: $err")))
     }
   }
 
-  private def checkVersionIsAllowed(ingestType: IngestType,
-                                    assignedVersion: Int): Either[VersionPickerError, Int] =
+  private def checkVersionIsAllowed(
+    ingestType: IngestType,
+    assignedVersion: Int): Either[VersionPickerError, Int] =
     if (ingestType == CreateIngestType && assignedVersion > 1) {
       Left(IngestTypeCreateForExistingBag())
     } else if (ingestType == UpdateIngestType && assignedVersion == 1) {
@@ -67,8 +80,10 @@ class VersionPicker(
 
       override def pure[A](x: A): Id[A] = x
 
-      override def flatMap[A, B](fa: Id[A])(f: A => Id[B]): Id[B] = I.flatMap(fa)(f)
+      override def flatMap[A, B](fa: Id[A])(f: A => Id[B]): Id[B] =
+        I.flatMap(fa)(f)
 
-      override def tailRecM[A, B](a: A)(f: A => Id[Either[A, B]]): Id[B] = I.tailRecM(a)(f)
+      override def tailRecM[A, B](a: A)(f: A => Id[Either[A, B]]): Id[B] =
+        I.tailRecM(a)(f)
     }
 }

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
@@ -7,8 +7,16 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.ingests.models.{CreateIngestType, Ingest, IngestStatusUpdate, UpdateIngestType}
-import uk.ac.wellcome.platform.archive.common.{BagRootLocationPayload, EnrichedBagInformationPayload}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  CreateIngestType,
+  Ingest,
+  IngestStatusUpdate,
+  UpdateIngestType
+}
+import uk.ac.wellcome.platform.archive.common.{
+  BagRootLocationPayload,
+  EnrichedBagInformationPayload
+}
 import uk.ac.wellcome.platform.storage.bagauditor.fixtures.BagAuditorFixtures
 
 class BagAuditorFeatureTest
@@ -128,20 +136,19 @@ class BagAuditorFeatureTest
           val outgoing = new MemoryMessageSender()
 
           withLocalSqsQueue { queue =>
-
             withAuditorWorker(
               queue,
               ingests,
               outgoing,
               stepName = "auditing bag") { _ =>
-
               // Send the initial payload with "create" and check it completes
               sendNotificationToSQS(queue, payload1)
 
               eventually {
                 assertQueueEmpty(queue)
 
-                outgoing.getMessages[EnrichedBagInformationPayload] should have size 1
+                outgoing
+                  .getMessages[EnrichedBagInformationPayload] should have size 1
 
                 assertTopicReceivesIngestEvents(
                   payload1.ingestId,
@@ -161,7 +168,8 @@ class BagAuditorFeatureTest
               eventually {
                 assertQueueEmpty(queue)
 
-                outgoing.getMessages[EnrichedBagInformationPayload] should have size 2
+                outgoing
+                  .getMessages[EnrichedBagInformationPayload] should have size 2
 
                 assertTopicReceivesIngestEvents(
                   payload1.ingestId,

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
@@ -1,15 +1,14 @@
 package uk.ac.wellcome.platform.storage.bagauditor
 
+import java.time.Instant
+
 import org.scalatest.FunSpec
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
-import uk.ac.wellcome.platform.archive.common.EnrichedBagInformationPayload
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  Ingest,
-  IngestStatusUpdate
-}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{CreateIngestType, Ingest, IngestStatusUpdate, UpdateIngestType}
+import uk.ac.wellcome.platform.archive.common.{BagRootLocationPayload, EnrichedBagInformationPayload}
 import uk.ac.wellcome.platform.storage.bagauditor.fixtures.BagAuditorFixtures
 
 class BagAuditorFeatureTest
@@ -96,6 +95,89 @@ class BagAuditorFeatureTest
                   ingestUpdates.tail.head.asInstanceOf[IngestStatusUpdate]
                 ingestFailed.status shouldBe Ingest.Failed
                 ingestFailed.events.head.description shouldBe "Auditing bag failed - Unable to find an external identifier"
+            }
+          }
+      }
+    }
+  }
+
+  it("assigns a version for an updated bag") {
+    withLocalS3Bucket { bucket =>
+      val bagInfo = createBagInfo
+      withBag(bucket, bagInfo = bagInfo) {
+        case (bagRootLocation, storageSpace) =>
+          val payload1 = BagRootLocationPayload(
+            context = createPipelineContextWith(
+              ingestId = createIngestID,
+              ingestType = CreateIngestType,
+              ingestDate = Instant.ofEpochSecond(1),
+              storageSpace = storageSpace
+            ),
+            bagRootLocation = bagRootLocation
+          )
+
+          val payload2 = payload1.copy(
+            context = payload1.context.copy(
+              ingestId = createIngestID,
+              ingestType = UpdateIngestType,
+              ingestDate = Instant.ofEpochSecond(2)
+            )
+          )
+
+          val ingests = new MemoryMessageSender()
+          val outgoing = new MemoryMessageSender()
+
+          withLocalSqsQueue { queue =>
+
+            withAuditorWorker(
+              queue,
+              ingests,
+              outgoing,
+              stepName = "auditing bag") { _ =>
+
+              // Send the initial payload with "create" and check it completes
+              sendNotificationToSQS(queue, payload1)
+
+              eventually {
+                assertQueueEmpty(queue)
+
+                outgoing.getMessages[EnrichedBagInformationPayload] should have size 1
+
+                assertTopicReceivesIngestEvents(
+                  payload1.ingestId,
+                  ingests,
+                  expectedDescriptions = Seq(
+                    "Auditing bag started",
+                    s"Detected bag identifier as ${bagInfo.externalIdentifier}",
+                    s"Assigned bag version 1",
+                    "Auditing bag succeeded"
+                  )
+                )
+              }
+
+              // Now send the payload with "update"
+              sendNotificationToSQS(queue, payload2)
+
+              eventually {
+                assertQueueEmpty(queue)
+
+                outgoing.getMessages[EnrichedBagInformationPayload] should have size 2
+
+                assertTopicReceivesIngestEvents(
+                  payload1.ingestId,
+                  ingests,
+                  expectedDescriptions = Seq(
+                    "Auditing bag started",
+                    s"Detected bag identifier as ${bagInfo.externalIdentifier}",
+                    s"Assigned bag version 1",
+                    "Auditing bag succeeded",
+                    "Auditing bag started",
+                    s"Detected bag identifier as ${bagInfo.externalIdentifier}",
+                    s"Assigned bag version 2",
+                    "Auditing bag succeeded"
+                  )
+                )
+              }
             }
           }
       }

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
@@ -102,7 +102,7 @@ class BagAuditorFeatureTest
                 val ingestFailed =
                   ingestUpdates.tail.head.asInstanceOf[IngestStatusUpdate]
                 ingestFailed.status shouldBe Ingest.Failed
-                ingestFailed.events.head.description shouldBe "Auditing bag failed - Unable to find an external identifier"
+                ingestFailed.events.head.description shouldBe "Auditing bag failed - An external identifier was not found in the bag info"
             }
           }
       }

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
@@ -95,7 +95,7 @@ class BagAuditorFeatureTest
                 val ingestFailed =
                   ingestUpdates.tail.head.asInstanceOf[IngestStatusUpdate]
                 ingestFailed.status shouldBe Ingest.Failed
-                ingestFailed.events.head.description shouldBe "Auditing bag failed"
+                ingestFailed.events.head.description shouldBe "Auditing bag failed - Unable to find an external identifier"
             }
           }
       }

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/fixtures/VersionPickerFixtures.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/fixtures/VersionPickerFixtures.scala
@@ -2,17 +2,12 @@ package uk.ac.wellcome.platform.storage.bagauditor.fixtures
 
 import java.util.UUID
 
+import cats.Id
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.archive.common.versioning.{
-  IngestVersionManager,
-  IngestVersionManagerDao,
-  MemoryIngestVersionManagerDao
-}
+import uk.ac.wellcome.platform.archive.common.versioning.{IngestVersionManager, IngestVersionManagerDao, IngestVersionManagerError, MemoryIngestVersionManagerDao}
 import uk.ac.wellcome.platform.storage.bagauditor.versioning.VersionPicker
 import uk.ac.wellcome.storage.{LockDao, LockingService}
 import uk.ac.wellcome.storage.memory.MemoryLockDao
-
-import scala.util.Try
 
 trait VersionPickerFixtures {
   def createLockDao: MemoryLockDao[String, UUID] =
@@ -25,7 +20,7 @@ trait VersionPickerFixtures {
 
   def withVersionPicker[R](dao: LockDao[String, UUID])(
     testWith: TestWith[VersionPicker, R]): R = {
-    val lockingService = new LockingService[Int, Try, LockDao[String, UUID]] {
+    val lockingService = new LockingService[Either[IngestVersionManagerError, Int], Id, LockDao[String, UUID]] {
       override implicit val lockDao: LockDao[String, UUID] = dao
 
       override protected def createContextId(): UUID = UUID.randomUUID()

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/fixtures/VersionPickerFixtures.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/fixtures/VersionPickerFixtures.scala
@@ -4,7 +4,12 @@ import java.util.UUID
 
 import cats.Id
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.archive.common.versioning.{IngestVersionManager, IngestVersionManagerDao, IngestVersionManagerError, MemoryIngestVersionManagerDao}
+import uk.ac.wellcome.platform.archive.common.versioning.{
+  IngestVersionManager,
+  IngestVersionManagerDao,
+  IngestVersionManagerError,
+  MemoryIngestVersionManagerDao
+}
 import uk.ac.wellcome.platform.storage.bagauditor.versioning.VersionPicker
 import uk.ac.wellcome.storage.{LockDao, LockingService}
 import uk.ac.wellcome.storage.memory.MemoryLockDao
@@ -20,7 +25,10 @@ trait VersionPickerFixtures {
 
   def withVersionPicker[R](dao: LockDao[String, UUID])(
     testWith: TestWith[VersionPicker, R]): R = {
-    val lockingService = new LockingService[Either[IngestVersionManagerError, Int], Id, LockDao[String, UUID]] {
+    val lockingService = new LockingService[
+      Either[IngestVersionManagerError, Int],
+      Id,
+      LockDao[String, UUID]] {
       override implicit val lockDao: LockDao[String, UUID] = dao
 
       override protected def createContextId(): UUID = UUID.randomUUID()

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorTest.scala
@@ -4,10 +4,16 @@ import java.time.Instant
 
 import org.scalatest.{FunSpec, Matchers, TryValues}
 import uk.ac.wellcome.platform.archive.common.fixtures.BagLocationFixtures
-import uk.ac.wellcome.platform.archive.common.ingests.models.{CreateIngestType, UpdateIngestType}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  CreateIngestType,
+  UpdateIngestType
+}
 import uk.ac.wellcome.platform.archive.common.storage.models.IngestFailed
 import uk.ac.wellcome.platform.storage.bagauditor.fixtures.BagAuditorFixtures
-import uk.ac.wellcome.platform.storage.bagauditor.models.{AuditFailureSummary, AuditSuccessSummary}
+import uk.ac.wellcome.platform.storage.bagauditor.models.{
+  AuditFailureSummary,
+  AuditSuccessSummary
+}
 
 class BagAuditorTest
     extends FunSpec
@@ -83,7 +89,8 @@ class BagAuditorTest
 
             val ingestFailed = result.asInstanceOf[IngestFailed[_]]
             ingestFailed.summary shouldBe a[AuditFailureSummary]
-            ingestFailed.maybeUserFacingMessage shouldBe Some("Unable to find an external identifier")
+            ingestFailed.maybeUserFacingMessage shouldBe Some(
+              "Unable to find an external identifier")
           }
       }
     }
@@ -108,7 +115,8 @@ class BagAuditorTest
 
             val ingestFailed = result.asInstanceOf[IngestFailed[_]]
             ingestFailed.summary shouldBe a[AuditFailureSummary]
-            ingestFailed.maybeUserFacingMessage shouldBe Some("This bag has never been ingested before, but was sent with ingestType update")
+            ingestFailed.maybeUserFacingMessage shouldBe Some(
+              "This bag has never been ingested before, but was sent with ingestType update")
           }
       }
     }
@@ -141,7 +149,8 @@ class BagAuditorTest
 
             val ingestFailed = result.asInstanceOf[IngestFailed[_]]
             ingestFailed.summary shouldBe a[AuditFailureSummary]
-            ingestFailed.maybeUserFacingMessage shouldBe Some("This bag has already been ingested, but was sent with ingestType create")
+            ingestFailed.maybeUserFacingMessage shouldBe Some(
+              "This bag has already been ingested, but was sent with ingestType create")
           }
       }
     }

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorTest.scala
@@ -25,6 +25,7 @@ class BagAuditorTest
             val maybeAudit = bagAuditor.getAuditSummary(
               ingestId = createIngestID,
               ingestDate = Instant.now,
+              ingestType = CreateIngestType,
               root = bagRootLocation,
               storageSpace = storageSpace
             )
@@ -45,6 +46,7 @@ class BagAuditorTest
       val maybeAudit = bagAuditor.getAuditSummary(
         ingestId = createIngestID,
         ingestDate = Instant.now,
+        ingestType = CreateIngestType,
         root = createObjectLocation,
         storageSpace = createStorageSpace
       )
@@ -70,6 +72,7 @@ class BagAuditorTest
             val maybeAudit = bagAuditor.getAuditSummary(
               ingestId = createIngestID,
               ingestDate = Instant.now,
+              ingestType = CreateIngestType,
               root = bagRootLocation,
               storageSpace = storageSpace
             )

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorTest.scala
@@ -90,7 +90,7 @@ class BagAuditorTest
             val ingestFailed = result.asInstanceOf[IngestFailed[_]]
             ingestFailed.summary shouldBe a[AuditFailureSummary]
             ingestFailed.maybeUserFacingMessage shouldBe Some(
-              "Unable to find an external identifier")
+              "An external identifier was not found in the bag info")
           }
       }
     }
@@ -116,7 +116,7 @@ class BagAuditorTest
             val ingestFailed = result.asInstanceOf[IngestFailed[_]]
             ingestFailed.summary shouldBe a[AuditFailureSummary]
             ingestFailed.maybeUserFacingMessage shouldBe Some(
-              "This bag has never been ingested before, but was sent with ingestType update")
+              "Cannot update existing bag: a bag with the supplied external identifier does not exist in this space")
           }
       }
     }
@@ -150,7 +150,7 @@ class BagAuditorTest
             val ingestFailed = result.asInstanceOf[IngestFailed[_]]
             ingestFailed.summary shouldBe a[AuditFailureSummary]
             ingestFailed.maybeUserFacingMessage shouldBe Some(
-              "This bag has already been ingested, but was sent with ingestType create")
+              "Cannot create new bag: a bag with the supplied external identifier already exists in this space")
           }
       }
     }

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorTest.scala
@@ -58,7 +58,7 @@ class BagAuditorTest
     }
   }
 
-  it("errors if it cannot find the bag identifier") {
+  it("errors if it cannot find the external identifier") {
     withLocalS3Bucket { bucket =>
       withBag(bucket) {
         case (bagRootLocation, storageSpace) =>
@@ -79,7 +79,10 @@ class BagAuditorTest
             val result = maybeAudit.success.get
 
             result shouldBe a[IngestFailed[_]]
-            result.summary shouldBe a[AuditFailureSummary]
+
+            val ingestFailed = result.asInstanceOf[IngestFailed[_]]
+            ingestFailed.summary shouldBe a[AuditFailureSummary]
+            ingestFailed.maybeUserFacingMessage shouldBe Some("Unable to find an external identifier")
           }
       }
     }

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorTest.scala
@@ -4,12 +4,10 @@ import java.time.Instant
 
 import org.scalatest.{FunSpec, Matchers, TryValues}
 import uk.ac.wellcome.platform.archive.common.fixtures.BagLocationFixtures
+import uk.ac.wellcome.platform.archive.common.ingests.models.UpdateIngestType
 import uk.ac.wellcome.platform.archive.common.storage.models.IngestFailed
 import uk.ac.wellcome.platform.storage.bagauditor.fixtures.BagAuditorFixtures
-import uk.ac.wellcome.platform.storage.bagauditor.models.{
-  AuditFailureSummary,
-  AuditSuccessSummary
-}
+import uk.ac.wellcome.platform.storage.bagauditor.models.{AuditFailureSummary, AuditSuccessSummary}
 
 class BagAuditorTest
     extends FunSpec
@@ -83,6 +81,31 @@ class BagAuditorTest
             val ingestFailed = result.asInstanceOf[IngestFailed[_]]
             ingestFailed.summary shouldBe a[AuditFailureSummary]
             ingestFailed.maybeUserFacingMessage shouldBe Some("Unable to find an external identifier")
+          }
+      }
+    }
+  }
+
+  it("fails if you ask for ingestType 'update' on a new bag") {
+    withLocalS3Bucket { bucket =>
+      withBag(bucket) {
+        case (bagRootLocation, storageSpace) =>
+          withBagAuditor { bagAuditor =>
+            val maybeAudit = bagAuditor.getAuditSummary(
+              ingestId = createIngestID,
+              ingestDate = Instant.now,
+              ingestType = UpdateIngestType,
+              root = bagRootLocation,
+              storageSpace = storageSpace
+            )
+
+            val result = maybeAudit.success.get
+
+            result shouldBe a[IngestFailed[_]]
+
+            val ingestFailed = result.asInstanceOf[IngestFailed[_]]
+            ingestFailed.summary shouldBe a[AuditFailureSummary]
+            ingestFailed.maybeUserFacingMessage shouldBe Some("This bag has never been ingested before, but was sent with ingestType update")
           }
       }
     }

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/versioning/VersionPickerTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/versioning/VersionPickerTest.scala
@@ -205,14 +205,14 @@ class VersionPickerTest
           externalIdentifier = externalIdentifier,
           ingestId = createIngestID,
           ingestType = CreateIngestType,
-          ingestDate = Instant.now()
+          ingestDate = Instant.ofEpochSecond(1)
         )
 
         val result = picker.chooseVersion(
           externalIdentifier = externalIdentifier,
           ingestId = createIngestID,
           ingestType = CreateIngestType,
-          ingestDate = Instant.now()
+          ingestDate = Instant.ofEpochSecond(2)
         )
 
         result.left.value shouldBe IngestTypeCreateForExistingBag()

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/versioning/VersionPickerTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/versioning/VersionPickerTest.scala
@@ -167,7 +167,26 @@ class VersionPickerTest
   }
 
   it("errors if there's an existing ingest with the wrong external identifier") {
-    true shouldBe false
+    withVersionPicker { picker =>
+      val ingestId = createIngestID
+
+      picker.chooseVersion(
+        externalIdentifier = createExternalIdentifier,
+        ingestId = ingestId,
+        ingestDate = Instant.now()
+      )
+
+      val result = picker.chooseVersion(
+        externalIdentifier = createExternalIdentifier,
+        ingestId = ingestId,
+        ingestDate = Instant.now()
+      )
+
+      result.left.value shouldBe a[InternalVersionPickerError]
+
+      val err = result.left.value.asInstanceOf[InternalVersionPickerError]
+      err.e.getMessage should startWith("External identifiers don't match")
+    }
   }
 
   describe("checking the ingest type") {

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/versioning/VersionPickerTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/versioning/VersionPickerTest.scala
@@ -5,8 +5,14 @@ import java.util.UUID
 
 import org.scalatest.{EitherValues, FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.common.generators.ExternalIdentifierGenerators
-import uk.ac.wellcome.platform.archive.common.ingests.models.{CreateIngestType, UpdateIngestType}
-import uk.ac.wellcome.platform.archive.common.versioning.{ExternalIdentifiersMismatch, NewerIngestAlreadyExists}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  CreateIngestType,
+  UpdateIngestType
+}
+import uk.ac.wellcome.platform.archive.common.versioning.{
+  ExternalIdentifiersMismatch,
+  NewerIngestAlreadyExists
+}
 import uk.ac.wellcome.platform.storage.bagauditor.fixtures.VersionPickerFixtures
 import uk.ac.wellcome.platform.storage.bagauditor.models._
 import uk.ac.wellcome.storage.{LockDao, LockFailure, UnlockFailure}
@@ -80,20 +86,26 @@ class VersionPickerTest
     withVersionPicker { picker =>
       val externalIdentifier = createExternalIdentifier
 
-      picker.chooseVersion(
-        externalIdentifier = externalIdentifier,
-        ingestId = createIngestID,
-        ingestType = CreateIngestType,
-        ingestDate = Instant.ofEpochSecond(1)
-      ).right.value shouldBe 1
-
-      (2 to 5).map { t =>
-        picker.chooseVersion(
+      picker
+        .chooseVersion(
           externalIdentifier = externalIdentifier,
           ingestId = createIngestID,
-          ingestType = UpdateIngestType,
-          ingestDate = Instant.ofEpochSecond(t)
-        ).right.value shouldBe t
+          ingestType = CreateIngestType,
+          ingestDate = Instant.ofEpochSecond(1)
+        )
+        .right
+        .value shouldBe 1
+
+      (2 to 5).map { t =>
+        picker
+          .chooseVersion(
+            externalIdentifier = externalIdentifier,
+            ingestId = createIngestID,
+            ingestType = UpdateIngestType,
+            ingestDate = Instant.ofEpochSecond(t)
+          )
+          .right
+          .value shouldBe t
       }
     }
   }

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/versioning/VersionPickerTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/versioning/VersionPickerTest.scala
@@ -6,8 +6,9 @@ import java.util.UUID
 import org.scalatest.{EitherValues, FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.common.generators.ExternalIdentifierGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.models.{CreateIngestType, UpdateIngestType}
+import uk.ac.wellcome.platform.archive.common.versioning.{ExternalIdentifiersMismatch, NewerIngestAlreadyExists}
 import uk.ac.wellcome.platform.storage.bagauditor.fixtures.VersionPickerFixtures
-import uk.ac.wellcome.platform.storage.bagauditor.models.{IngestTypeCreateForExistingBag, IngestTypeUpdateForNewBag, InternalVersionPickerError, VersionPickerError}
+import uk.ac.wellcome.platform.storage.bagauditor.models._
 import uk.ac.wellcome.storage.{LockDao, LockFailure, UnlockFailure}
 
 class VersionPickerTest
@@ -115,10 +116,10 @@ class VersionPickerTest
           ingestDate = Instant.ofEpochSecond(t)
         )
 
-        result.left.value shouldBe a[InternalVersionPickerError]
+        result.left.value shouldBe a[UnableToAssignVersion]
 
-        val err = result.left.value.asInstanceOf[InternalVersionPickerError]
-        err.e.getMessage should startWith("Latest version has a newer ingest date")
+        val err = result.left.value.asInstanceOf[UnableToAssignVersion]
+        err.e shouldBe a[NewerIngestAlreadyExists]
       }
     }
   }
@@ -189,10 +190,10 @@ class VersionPickerTest
         ingestDate = Instant.now()
       )
 
-      result.left.value shouldBe a[InternalVersionPickerError]
+      result.left.value shouldBe a[UnableToAssignVersion]
 
-      val err = result.left.value.asInstanceOf[InternalVersionPickerError]
-      err.e.getMessage should startWith("External identifiers don't match")
+      val err = result.left.value.asInstanceOf[UnableToAssignVersion]
+      err.e shouldBe a[ExternalIdentifiersMismatch]
     }
   }
 

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/versioning/VersionPickerTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/versioning/VersionPickerTest.scala
@@ -22,6 +22,7 @@ class VersionPickerTest
       val result = picker.chooseVersion(
         externalIdentifier = createExternalIdentifier,
         ingestId = createIngestID,
+        ingestType = CreateIngestType,
         ingestDate = Instant.now()
       )
 
@@ -102,6 +103,7 @@ class VersionPickerTest
       picker.chooseVersion(
         externalIdentifier = externalIdentifier,
         ingestId = createIngestID,
+        ingestType = CreateIngestType,
         ingestDate = Instant.now()
       )
 
@@ -109,6 +111,7 @@ class VersionPickerTest
         val result = picker.chooseVersion(
           externalIdentifier = externalIdentifier,
           ingestId = createIngestID,
+          ingestType = UpdateIngestType,
           ingestDate = Instant.ofEpochSecond(t)
         )
 
@@ -130,6 +133,7 @@ class VersionPickerTest
       picker.chooseVersion(
         externalIdentifier = externalIdentifier,
         ingestId = ingestId,
+        ingestType = CreateIngestType,
         ingestDate = Instant.now()
       )
 
@@ -156,6 +160,7 @@ class VersionPickerTest
       val result: Either[VersionPickerError, Int] = picker.chooseVersion(
         externalIdentifier = createExternalIdentifier,
         ingestId = createIngestID,
+        ingestType = CreateIngestType,
         ingestDate = Instant.now()
       )
 
@@ -173,12 +178,14 @@ class VersionPickerTest
       picker.chooseVersion(
         externalIdentifier = createExternalIdentifier,
         ingestId = ingestId,
+        ingestType = CreateIngestType,
         ingestDate = Instant.now()
       )
 
       val result = picker.chooseVersion(
         externalIdentifier = createExternalIdentifier,
         ingestId = ingestId,
+        ingestType = UpdateIngestType,
         ingestDate = Instant.now()
       )
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/versioning/IngestVersionManager.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/versioning/IngestVersionManager.scala
@@ -5,7 +5,7 @@ import java.time.Instant
 import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
 
-import scala.util.{Success, Try}
+import scala.util.{Failure, Success}
 
 trait IngestVersionManager {
   val dao: IngestVersionManagerDao
@@ -14,50 +14,74 @@ trait IngestVersionManager {
     externalIdentifier: ExternalIdentifier,
     ingestId: IngestID,
     ingestDate: Instant
-  ): Try[Int] =
-    dao.lookupLatestVersionFor(externalIdentifier).flatMap { maybeRecord =>
-      Try {
-        val newVersion: Int = maybeRecord match {
-          case Some(existingRecord) =>
-            if (existingRecord.ingestDate.isBefore(ingestDate))
-              existingRecord.version + 1
-            else
-              throw new RuntimeException(
-                s"Latest version has a newer ingest date: ${existingRecord.ingestDate} (stored) > $ingestDate (request)")
-          case None => 1
-        }
+  ): Either[IngestVersionManagerError, Int] =
+    dao.lookupLatestVersionFor(externalIdentifier) match {
+      case Success(Some(existingRecord)) =>
+        if (existingRecord.ingestDate.isBefore(ingestDate))
+          storeNewVersion(
+            externalIdentifier = externalIdentifier,
+            ingestId = ingestId,
+            ingestDate = ingestDate,
+            newVersion = existingRecord.version + 1
+          )
+        else
+          Left(NewerIngestAlreadyExists(
+            stored = existingRecord.ingestDate,
+            request = ingestDate
+          ))
 
-        val newRecord = VersionRecord(
+      case Success(None) =>
+        storeNewVersion(
           externalIdentifier = externalIdentifier,
           ingestId = ingestId,
           ingestDate = ingestDate,
-          version = newVersion
+          newVersion = 1
         )
 
-        dao.storeNewVersion(newRecord)
-
-        newVersion
-      }
+      case Failure(err) => Left(InternalVersionManagerError(err))
     }
+
+  private def storeNewVersion(
+    externalIdentifier: ExternalIdentifier,
+    ingestId: IngestID,
+    ingestDate: Instant,
+    newVersion: Int
+  ): Either[InternalVersionManagerError, Int] = {
+    val newRecord = VersionRecord(
+      externalIdentifier = externalIdentifier,
+      ingestId = ingestId,
+      ingestDate = ingestDate,
+      version = newVersion
+    )
+
+    dao.storeNewVersion(newRecord) match {
+      case Success(_)   => Right(newVersion)
+      case Failure(err) => Left(InternalVersionManagerError(err))
+    }
+  }
 
   def assignVersion(
     externalIdentifier: ExternalIdentifier,
     ingestId: IngestID,
     ingestDate: Instant
-  ): Try[Int] =
-    dao.lookupExistingVersion(ingestId).flatMap {
-      case Some(existingRecord) =>
+  ): Either[IngestVersionManagerError, Int] =
+    dao.lookupExistingVersion(ingestId) match {
+      case Success(Some(existingRecord)) =>
         if (existingRecord.externalIdentifier == externalIdentifier)
-          Success(existingRecord.version)
+          Right(existingRecord.version)
         else
-          throw new RuntimeException(
-            s"External identifiers don't match: ${existingRecord.externalIdentifier} (stored) != $externalIdentifier (request)")
+          Left(ExternalIdentifiersMismatch(
+            stored = existingRecord.externalIdentifier,
+            request = externalIdentifier
+          ))
 
-      case None =>
+      case Success(None) =>
         createNewVersionFor(
           externalIdentifier = externalIdentifier,
           ingestId = ingestId,
           ingestDate = ingestDate
         )
+
+      case Failure(err) => Left(InternalVersionManagerError(err))
     }
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/versioning/IngestVersionManager.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/versioning/IngestVersionManager.scala
@@ -25,10 +25,11 @@ trait IngestVersionManager {
             newVersion = existingRecord.version + 1
           )
         else
-          Left(NewerIngestAlreadyExists(
-            stored = existingRecord.ingestDate,
-            request = ingestDate
-          ))
+          Left(
+            NewerIngestAlreadyExists(
+              stored = existingRecord.ingestDate,
+              request = ingestDate
+            ))
 
       case Success(None) =>
         storeNewVersion(
@@ -70,10 +71,11 @@ trait IngestVersionManager {
         if (existingRecord.externalIdentifier == externalIdentifier)
           Right(existingRecord.version)
         else
-          Left(ExternalIdentifiersMismatch(
-            stored = existingRecord.externalIdentifier,
-            request = externalIdentifier
-          ))
+          Left(
+            ExternalIdentifiersMismatch(
+              stored = existingRecord.externalIdentifier,
+              request = externalIdentifier
+            ))
 
       case Success(None) =>
         createNewVersionFor(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/versioning/IngestVersionManagerError.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/versioning/IngestVersionManagerError.scala
@@ -6,8 +6,12 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
 
 sealed trait IngestVersionManagerError
 
-case class InternalVersionManagerError(e: Throwable) extends IngestVersionManagerError
+case class InternalVersionManagerError(e: Throwable)
+    extends IngestVersionManagerError
 
-case class ExternalIdentifiersMismatch(stored: ExternalIdentifier, request: ExternalIdentifier) extends IngestVersionManagerError
+case class ExternalIdentifiersMismatch(stored: ExternalIdentifier,
+                                       request: ExternalIdentifier)
+    extends IngestVersionManagerError
 
-case class NewerIngestAlreadyExists(stored: Instant, request: Instant) extends IngestVersionManagerError
+case class NewerIngestAlreadyExists(stored: Instant, request: Instant)
+    extends IngestVersionManagerError

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/versioning/IngestVersionManagerError.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/versioning/IngestVersionManagerError.scala
@@ -1,0 +1,13 @@
+package uk.ac.wellcome.platform.archive.common.versioning
+
+import java.time.Instant
+
+import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
+
+sealed trait IngestVersionManagerError
+
+case class InternalVersionManagerError(e: Throwable) extends IngestVersionManagerError
+
+case class ExternalIdentifiersMismatch(stored: ExternalIdentifier, request: ExternalIdentifier) extends IngestVersionManagerError
+
+case class NewerIngestAlreadyExists(stored: Instant, request: Instant) extends IngestVersionManagerError

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -4,7 +4,12 @@ import java.time.Instant
 
 import uk.ac.wellcome.platform.archive.common._
 import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
-import uk.ac.wellcome.platform.archive.common.ingests.models.{CreateIngestType, IngestID, IngestType, UpdateIngestType}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  CreateIngestType,
+  IngestID,
+  IngestType,
+  UpdateIngestType
+}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.generators.ObjectLocationGenerators

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -4,27 +4,30 @@ import java.time.Instant
 
 import uk.ac.wellcome.platform.archive.common._
 import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  CreateIngestType,
-  IngestID
-}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{CreateIngestType, IngestID, IngestType, UpdateIngestType}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
+
+import scala.util.Random
 
 trait PayloadGenerators
     extends ExternalIdentifierGenerators
     with StorageSpaceGenerators
     with ObjectLocationGenerators {
 
+  def randomIngestType: IngestType =
+    Seq(CreateIngestType, UpdateIngestType)(Random.nextInt(1))
+
   def createPipelineContextWith(
     ingestId: IngestID = createIngestID,
+    ingestType: IngestType = randomIngestType,
     ingestDate: Instant = Instant.now(),
     storageSpace: StorageSpace = createStorageSpace
   ): PipelineContext =
     PipelineContext(
       ingestId = ingestId,
-      ingestType = CreateIngestType,
+      ingestType = ingestType,
       storageSpace = storageSpace,
       ingestDate = ingestDate
     )

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/fixtures/IngestUpdateAssertions.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/fixtures/IngestUpdateAssertions.scala
@@ -56,7 +56,7 @@ trait IngestUpdateAssertions extends Inside with Logging with Matchers {
           .map { _.description }
           .distinct
 
-      eventDescriptions should contain theSameElementsAs expectedDescriptions
+      eventDescriptions should contain theSameElementsAs expectedDescriptions.distinct
     }
 
   def assertTopicReceivesIngestEvent(ingestId: IngestID,

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/versioning/IngestVersionManagerTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/versioning/IngestVersionManagerTest.scala
@@ -46,11 +46,14 @@ class IngestVersionManagerTest
   it("assigns version 1 if it hasn't seen this external ID before") {
     val manager = new MemoryIngestVersionManager()
 
-    manager.assignVersion(
-      externalIdentifier = createExternalIdentifier,
-      ingestId = createIngestID,
-      ingestDate = Instant.now
-    ).right.value shouldBe 1
+    manager
+      .assignVersion(
+        externalIdentifier = createExternalIdentifier,
+        ingestId = createIngestID,
+        ingestDate = Instant.now
+      )
+      .right
+      .value shouldBe 1
   }
 
   it("assigns increasing versions if it sees newer ingest dates each time") {
@@ -59,11 +62,14 @@ class IngestVersionManagerTest
     val externalIdentifier = createExternalIdentifier
 
     (1 to 5).map { version =>
-      manager.assignVersion(
-        externalIdentifier = externalIdentifier,
-        ingestId = createIngestID,
-        ingestDate = Instant.ofEpochSecond(version)
-      ).right.value shouldBe version
+      manager
+        .assignVersion(
+          externalIdentifier = externalIdentifier,
+          ingestId = createIngestID,
+          ingestDate = Instant.ofEpochSecond(version)
+        )
+        .right
+        .value shouldBe version
     }
   }
 
@@ -84,18 +90,22 @@ class IngestVersionManagerTest
             ingestId = ingestId,
             ingestDate = Instant.ofEpochSecond(idx)
           )
-          .right.value
+          .right
+          .value
 
         (idx, ingestId, version)
     }
 
     assignedVersions.foreach {
       case (idx, ingestId, version) =>
-        manager.assignVersion(
-          externalIdentifier = externalIdentifier,
-          ingestId = ingestId,
-          ingestDate = Instant.ofEpochSecond(idx)
-        ).right.value shouldBe version
+        manager
+          .assignVersion(
+            externalIdentifier = externalIdentifier,
+            ingestId = ingestId,
+            ingestDate = Instant.ofEpochSecond(idx)
+          )
+          .right
+          .value shouldBe version
     }
   }
 


### PR DESCRIPTION
Closes wellcometrust/platform#3657, and possibly wellcometrust/platform#3499?

It includes some new user-facing messages in the ingests response:

> Unable to find an external identifier
>
> This bag has never been ingested before, but was sent with ingestType update
>
> This bag has already been ingested, but was sent with ingestType create
>
> Another version of this bag was ingested at ${e.stored}, which is newer than the current ingest ${e.request}

I discovered wellcometrust/platform#3693 while working on this.