### PR TITLE
change format of POST to /ingest

### DIFF
--- a/bagger/src/storage_api.py
+++ b/bagger/src/storage_api.py
@@ -9,6 +9,10 @@ ingest_template = {
     "type": "Ingest",
     "ingestType": {"id": "create", "type": "IngestType"},
     "space": {"id": "digitised", "type": "Space"},
+    "bag": {
+        "type": "Bag",
+        "info": {"type": "BagInfo", "externalIdentifier": None}
+    },
     "sourceLocation": {
         "type": "Location",
         "provider": {"type": "Provider", "id": "aws-s3-standard"},
@@ -68,6 +72,7 @@ def ingest(bnumber):
     global ingest_template
     body = deepcopy(ingest_template)
     body["sourceLocation"]["path"] = bnumber + ".tar.gz"
+    body["bag"]["info"]["externalIdentifier"] = bnumber
     url = settings.STORAGE_API_INGESTS
     scope = get_ingest_scope()
     return get_oauthed_json(url, scope, method="POST", data=json.dumps(body))

--- a/bagger/src/storage_api.py
+++ b/bagger/src/storage_api.py
@@ -9,10 +9,7 @@ ingest_template = {
     "type": "Ingest",
     "ingestType": {"id": "create", "type": "IngestType"},
     "space": {"id": "digitised", "type": "Space"},
-    "bag": {
-        "type": "Bag",
-        "info": {"type": "BagInfo", "externalIdentifier": None}
-    },
+    "bag": {"type": "Bag", "info": {"type": "BagInfo", "externalIdentifier": None}},
     "sourceLocation": {
         "type": "Location",
         "provider": {"type": "Provider", "id": "aws-s3-standard"},


### PR DESCRIPTION
So far this is the only change needed to Python migration tools, as they aren't consuming ingests or bag API responses.