### PR TITLE
Store multiple versions of a storage manifest

### DIFF
--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Router.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Router.scala
@@ -40,7 +40,7 @@ class Router(vhs: StorageManifestDao, contextURL: URL)(
         )
 
         get {
-          vhs.get(bagId) match {
+          vhs.getLatest(bagId) match {
             case Right(storageManifest) =>
               complete(
                 DisplayBag(

--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
@@ -31,6 +31,7 @@ class BagsApiFeatureTest
 
   describe("GET /bags/:space/:id") {
     it("returns a bag when available") {
+      // TODO: Make this take initialManifests
       withConfiguredApp {
         case (vhs, metricsSender, baseUrl) =>
           withMaterializer { implicit materializer =>
@@ -90,7 +91,7 @@ class BagsApiFeatureTest
             val storageManifest = createStorageManifestWith(
               bagInfo = createBagInfoWith(externalDescription = None)
             )
-            storeSingleManifest(vhs, storageManifest) shouldBe a[Right[_, _]]
+            vhs.put(storageManifest) shouldBe a[Right[_, _]]
 
             whenGetRequestReady(
               s"$baseUrl/bags/${storageManifest.id.space.underlying}/${storageManifest.id.externalIdentifier.underlying}") {

--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
@@ -7,12 +7,9 @@ import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
-import uk.ac.wellcome.platform.archive.common.fixtures.{
-  HttpFixtures,
-  StorageManifestVHSFixture,
-  StorageRandomThings
-}
+import uk.ac.wellcome.platform.archive.common.fixtures.{HttpFixtures, StorageManifestVHSFixture, StorageRandomThings}
 import uk.ac.wellcome.platform.archive.common.http.HttpMetrics
+import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
 import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
 import uk.ac.wellcome.platform.storage.bags.api.BagsApi
 import uk.ac.wellcome.storage._
@@ -56,13 +53,17 @@ trait BagsApiFixture
       }
     }
 
-  def withConfiguredApp[R](
+  def withConfiguredApp[R](initialManifests: Seq[StorageManifest] = Seq.empty)(
     testWith: TestWith[(StorageManifestDao, MetricsSender, String), R]): R = {
-    val vhs = createStorageManifestDao()
+    val dao = createStorageManifestDao()
+
+    initialManifests.foreach { manifest =>
+      dao.put(manifest) shouldBe a[Right[_, _]]
+    }
 
     withMockMetricsSender { metricsSender =>
-      withApp(metricsSender, vhs) { _ =>
-        testWith((vhs, metricsSender, httpServerConfig.externalBaseURL))
+      withApp(metricsSender, dao) { _ =>
+        testWith((dao, metricsSender, httpServerConfig.externalBaseURL))
       }
     }
   }

--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
@@ -7,7 +7,11 @@ import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.monitoring.MetricsSender
 import uk.ac.wellcome.monitoring.fixtures.MetricsSenderFixture
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
-import uk.ac.wellcome.platform.archive.common.fixtures.{HttpFixtures, StorageManifestVHSFixture, StorageRandomThings}
+import uk.ac.wellcome.platform.archive.common.fixtures.{
+  HttpFixtures,
+  StorageManifestVHSFixture,
+  StorageRandomThings
+}
 import uk.ac.wellcome.platform.archive.common.http.HttpMetrics
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
 import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
@@ -34,7 +34,8 @@ class BagAuditorFeatureTest
 
           val expectedPayload = createEnrichedBagInformationPayloadWith(
             context = payload.context,
-            bagRootLocation = bagRootLocation
+            bagRootLocation = bagRootLocation,
+            version = 1
           )
 
           withLocalSqsQueue { queue =>

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/BagRegisterFeatureTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/BagRegisterFeatureTest.scala
@@ -22,7 +22,7 @@ class BagRegisterFeatureTest
 
   it("sends an update if it registers a bag") {
     withBagRegisterWorker {
-      case (_, dao, store, ingests, _, queuePair) =>
+      case (_, storageManifestDao, ingests, _, queuePair) =>
         val createdAfterDate = Instant.now()
         val bagInfo = createBagInfo
 
@@ -44,7 +44,7 @@ class BagRegisterFeatureTest
               sendNotificationToSQS(queuePair.queue, payload)
 
               eventually {
-                val storageManifest = getStorageManifest(dao, store, id = bagId)
+                val storageManifest = storageManifestDao.getLatest(bagId).right.value
 
                 storageManifest.space shouldBe bagId.space
                 storageManifest.info shouldBe bagInfo
@@ -73,7 +73,7 @@ class BagRegisterFeatureTest
 
   it("sends a failed update and discards the work on error") {
     withBagRegisterWorker {
-      case (_, _, _, ingests, _, queuePair) =>
+      case (_, _, ingests, _, queuePair) =>
         val payload = createEnrichedBagInformationPayload
 
         sendNotificationToSQS(queuePair.queue, payload)

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/BagRegisterFeatureTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/BagRegisterFeatureTest.scala
@@ -44,7 +44,8 @@ class BagRegisterFeatureTest
               sendNotificationToSQS(queuePair.queue, payload)
 
               eventually {
-                val storageManifest = storageManifestDao.getLatest(bagId).right.value
+                val storageManifest =
+                  storageManifestDao.getLatest(bagId).right.value
 
                 storageManifest.space shouldBe bagId.space
                 storageManifest.info shouldBe bagInfo

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
@@ -29,7 +29,7 @@ class BagRegisterWorkerTest
 
   it("sends a successful IngestUpdate upon registration") {
     withBagRegisterWorker {
-      case (service, dao, store, ingests, _, _) =>
+      case (service, storageManifestDao, ingests, _, _) =>
         val createdAfterDate = Instant.now()
         val bagInfo = createBagInfo
 
@@ -50,7 +50,7 @@ class BagRegisterWorkerTest
 
               service.processMessage(payload) shouldBe a[Success[_]]
 
-              val storageManifest = getStorageManifest(dao, store, id = bagId)
+              val storageManifest = storageManifestDao.getLatest(bagId).right.value
 
               storageManifest.space shouldBe bagId.space
               storageManifest.info shouldBe bagInfo
@@ -76,7 +76,7 @@ class BagRegisterWorkerTest
 
   it("sends a failed IngestUpdate if storing fails") {
     withBagRegisterWorker {
-      case (service, _, _, ingests, _, _) =>
+      case (service, _, ingests, _, _) =>
         val payload = createEnrichedBagInformationPayload
 
         service.processMessage(payload) shouldBe a[Success[_]]

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
@@ -50,7 +50,8 @@ class BagRegisterWorkerTest
 
               service.processMessage(payload) shouldBe a[Success[_]]
 
-              val storageManifest = storageManifestDao.getLatest(bagId).right.value
+              val storageManifest =
+                storageManifestDao.getLatest(bagId).right.value
 
               storageManifest.space shouldBe bagId.space
               storageManifest.info shouldBe bagInfo
@@ -105,8 +106,16 @@ class BagRegisterWorkerTest
               service.processMessage(payload1) shouldBe a[Success[_]]
               service.processMessage(payload2) shouldBe a[Success[_]]
 
-              storageManifestDao.get(bagId, version = 1).right.value.version shouldBe 1
-              storageManifestDao.get(bagId, version = 2).right.value.version shouldBe 2
+              storageManifestDao
+                .get(bagId, version = 1)
+                .right
+                .value
+                .version shouldBe 1
+              storageManifestDao
+                .get(bagId, version = 2)
+                .right
+                .value
+                .version shouldBe 2
 
               storageManifestDao.getLatest(bagId).right.value.version shouldBe 2
           }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestDao.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestDao.scala
@@ -15,6 +15,9 @@ class StorageManifestDao(
   def get(id: BagId): Either[ReadError, StorageManifest] =
     vhs.getLatest(id).map { _.identifiedT.t }
 
+  def get(id: BagId, version: Int): Either[ReadError, StorageManifest] =
+    vhs.getLatest(id).map { _.identifiedT.t }
+
   def put(
     storageManifest: StorageManifest): Either[WriteError, StorageManifest] =
     vhs

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestDao.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestDao.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.archive.common.storage.services
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
 import uk.ac.wellcome.storage.store.{HybridStoreEntry, VersionedStore}
-import uk.ac.wellcome.storage.{ReadError, WriteError}
+import uk.ac.wellcome.storage.{ReadError, Version, WriteError}
 
 // TODO: Do we need this wrapper at all now?
 // TODO: This could be a Store!
@@ -12,16 +12,17 @@ class StorageManifestDao(
                       Int,
                       HybridStoreEntry[StorageManifest, Map[String, String]]]
 ) {
-  def get(id: BagId): Either[ReadError, StorageManifest] =
+  def getLatest(id: BagId): Either[ReadError, StorageManifest] =
     vhs.getLatest(id).map { _.identifiedT.t }
 
   def get(id: BagId, version: Int): Either[ReadError, StorageManifest] =
-    vhs.getLatest(id).map { _.identifiedT.t }
+    vhs.get(Version(id, version)).map { _.identifiedT.t }
 
   def put(
     storageManifest: StorageManifest): Either[WriteError, StorageManifest] =
     vhs
-      .init(id = storageManifest.id)(
-        HybridStoreEntry(storageManifest, metadata = Map.empty))
+      .put(id = Version(storageManifest.id, storageManifest.version))(
+        HybridStoreEntry(storageManifest, metadata = Map.empty)
+      )
       .map { _.identifiedT.t }
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageManifestVHSFixture.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageManifestVHSFixture.scala
@@ -5,10 +5,10 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
 import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
+import uk.ac.wellcome.storage.Version
 import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
 import uk.ac.wellcome.storage.store.HybridIndexedStoreEntry
 import uk.ac.wellcome.storage.store.memory._
-import uk.ac.wellcome.storage.{Version, WriteError}
 
 trait StorageManifestVHSFixture extends EitherValues {
   type StorageManifestIndex =
@@ -55,18 +55,4 @@ trait StorageManifestVHSFixture extends EitherValues {
           Map[String, String]]()
       )
     )
-
-  def storeSingleManifest(
-    vhs: StorageManifestDao,
-    storageManifest: StorageManifest): Either[WriteError, StorageManifest] =
-    vhs.put(storageManifest)
-
-  def getStorageManifest(indexStore: StorageManifestIndex,
-                         typedStore: StorageManifestTypedStore,
-                         id: BagId): StorageManifest = {
-    val version = indexStore.max(id).right.value
-    val entry = indexStore.entries(Version(id, version))
-
-    typedStore.get(entry.typedStoreId).right.value.identifiedT.t
-  }
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -70,7 +70,7 @@ trait PayloadGenerators
   def createEnrichedBagInformationPayloadWith(
     context: PipelineContext = createPipelineContext,
     bagRootLocation: ObjectLocation = createObjectLocation,
-    version: Int = 1
+    version: Int = Random.nextInt()
   ): EnrichedBagInformationPayload =
     EnrichedBagInformationPayload(
       context = context,

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestDaoTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestDaoTest.scala
@@ -3,7 +3,11 @@ package uk.ac.wellcome.platform.archive.common.storage.services
 import org.scalatest.{EitherValues, FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageManifestVHSFixture
 import uk.ac.wellcome.platform.archive.common.generators.StorageManifestGenerators
-import uk.ac.wellcome.storage.{NoVersionExistsError, VersionAlreadyExistsError, WriteError}
+import uk.ac.wellcome.storage.{
+  NoVersionExistsError,
+  VersionAlreadyExistsError,
+  WriteError
+}
 
 class StorageManifestDaoTest
     extends FunSpec
@@ -66,8 +70,14 @@ class StorageManifestDaoTest
 
     index.entries.size shouldBe 2
 
-    dao.get(id = storageManifest.id, version = storageManifest.version).right.value shouldBe storageManifest
-    dao.get(id = storageManifest.id, version = newStorageManifest.version).right.value shouldBe newStorageManifest
+    dao
+      .get(id = storageManifest.id, version = storageManifest.version)
+      .right
+      .value shouldBe storageManifest
+    dao
+      .get(id = storageManifest.id, version = newStorageManifest.version)
+      .right
+      .value shouldBe newStorageManifest
   }
 
   it("blocks putting two manifests with the same version") {

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestDaoTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestDaoTest.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.archive.common.storage.services
 import org.scalatest.{EitherValues, FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageManifestVHSFixture
 import uk.ac.wellcome.platform.archive.common.generators.StorageManifestGenerators
-import uk.ac.wellcome.storage.{NoVersionExistsError, WriteError}
+import uk.ac.wellcome.storage.{NoVersionExistsError, VersionAlreadyExistsError, WriteError}
 
 class StorageManifestDaoTest
     extends FunSpec
@@ -29,7 +29,7 @@ class StorageManifestDaoTest
 
     // Empty get
 
-    val getResultPreInsert = dao.get(storageManifest.id)
+    val getResultPreInsert = dao.getLatest(storageManifest.id)
     getResultPreInsert.left.value shouldBe a[NoVersionExistsError]
 
     // Insert
@@ -37,7 +37,7 @@ class StorageManifestDaoTest
     val insertResult = dao.put(storageManifest)
     insertResult shouldBe a[Right[_, _]]
 
-    val getResultPostInsert = dao.get(storageManifest.id)
+    val getResultPostInsert = dao.getLatest(storageManifest.id)
     getResultPostInsert.right.value shouldBe storageManifest
 
     // Update
@@ -76,6 +76,6 @@ class StorageManifestDaoTest
     val storageManifest = createStorageManifest
 
     dao.put(storageManifest).right.value shouldBe storageManifest
-    dao.put(storageManifest).left.value shouldBe "hello world"
+    dao.put(storageManifest).left.value shouldBe a[VersionAlreadyExistsError]
   }
 }


### PR DESCRIPTION
For wellcometrust/platform#3625.

Previously this class would store a manifest at version 0; now it inspects the manifest to see the version it contains and uses that to put it in VHS.