### PR TITLE
Change the ingests API to reflect the RFC

### DIFF
--- a/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestStarter.scala
+++ b/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestStarter.scala
@@ -17,7 +17,7 @@ class IngestStarter[UnpackerDestination](
       ingest <- ingestTracker.init(ingest) match {
         case Right(result) => Success(result.identifiedT)
         case Left(err) =>
-          Failure(new Throwable(s"Error form the ingest tracker: $err"))
+          Failure(new Throwable(s"Error from the ingest tracker: $err"))
       }
       _ <- unpackerMessageSender.sendT(SourceLocationPayload(ingest))
     } yield ingest

--- a/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/Router.scala
+++ b/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/Router.scala
@@ -52,7 +52,10 @@ class Router[UnpackerDestination](
           ingestStarter.initialise(requestDisplayIngest.toIngest) match {
             case Success(ingest) =>
               respondWithHeaders(List(createLocationHeader(ingest))) {
-                complete(StatusCodes.Created -> ResponseDisplayIngest(ingest, contextURL))
+                complete(
+                  StatusCodes.Created -> ResponseDisplayIngest(
+                    ingest,
+                    contextURL))
               }
             case Failure(err) =>
               error(

--- a/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/Router.scala
+++ b/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/Router.scala
@@ -4,7 +4,6 @@ import java.net.URL
 import java.util.UUID
 
 import akka.http.scaladsl.model.StatusCodes
-import akka.http.scaladsl.model.StatusCodes._
 import akka.http.scaladsl.model.headers.Location
 import akka.http.scaladsl.server._
 import grizzled.slf4j.Logging
@@ -30,6 +29,8 @@ import uk.ac.wellcome.platform.archive.display.{
   ResponseDisplayIngest
 }
 
+import scala.util.{Failure, Success}
+
 class Router[UnpackerDestination](
   ingestTracker: IngestTracker,
   ingestStarter: IngestStarter[UnpackerDestination],
@@ -49,16 +50,16 @@ class Router[UnpackerDestination](
         entity(as[RequestDisplayIngest]) { requestDisplayIngest =>
           // TODO: Do we have a test for the failure case?
           ingestStarter.initialise(requestDisplayIngest.toIngest) match {
-            case scala.util.Success(ingest) =>
+            case Success(ingest) =>
               respondWithHeaders(List(createLocationHeader(ingest))) {
-                complete(Created -> ResponseDisplayIngest(ingest, contextURL))
+                complete(StatusCodes.Created -> ResponseDisplayIngest(ingest, contextURL))
               }
-            case scala.util.Failure(err) =>
+            case Failure(err) =>
               error(
                 s"Unexpected error while creating an ingest $requestDisplayIngest",
                 err)
               complete(
-                InternalServerError -> InternalServerErrorResponse(
+                StatusCodes.InternalServerError -> InternalServerErrorResponse(
                   contextURL,
                   statusCode = StatusCodes.InternalServerError
                 )
@@ -73,7 +74,7 @@ class Router[UnpackerDestination](
               complete(ResponseDisplayIngest(ingest.identifiedT, contextURL))
             case Left(_: IngestDoesNotExistError) =>
               complete(
-                NotFound -> UserErrorResponse(
+                StatusCodes.NotFound -> UserErrorResponse(
                   context = contextURL,
                   statusCode = StatusCodes.NotFound,
                   description = s"Ingest $id not found"
@@ -81,7 +82,7 @@ class Router[UnpackerDestination](
             case Left(err) =>
               error(s"Unexpected error while fetching ingest $id: $err")
               complete(
-                InternalServerError -> InternalServerErrorResponse(
+                StatusCodes.InternalServerError -> InternalServerErrorResponse(
                   contextURL,
                   statusCode = StatusCodes.InternalServerError
                 )
@@ -111,17 +112,17 @@ class Router[UnpackerDestination](
     ingestTracker.listByBagId(bagId) match {
       case Right(results) =>
         if (results.nonEmpty) {
-          complete(OK -> results.map { DisplayIngestMinimal(_) })
+          complete(StatusCodes.OK -> results.map { DisplayIngestMinimal(_) })
         } else {
-          complete(NotFound -> List[DisplayIngestMinimal]())
+          complete(StatusCodes.NotFound -> List[DisplayIngestMinimal]())
         }
 
       case Left(err) =>
         warn(s"""errors fetching ingests for $bagId: $err""")
         complete(
-          InternalServerError -> InternalServerErrorResponse(
+          StatusCodes.InternalServerError -> InternalServerErrorResponse(
             context = contextURL,
-            statusCode = InternalServerError
+            statusCode = StatusCodes.InternalServerError
           )
         )
     }

--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestStarterTest.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestStarterTest.scala
@@ -53,7 +53,8 @@ class IngestStarterTest
       withIngestStarter(ingestTracker, messageSender) { ingestStarter =>
         val result = ingestStarter.initialise(ingest)
         result.failed shouldBe a[Success[_]]
-        result.failed.get.getMessage should startWith("Error from the ingest tracker: IngestAlreadyExistsError")
+        result.failed.get.getMessage should startWith(
+          "Error from the ingest tracker: IngestAlreadyExistsError")
 
         messageSender.messages shouldBe empty
       }

--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
@@ -625,7 +625,13 @@ class IngestsApiFeatureTest
           |  "callback": {
           |    "url": "${testCallbackUri.toString}"
           |  },
-          |  "externalIdentifier": "${externalIdentifier.underlying}"
+          |  "bag": {
+          |    "type": "Bag",
+          |    "info": {
+          |      "type": "BagInfo",
+          |      "externalIdentifier": "${externalIdentifier.underlying}"
+          |    }
+          |  }
           |}""".stripMargin
     ).right.value
 

--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
@@ -283,9 +283,7 @@ class IngestsApiFeatureTest
               messageSender.getMessages[SourceLocationPayload].head
             payload.context.ingestType shouldBe CreateIngestType
 
-            assertMetricSent(
-              metricsSender,
-              result = HttpMetricResults.Success)
+            assertMetricSent(metricsSender, result = HttpMetricResults.Success)
           }
       }
     }
@@ -309,9 +307,7 @@ class IngestsApiFeatureTest
             val payload = messageSender.getMessages[SourceLocationPayload].head
             payload.context.ingestType shouldBe UpdateIngestType
 
-            assertMetricSent(
-              metricsSender,
-              result = HttpMetricResults.Success)
+            assertMetricSent(metricsSender, result = HttpMetricResults.Success)
           }
       }
     }
@@ -327,7 +323,8 @@ class IngestsApiFeatureTest
 
           assertCatchesMalformedRequest(
             badJson(json).noSpaces,
-            expectedMessage = "Invalid value at .ingestType: required property not supplied."
+            expectedMessage =
+              "Invalid value at .ingestType: required property not supplied."
           )
         }
 
@@ -338,7 +335,8 @@ class IngestsApiFeatureTest
 
           assertCatchesMalformedRequest(
             badJson(json).noSpaces,
-            expectedMessage = "Invalid value at .ingestType.id: required property not supplied."
+            expectedMessage =
+              "Invalid value at .ingestType.id: required property not supplied."
           )
         }
 
@@ -363,7 +361,8 @@ class IngestsApiFeatureTest
 
           assertCatchesMalformedRequest(
             badJson(json).noSpaces,
-            expectedMessage = "Invalid value at .space: required property not supplied."
+            expectedMessage =
+              "Invalid value at .space: required property not supplied."
           )
         }
 
@@ -374,7 +373,8 @@ class IngestsApiFeatureTest
 
           assertCatchesMalformedRequest(
             badJson(json).noSpaces,
-            expectedMessage = "Invalid value at .space.id: required property not supplied."
+            expectedMessage =
+              "Invalid value at .space.id: required property not supplied."
           )
         }
       }
@@ -387,7 +387,8 @@ class IngestsApiFeatureTest
 
           assertCatchesMalformedRequest(
             badJson(json).noSpaces,
-            expectedMessage = "Invalid value at .bag: required property not supplied."
+            expectedMessage =
+              "Invalid value at .bag: required property not supplied."
           )
         }
 
@@ -398,7 +399,8 @@ class IngestsApiFeatureTest
 
           assertCatchesMalformedRequest(
             badJson(json).noSpaces,
-            expectedMessage = "Invalid value at .bag.info: required property not supplied."
+            expectedMessage =
+              "Invalid value at .bag.info: required property not supplied."
           )
         }
 
@@ -409,7 +411,8 @@ class IngestsApiFeatureTest
 
           assertCatchesMalformedRequest(
             badJson(json).noSpaces,
-            expectedMessage = "Invalid value at .bag.info.externalIdentifier: required property not supplied."
+            expectedMessage =
+              "Invalid value at .bag.info.externalIdentifier: required property not supplied."
           )
         }
       }
@@ -422,7 +425,8 @@ class IngestsApiFeatureTest
 
           assertCatchesMalformedRequest(
             badJson(json).noSpaces,
-            expectedMessage = "Invalid value at .sourceLocation: required property not supplied."
+            expectedMessage =
+              "Invalid value at .sourceLocation: required property not supplied."
           )
         }
 
@@ -433,7 +437,8 @@ class IngestsApiFeatureTest
 
           assertCatchesMalformedRequest(
             badJson(json).noSpaces,
-            expectedMessage = "Invalid value at .sourceLocation.provider: required property not supplied."
+            expectedMessage =
+              "Invalid value at .sourceLocation.provider: required property not supplied."
           )
         }
 
@@ -444,7 +449,8 @@ class IngestsApiFeatureTest
 
           assertCatchesMalformedRequest(
             badJson(json).noSpaces,
-            expectedMessage = "Invalid value at .sourceLocation.bucket: required property not supplied."
+            expectedMessage =
+              "Invalid value at .sourceLocation.bucket: required property not supplied."
           )
         }
 
@@ -455,7 +461,8 @@ class IngestsApiFeatureTest
 
           assertCatchesMalformedRequest(
             badJson(json).noSpaces,
-            expectedMessage = "Invalid value at .sourceLocation.path: required property not supplied."
+            expectedMessage =
+              "Invalid value at .sourceLocation.path: required property not supplied."
           )
         }
       }
@@ -463,7 +470,8 @@ class IngestsApiFeatureTest
       it("if the body is not valid JSON") {
         assertCatchesMalformedRequest(
           requestBody = "hgjh",
-          expectedMessage = "The request content was malformed:\nexpected json value got h (line 1, column 1)"
+          expectedMessage =
+            "The request content was malformed:\nexpected json value got h (line 1, column 1)"
         )
       }
 
@@ -471,7 +479,8 @@ class IngestsApiFeatureTest
         assertCatchesMalformedRequest(
           contentType = ContentTypes.`text/plain(UTF-8)`,
           expectedStatusCode = StatusCodes.UnsupportedMediaType,
-          expectedMessage = "The request's Content-Type is not supported. Expected:\napplication/json",
+          expectedMessage =
+            "The request's Content-Type is not supported. Expected:\napplication/json",
           expectedLabel = "Unsupported Media Type"
         )
       }
@@ -492,15 +501,16 @@ class IngestsApiFeatureTest
 
     it("returns a 500 Server Error if updating the ingest starter fails") {
       withMaterializer { implicit materializer =>
-        withBrokenApp { case (_, _, metricsSender, baseUrl) =>
-          whenPostRequestReady(s"$baseUrl/ingests/$randomUUID", createRequest) {
-            response =>
-              assertIsInternalServerErrorResponse(response)
+        withBrokenApp {
+          case (_, _, metricsSender, baseUrl) =>
+            whenPostRequestReady(s"$baseUrl/ingests/$randomUUID", createRequest) {
+              response =>
+                assertIsInternalServerErrorResponse(response)
 
-              assertMetricSent(
-                metricsSender,
-                result = HttpMetricResults.ServerError)
-          }
+                assertMetricSent(
+                  metricsSender,
+                  result = HttpMetricResults.ServerError)
+            }
         }
       }
     }
@@ -561,19 +571,20 @@ class IngestsApiFeatureTest
     }
 
     it("returns 'Not Found' if there are no ingests for the given bag id") {
-      withConfiguredApp() { case (_, _, metricsSender, baseUrl) =>
-        whenGetRequestReady(s"$baseUrl/ingests/find-by-bag-id/$randomUUID") {
-          response =>
-            response.status shouldBe StatusCodes.NotFound
-            response.entity.contentType shouldBe ContentTypes.`application/json`
+      withConfiguredApp() {
+        case (_, _, metricsSender, baseUrl) =>
+          whenGetRequestReady(s"$baseUrl/ingests/find-by-bag-id/$randomUUID") {
+            response =>
+              response.status shouldBe StatusCodes.NotFound
+              response.entity.contentType shouldBe ContentTypes.`application/json`
 
-            getT[List[DisplayIngestMinimal]](response.entity) shouldBe empty
+              getT[List[DisplayIngestMinimal]](response.entity) shouldBe empty
 
-            assertMetricSent(
-              metricsSender,
-              result = HttpMetricResults.UserError
-            )
-        }
+              assertMetricSent(
+                metricsSender,
+                result = HttpMetricResults.UserError
+              )
+          }
       }
     }
   }
@@ -667,9 +678,7 @@ class IngestsApiFeatureTest
 
           messageSender.messages shouldBe empty
 
-          assertMetricSent(
-            metricsSender,
-            result = HttpMetricResults.UserError)
+          assertMetricSent(metricsSender, result = HttpMetricResults.UserError)
         }
     }
   }

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayBag.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayBag.scala
@@ -1,0 +1,14 @@
+package uk.ac.wellcome.platform.archive.display
+
+import io.circe.generic.extras.JsonKey
+import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
+
+case class DisplayBag(
+  info: DisplayBagInfo,
+  @JsonKey("type") ontologyType: String
+)
+
+case class DisplayBagInfo(
+  externalIdentifier: ExternalIdentifier,
+  @JsonKey("type") ontologyType: String
+)

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayBag.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayBag.scala
@@ -5,10 +5,10 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
 
 case class DisplayBag(
   info: DisplayBagInfo,
-  @JsonKey("type") ontologyType: String
+  @JsonKey("type") ontologyType: String = "Bag"
 )
 
 case class DisplayBagInfo(
   externalIdentifier: ExternalIdentifier,
-  @JsonKey("type") ontologyType: String
+  @JsonKey("type") ontologyType: String = "BagInfo"
 )

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayIngest.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayIngest.scala
@@ -41,7 +41,7 @@ case class ResponseDisplayIngest(
   ingestType: DisplayIngestType,
   space: DisplayStorageSpace,
   status: DisplayStatus,
-  externalIdentifier: String,
+  bag: DisplayBag,
   events: Seq[DisplayIngestEvent] = Seq.empty,
   createdDate: String,
   lastModifiedDate: Option[String],
@@ -57,7 +57,11 @@ object ResponseDisplayIngest {
       callback = ingest.callback.map { DisplayCallback(_) },
       space = DisplayStorageSpace(ingest.space.toString),
       ingestType = DisplayIngestType(ingest.ingestType),
-      externalIdentifier = ingest.externalIdentifier.underlying,
+      bag = DisplayBag(
+        info = DisplayBagInfo(
+          externalIdentifier = ingest.externalIdentifier
+        )
+      ),
       status = DisplayStatus(ingest.status),
       events = ingest.events
         .sortBy { _.createdDate }

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayIngest.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayIngest.scala
@@ -5,7 +5,6 @@ import java.time.Instant
 import java.util.UUID
 
 import io.circe.generic.extras.JsonKey
-import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 
@@ -16,7 +15,7 @@ case class RequestDisplayIngest(
   callback: Option[DisplayCallback],
   ingestType: DisplayIngestType,
   space: DisplayStorageSpace,
-  externalIdentifier: String,
+  bag: DisplayBag,
   @JsonKey("type")
   ontologyType: String = "Ingest"
 ) extends DisplayIngest {
@@ -28,25 +27,25 @@ case class RequestDisplayIngest(
       callback = Callback(
         callback.map(displayCallback => URI.create(displayCallback.url))),
       space = StorageSpace(space.id),
-      externalIdentifier = ExternalIdentifier(externalIdentifier),
+      externalIdentifier = bag.info.externalIdentifier,
       status = Ingest.Accepted,
       createdDate = Instant.now
     )
 }
 
-case class ResponseDisplayIngest(@JsonKey("@context") context: String,
-                                 id: UUID,
-                                 sourceLocation: DisplayLocation,
-                                 callback: Option[DisplayCallback],
-                                 ingestType: DisplayIngestType,
-                                 space: DisplayStorageSpace,
-                                 status: DisplayStatus,
-                                 externalIdentifier: String,
-                                 events: Seq[DisplayIngestEvent] = Seq.empty,
-                                 createdDate: String,
-                                 lastModifiedDate: Option[String],
-                                 @JsonKey("type") ontologyType: String =
-                                   "Ingest")
+case class ResponseDisplayIngest(
+  @JsonKey("@context") context: String,
+  id: UUID,
+  sourceLocation: DisplayLocation,
+  callback: Option[DisplayCallback],
+  ingestType: DisplayIngestType,
+  space: DisplayStorageSpace,
+  status: DisplayStatus,
+  externalIdentifier: String,
+  events: Seq[DisplayIngestEvent] = Seq.empty,
+  createdDate: String,
+  lastModifiedDate: Option[String],
+  @JsonKey("type") ontologyType: String = "Ingest")
     extends DisplayIngest
 
 object ResponseDisplayIngest {

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayIngest.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayIngest.scala
@@ -33,19 +33,19 @@ case class RequestDisplayIngest(
     )
 }
 
-case class ResponseDisplayIngest(
-  @JsonKey("@context") context: String,
-  id: UUID,
-  sourceLocation: DisplayLocation,
-  callback: Option[DisplayCallback],
-  ingestType: DisplayIngestType,
-  space: DisplayStorageSpace,
-  status: DisplayStatus,
-  bag: DisplayBag,
-  events: Seq[DisplayIngestEvent] = Seq.empty,
-  createdDate: String,
-  lastModifiedDate: Option[String],
-  @JsonKey("type") ontologyType: String = "Ingest")
+case class ResponseDisplayIngest(@JsonKey("@context") context: String,
+                                 id: UUID,
+                                 sourceLocation: DisplayLocation,
+                                 callback: Option[DisplayCallback],
+                                 ingestType: DisplayIngestType,
+                                 space: DisplayStorageSpace,
+                                 status: DisplayStatus,
+                                 bag: DisplayBag,
+                                 events: Seq[DisplayIngestEvent] = Seq.empty,
+                                 createdDate: String,
+                                 lastModifiedDate: Option[String],
+                                 @JsonKey("type") ontologyType: String =
+                                   "Ingest")
     extends DisplayIngest
 
 object ResponseDisplayIngest {

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayIngestTest.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayIngestTest.scala
@@ -118,6 +118,9 @@ class DisplayIngestTest
       val displayProvider = InfrequentAccessDisplayProvider
       val bucket = "ingest-bucket"
       val path = "bag.zip"
+
+      val externalIdentifier = createExternalIdentifier
+
       val ingestCreateRequest = RequestDisplayIngest(
         sourceLocation = DisplayLocation(displayProvider, bucket, path),
         callback = Some(
@@ -126,7 +129,13 @@ class DisplayIngestTest
             status = None
           )
         ),
-        externalIdentifier = createExternalIdentifier.underlying,
+        bag = DisplayBag(
+          info = DisplayBagInfo(
+            externalIdentifier = externalIdentifier,
+            ontologyType = "BagInfo"
+          ),
+          ontologyType = "Bag"
+        ),
         ingestType = CreateDisplayIngestType,
         space = DisplayStorageSpace("space-id")
       )
@@ -140,6 +149,7 @@ class DisplayIngestTest
       ingest.callback shouldBe Some(
         Callback(URI.create(ingestCreateRequest.callback.get.url)))
       ingest.status shouldBe Ingest.Accepted
+      ingest.externalIdentifier shouldBe externalIdentifier
       assertRecent(ingest.createdDate)
       ingest.lastModifiedDate shouldBe None
       ingest.events shouldBe empty
@@ -176,7 +186,13 @@ class DisplayIngestTest
       sourceLocation = sourceLocation,
       callback = callback,
       ingestType = ingestType,
-      externalIdentifier = createExternalIdentifier.underlying,
+      bag = DisplayBag(
+        info = DisplayBagInfo(
+          externalIdentifier = createExternalIdentifier,
+          ontologyType = "BagInfo"
+        ),
+        ontologyType = "Bag"
+      ),
       space = space
     )
 }

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayIngestTest.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayIngestTest.scala
@@ -67,7 +67,7 @@ class DisplayIngestTest
       )
       displayIngest.space shouldBe DisplayStorageSpace(spaceId)
       displayIngest.status shouldBe DisplayStatus("processing")
-      displayIngest.externalIdentifier shouldBe externalIdentifier.underlying
+      displayIngest.bag.info.externalIdentifier shouldBe externalIdentifier
       displayIngest.createdDate shouldBe createdDate
       displayIngest.lastModifiedDate.get shouldBe modifiedDate
       displayIngest.events shouldBe List(
@@ -131,10 +131,8 @@ class DisplayIngestTest
         ),
         bag = DisplayBag(
           info = DisplayBagInfo(
-            externalIdentifier = externalIdentifier,
-            ontologyType = "BagInfo"
-          ),
-          ontologyType = "Bag"
+            externalIdentifier = externalIdentifier
+          )
         ),
         ingestType = CreateDisplayIngestType,
         space = DisplayStorageSpace("space-id")

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
@@ -73,7 +73,11 @@ class NotifierFeatureTest
                 ingestType = CreateDisplayIngestType,
                 space = DisplayStorageSpace(ingest.space.underlying),
                 status = DisplayStatus(ingest.status.toString),
-                externalIdentifier = ingest.externalIdentifier.toString,
+                bag = DisplayBag(
+                  info = DisplayBagInfo(
+                    externalIdentifier = ingest.externalIdentifier
+                  )
+                ),
                 events = ingest.events.map { event =>
                   DisplayIngestEvent(
                     event.description,
@@ -144,7 +148,11 @@ class NotifierFeatureTest
                 ingestType = DisplayIngestType(ingest.ingestType),
                 space = DisplayStorageSpace(ingest.space.underlying),
                 status = DisplayStatus(ingest.status.toString),
-                externalIdentifier = ingest.externalIdentifier.toString,
+                bag = DisplayBag(
+                  info = DisplayBagInfo(
+                    externalIdentifier = ingest.externalIdentifier
+                  )
+                ),
                 events = ingest.events.map(
                   event =>
                     DisplayIngestEvent(


### PR DESCRIPTION
Closes wellcometrust/platform#3702

Rather than asking for a flat string "externalIdentifier", the ingests API now looks for a "Bag" object.

Along the way, I tidied up the tests for the ingests API to make them easier to follow and reduce the boilerplate. We have more tests, less code!

I also found a couple of places where the RFC doesn't match the API – see wellcometrust/platform#3704.