### PR TITLE
Distinguish between “there’s no bag-info.txt” and “the bag-info.txt has the wrong contents”

### DIFF
--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/UserFacingMessages.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/UserFacingMessages.scala
@@ -2,6 +2,7 @@ package uk.ac.wellcome.platform.storage.bagauditor.services
 
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
+import uk.ac.wellcome.platform.archive.common.storage.StreamUnavailable
 import uk.ac.wellcome.platform.archive.common.versioning.{
   ExternalIdentifiersMismatch,
   NewerIngestAlreadyExists
@@ -12,6 +13,11 @@ object UserFacingMessages extends Logging {
   def createMessage(ingestId: IngestID,
                     auditError: AuditError): Option[String] =
     auditError match {
+      case CannotFindExternalIdentifier(err: StreamUnavailable) =>
+        info(
+          s"Could not find bag-info to parse an external identifier for $ingestId: $err")
+        Some("Could not find a bag-info file in the bag")
+
       case CannotFindExternalIdentifier(err) =>
         info(
           s"Unable to find an external identifier for $ingestId. Error: $err")

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
@@ -102,7 +102,7 @@ class BagAuditorFeatureTest
                 val ingestFailed =
                   ingestUpdates.tail.head.asInstanceOf[IngestStatusUpdate]
                 ingestFailed.status shouldBe Ingest.Failed
-                ingestFailed.events.head.description shouldBe "Auditing bag failed - An external identifier was not found in the bag info"
+                ingestFailed.events.head.description shouldBe "Auditing bag failed - Could not find a bag-info file in the bag"
             }
           }
       }


### PR DESCRIPTION
Closes https://github.com/wellcometrust/platform/issues/3695

Along the way, I discovered that the bag auditor was still doing bag root detection, even though it's not supposed to. Ditch that!