### PR TITLE
Replace S3ObjectVerifier with a Verifier type class and two implementations

### DIFF
--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/Main.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/Main.scala
@@ -5,12 +5,23 @@ import akka.stream.ActorMaterializer
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.typesafe.config.Config
-import uk.ac.wellcome.messaging.typesafe.{AlpakkaSqsWorkerConfigBuilder, CloudwatchMonitoringClientBuilder, SQSBuilder}
+import uk.ac.wellcome.messaging.typesafe.{
+  AlpakkaSqsWorkerConfigBuilder,
+  CloudwatchMonitoringClientBuilder,
+  SQSBuilder
+}
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
-import uk.ac.wellcome.platform.archive.bagverifier.services.{BagVerifier, BagVerifierWorker}
+import uk.ac.wellcome.platform.archive.bagverifier.services.{
+  BagVerifier,
+  BagVerifierWorker
+}
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagReader
 import uk.ac.wellcome.platform.archive.common.bagit.services.s3.S3BagReader
-import uk.ac.wellcome.platform.archive.common.config.builders.{IngestUpdaterBuilder, OperationNameBuilder, OutgoingPublisherBuilder}
+import uk.ac.wellcome.platform.archive.common.config.builders.{
+  IngestUpdaterBuilder,
+  OperationNameBuilder,
+  OutgoingPublisherBuilder
+}
 import uk.ac.wellcome.platform.archive.common.storage.services.S3Resolvable
 import uk.ac.wellcome.storage.typesafe.S3Builder
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/Main.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/Main.scala
@@ -5,34 +5,20 @@ import akka.stream.ActorMaterializer
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.typesafe.config.Config
-import uk.ac.wellcome.messaging.typesafe.{
-  AlpakkaSqsWorkerConfigBuilder,
-  CloudwatchMonitoringClientBuilder,
-  SQSBuilder
-}
+import uk.ac.wellcome.messaging.typesafe.{AlpakkaSqsWorkerConfigBuilder, CloudwatchMonitoringClientBuilder, SQSBuilder}
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
-import uk.ac.wellcome.platform.archive.bagverifier.services.{
-  BagVerifier,
-  BagVerifierWorker
-}
+import uk.ac.wellcome.platform.archive.bagverifier.services.{BagVerifier, BagVerifierWorker}
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagReader
 import uk.ac.wellcome.platform.archive.common.bagit.services.s3.S3BagReader
-import uk.ac.wellcome.platform.archive.common.config.builders.{
-  IngestUpdaterBuilder,
-  OperationNameBuilder,
-  OutgoingPublisherBuilder
-}
-import uk.ac.wellcome.platform.archive.common.storage.services.{
-  S3ObjectVerifier,
-  S3Resolvable
-}
+import uk.ac.wellcome.platform.archive.common.config.builders.{IngestUpdaterBuilder, OperationNameBuilder, OutgoingPublisherBuilder}
+import uk.ac.wellcome.platform.archive.common.storage.services.S3Resolvable
 import uk.ac.wellcome.storage.typesafe.S3Builder
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 
 import scala.concurrent.ExecutionContext
-
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.platform.archive.common.verify.s3.S3ObjectVerifier
 
 object Main extends WellcomeTypesafeApp {
   runWithConfig { config: Config =>

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -20,7 +20,7 @@ import scala.util.Try
 class BagVerifier()(
   implicit bagReader: BagReader[_],
   resolvable: Resolvable[ObjectLocation],
-  verifier: Verifier
+  verifier: Verifier[_]
 ) extends Logging {
 
   def verify(root: ObjectLocation): Try[IngestStepResult[VerificationSummary]] =

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
@@ -6,10 +6,16 @@ import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
-import uk.ac.wellcome.platform.archive.bagverifier.services.{BagVerifier, BagVerifierWorker}
+import uk.ac.wellcome.platform.archive.bagverifier.services.{
+  BagVerifier,
+  BagVerifierWorker
+}
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagReader
 import uk.ac.wellcome.platform.archive.common.bagit.services.s3.S3BagReader
-import uk.ac.wellcome.platform.archive.common.fixtures.{MonitoringClientFixture, OperationFixtures}
+import uk.ac.wellcome.platform.archive.common.fixtures.{
+  MonitoringClientFixture,
+  OperationFixtures
+}
 import uk.ac.wellcome.platform.archive.common.storage.services.S3Resolvable
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.json.JsonUtil._

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
@@ -6,22 +6,14 @@ import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
-import uk.ac.wellcome.platform.archive.bagverifier.services.{
-  BagVerifier,
-  BagVerifierWorker
-}
+import uk.ac.wellcome.platform.archive.bagverifier.services.{BagVerifier, BagVerifierWorker}
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagReader
 import uk.ac.wellcome.platform.archive.common.bagit.services.s3.S3BagReader
-import uk.ac.wellcome.platform.archive.common.fixtures.{
-  MonitoringClientFixture,
-  OperationFixtures
-}
-import uk.ac.wellcome.platform.archive.common.storage.services.{
-  S3ObjectVerifier,
-  S3Resolvable
-}
+import uk.ac.wellcome.platform.archive.common.fixtures.{MonitoringClientFixture, OperationFixtures}
+import uk.ac.wellcome.platform.archive.common.storage.services.S3Resolvable
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.platform.archive.common.verify.s3.S3ObjectVerifier
 
 trait BagVerifierFixtures
     extends AlpakkaSQSWorkerFixtures

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3ObjectVerifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3ObjectVerifier.scala
@@ -1,121 +1,18 @@
 package uk.ac.wellcome.platform.archive.common.storage.services
 
-import java.io.InputStream
 import java.net.URI
 
 import com.amazonaws.services.s3.AmazonS3
 import grizzled.slf4j.Logging
-import uk.ac.wellcome.platform.archive.common.storage.{LocateFailure, LocationError, LocationNotFound, LocationParsingError}
+import uk.ac.wellcome.platform.archive.common.storage.LocateFailure
 import uk.ac.wellcome.platform.archive.common.verify._
+import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.store.StreamStore
-import uk.ac.wellcome.storage.{DoesNotExistError, ObjectLocation}
 import uk.ac.wellcome.storage.store.s3.S3StreamStore
-import uk.ac.wellcome.storage.streaming.{HasLength, InputStreamWithLengthAndMetadata}
-
-import scala.util.{Failure, Success}
-
-trait BetterVerifier[IS <: InputStream with HasLength] extends Logging {
-  protected val streamStore: StreamStore[ObjectLocation, IS]
-
-  def locate(uri: URI): Either[LocateFailure[URI], ObjectLocation]
-
-  def verify(verifiableLocation: VerifiableLocation): VerifiedLocation = {
-    debug(s"Attempting to verify: $verifiableLocation")
-
-    val algorithm = verifiableLocation.checksum.algorithm
-
-    val eitherInputStream = for {
-      objectLocation <- locate(verifiableLocation.uri) match {
-        case Right(l) => Right(l)
-        case Left(e) =>
-          Left(
-            LocationParsingError(verifiableLocation, e.msg)
-          )
-      }
-
-      inputStream <- streamStore.get(objectLocation) match {
-        case Right(stream)                => Right(Some(stream.identifiedT))
-        case Left(err: DoesNotExistError) => Right(None)
-        case Left(storageError) =>
-          Left(
-            LocationError(verifiableLocation, storageError.e.getMessage)
-          )
-      }
-    } yield inputStream
-
-    val result = eitherInputStream match {
-      case Left(e) => VerifiedFailure(verifiableLocation, e)
-
-      // ObjectLocation was not available to retrieve (permissions/missing)
-      case Right(None) =>
-        VerifiedFailure(
-          verifiableLocation,
-          LocationNotFound(verifiableLocation, "Location not available!")
-        )
-
-      case Right(Some(inputStream)) =>
-        verifiableLocation.length match {
-          case Some(expectedLength) =>
-            debug(
-              "Location specifies an expected length, checking it's correct")
-
-            if (expectedLength == inputStream.length) {
-              verifyChecksum(
-                verifiableLocation = verifiableLocation,
-                inputStream = inputStream,
-                algorithm = algorithm
-              )
-            } else {
-              VerifiedFailure(
-                verifiableLocation,
-                new Throwable("" +
-                  s"Lengths do not match: $expectedLength != ${inputStream.available()}")
-              )
-            }
-
-          case None =>
-            verifyChecksum(
-              verifiableLocation = verifiableLocation,
-              inputStream = inputStream,
-              algorithm = algorithm
-            )
-        }
-    }
-
-    debug(s"Got: $result")
-    result
-  }
-
-  private def verifyChecksum(verifiableLocation: VerifiableLocation,
-                             inputStream: InputStream,
-                             algorithm: HashingAlgorithm): VerifiedLocation =
-    Checksum.create(inputStream, algorithm) match {
-      // Failure to create a checksum (parsing/algorithm)
-      case Failure(e) =>
-        VerifiedFailure(
-          verifiableLocation,
-          FailedChecksumCreation(algorithm, e))
-
-      // Checksum does not match that provided
-      case Success(checksum) =>
-        if (checksum != verifiableLocation.checksum) {
-          VerifiedFailure(
-            verifiableLocation,
-            FailedChecksumNoMatch(
-              checksum,
-              verifiableLocation.checksum
-            )
-          )
-        } else {
-          // Happy path!
-          VerifiedSuccess(verifiableLocation)
-        }
-    }
-}
+import uk.ac.wellcome.storage.streaming.InputStreamWithLengthAndMetadata
 
 class S3ObjectVerifier(implicit s3Client: AmazonS3)
-    extends Verifier
-    with BetterVerifier[InputStreamWithLengthAndMetadata]
+    extends Verifier[InputStreamWithLengthAndMetadata]
     with Logging {
 
   import uk.ac.wellcome.platform.archive.common.storage.Locatable._

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Verification.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Verification.scala
@@ -10,7 +10,7 @@ object Verification extends Logging {
 
   implicit def verification[Container](
     implicit verifiable: Verifiable[Container],
-    verifier: Verifier
+    verifier: Verifier[_]
   ) =
     new Verification[Container] {
       override def verify(container: Container): VerificationResult = {

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Verifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Verifier.scala
@@ -1,5 +1,111 @@
 package uk.ac.wellcome.platform.archive.common.verify
 
-trait Verifier {
-  def verify(location: VerifiableLocation): VerifiedLocation
+import java.io.InputStream
+import java.net.URI
+
+import grizzled.slf4j.Logging
+import uk.ac.wellcome.platform.archive.common.storage.{LocateFailure, LocationError, LocationNotFound, LocationParsingError}
+import uk.ac.wellcome.storage.{DoesNotExistError, ObjectLocation}
+import uk.ac.wellcome.storage.store.StreamStore
+import uk.ac.wellcome.storage.streaming.HasLength
+
+import scala.util.{Failure, Success}
+
+trait Verifier[IS <: InputStream with HasLength] extends Logging {
+  protected val streamStore: StreamStore[ObjectLocation, IS]
+
+  def locate(uri: URI): Either[LocateFailure[URI], ObjectLocation]
+
+  def verify(verifiableLocation: VerifiableLocation): VerifiedLocation = {
+    debug(s"Attempting to verify: $verifiableLocation")
+
+    val algorithm = verifiableLocation.checksum.algorithm
+
+    val eitherInputStream = for {
+      objectLocation <- locate(verifiableLocation.uri) match {
+        case Right(l) => Right(l)
+        case Left(e) =>
+          Left(
+            LocationParsingError(verifiableLocation, e.msg)
+          )
+      }
+
+      inputStream <- streamStore.get(objectLocation) match {
+        case Right(stream)                => Right(Some(stream.identifiedT))
+        case Left(err: DoesNotExistError) => Right(None)
+        case Left(storageError) =>
+          Left(
+            LocationError(verifiableLocation, storageError.e.getMessage)
+          )
+      }
+    } yield inputStream
+
+    val result = eitherInputStream match {
+      case Left(e) => VerifiedFailure(verifiableLocation, e)
+
+      // ObjectLocation was not available to retrieve (permissions/missing)
+      case Right(None) =>
+        VerifiedFailure(
+          verifiableLocation,
+          LocationNotFound(verifiableLocation, "Location not available!")
+        )
+
+      case Right(Some(inputStream)) =>
+        verifiableLocation.length match {
+          case Some(expectedLength) =>
+            debug(
+              "Location specifies an expected length, checking it's correct")
+
+            if (expectedLength == inputStream.length) {
+              verifyChecksum(
+                verifiableLocation = verifiableLocation,
+                inputStream = inputStream,
+                algorithm = algorithm
+              )
+            } else {
+              VerifiedFailure(
+                verifiableLocation,
+                new Throwable("" +
+                  s"Lengths do not match: $expectedLength != ${inputStream.available()}")
+              )
+            }
+
+          case None =>
+            verifyChecksum(
+              verifiableLocation = verifiableLocation,
+              inputStream = inputStream,
+              algorithm = algorithm
+            )
+        }
+    }
+
+    debug(s"Got: $result")
+    result
+  }
+
+  private def verifyChecksum(verifiableLocation: VerifiableLocation,
+                             inputStream: InputStream,
+                             algorithm: HashingAlgorithm): VerifiedLocation =
+    Checksum.create(inputStream, algorithm) match {
+      // Failure to create a checksum (parsing/algorithm)
+      case Failure(e) =>
+        VerifiedFailure(
+          verifiableLocation,
+          FailedChecksumCreation(algorithm, e))
+
+      // Checksum does not match that provided
+      case Success(checksum) =>
+        if (checksum != verifiableLocation.checksum) {
+          VerifiedFailure(
+            verifiableLocation,
+            FailedChecksumNoMatch(
+              checksum,
+              verifiableLocation.checksum
+            )
+          )
+        } else {
+          // Happy path!
+          VerifiedSuccess(verifiableLocation)
+        }
+    }
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Verifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Verifier.scala
@@ -4,7 +4,12 @@ import java.io.InputStream
 import java.net.URI
 
 import grizzled.slf4j.Logging
-import uk.ac.wellcome.platform.archive.common.storage.{LocateFailure, LocationError, LocationNotFound, LocationParsingError}
+import uk.ac.wellcome.platform.archive.common.storage.{
+  LocateFailure,
+  LocationError,
+  LocationNotFound,
+  LocationParsingError
+}
 import uk.ac.wellcome.storage.{DoesNotExistError, ObjectLocation}
 import uk.ac.wellcome.storage.store.StreamStore
 import uk.ac.wellcome.storage.streaming.HasLength

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/memory/MemoryVerifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/memory/MemoryVerifier.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
 import uk.ac.wellcome.storage.streaming.InputStreamWithLengthAndMetadata
 
 class MemoryVerifier(val streamStore: MemoryStreamStore[ObjectLocation])
-  extends Verifier[InputStreamWithLengthAndMetadata] {
+    extends Verifier[InputStreamWithLengthAndMetadata] {
   override def locate(uri: URI): Either[LocateFailure[URI], ObjectLocation] =
     Right(
       ObjectLocation(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/memory/MemoryVerifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/memory/MemoryVerifier.scala
@@ -1,0 +1,20 @@
+package uk.ac.wellcome.platform.archive.common.verify.memory
+
+import java.net.URI
+
+import uk.ac.wellcome.platform.archive.common.storage.LocateFailure
+import uk.ac.wellcome.platform.archive.common.verify.Verifier
+import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
+import uk.ac.wellcome.storage.streaming.InputStreamWithLengthAndMetadata
+
+class MemoryVerifier(val streamStore: MemoryStreamStore[ObjectLocation])
+  extends Verifier[InputStreamWithLengthAndMetadata] {
+  override def locate(uri: URI): Either[LocateFailure[URI], ObjectLocation] =
+    Right(
+      ObjectLocation(
+        namespace = uri.getHost,
+        path = uri.getPath.stripPrefix("/")
+      )
+    )
+}

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/s3/S3ObjectVerifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/s3/S3ObjectVerifier.scala
@@ -18,7 +18,8 @@ class S3ObjectVerifier(implicit s3Client: AmazonS3)
   import uk.ac.wellcome.platform.archive.common.storage.Locatable._
   import uk.ac.wellcome.platform.archive.common.storage.services.S3LocatableInstances._
 
-  override protected val streamStore: StreamStore[ObjectLocation, InputStreamWithLengthAndMetadata] =
+  override protected val streamStore
+    : StreamStore[ObjectLocation, InputStreamWithLengthAndMetadata] =
     new S3StreamStore()
 
   override def locate(uri: URI): Either[LocateFailure[URI], ObjectLocation] =

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/s3/S3ObjectVerifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/s3/S3ObjectVerifier.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.storage.services
+package uk.ac.wellcome.platform.archive.common.verify.s3
 
 import java.net.URI
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/VerifyFixtures.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/VerifyFixtures.scala
@@ -1,19 +1,14 @@
-package uk.ac.wellcome.platform.archive.bagverifier.fixtures
+package uk.ac.wellcome.platform.archive.common.fixtures
 
-import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
-import uk.ac.wellcome.platform.archive.common.storage.services.{
-  S3ObjectVerifier,
-  S3Resolvable
-}
+import uk.ac.wellcome.platform.archive.common.storage.services.{S3ObjectVerifier, S3Resolvable}
 import uk.ac.wellcome.platform.archive.common.verify._
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 
 trait VerifyFixtures extends S3Fixtures with StorageRandomThings {
+  implicit val objectVerifier: S3ObjectVerifier = new S3ObjectVerifier()
 
-  implicit val objectVerifier = new S3ObjectVerifier()
-
-  implicit val s3Resolvable = new S3Resolvable()
+  implicit val s3Resolvable: S3Resolvable = new S3Resolvable()
   import uk.ac.wellcome.platform.archive.common.storage.Resolvable._
 
   def randomChecksumValue = ChecksumValue(randomAlphanumericWithLength())

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/VerifyFixtures.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/VerifyFixtures.scala
@@ -1,7 +1,8 @@
 package uk.ac.wellcome.platform.archive.common.fixtures
 
-import uk.ac.wellcome.platform.archive.common.storage.services.{S3ObjectVerifier, S3Resolvable}
+import uk.ac.wellcome.platform.archive.common.storage.services.S3Resolvable
 import uk.ac.wellcome.platform.archive.common.verify._
+import uk.ac.wellcome.platform.archive.common.verify.s3.S3ObjectVerifier
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/VerifyFixtures.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/VerifyFixtures.scala
@@ -1,17 +1,12 @@
 package uk.ac.wellcome.platform.archive.common.fixtures
 
-import uk.ac.wellcome.platform.archive.common.storage.services.S3Resolvable
+import java.net.URI
+
 import uk.ac.wellcome.platform.archive.common.verify._
-import uk.ac.wellcome.platform.archive.common.verify.s3.S3ObjectVerifier
 import uk.ac.wellcome.storage.ObjectLocation
-import uk.ac.wellcome.storage.fixtures.S3Fixtures
+import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
 
-trait VerifyFixtures extends S3Fixtures with StorageRandomThings {
-  implicit val objectVerifier: S3ObjectVerifier = new S3ObjectVerifier()
-
-  implicit val s3Resolvable: S3Resolvable = new S3Resolvable()
-  import uk.ac.wellcome.platform.archive.common.storage.Resolvable._
-
+trait VerifyFixtures extends StorageRandomThings with ObjectLocationGenerators {
   def randomChecksumValue = ChecksumValue(randomAlphanumericWithLength())
   def randomChecksum = Checksum(SHA256, randomChecksumValue)
   def badChecksum = Checksum(MD5, randomChecksumValue)
@@ -19,13 +14,15 @@ trait VerifyFixtures extends S3Fixtures with StorageRandomThings {
   def createVerifiableLocation: VerifiableLocation =
     createVerifiableLocationWith()
 
+  def resolve(location: ObjectLocation): URI
+
   def createVerifiableLocationWith(
     location: ObjectLocation = createObjectLocation,
     checksum: Checksum = randomChecksum,
     length: Option[Long] = None
   ): VerifiableLocation = {
     VerifiableLocation(
-      uri = location.resolve,
+      uri = resolve(location),
       checksum = checksum,
       length = length
     )

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3ObjectVerifierTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3ObjectVerifierTest.scala
@@ -1,7 +1,7 @@
-package uk.ac.wellcome.platform.archive.bagverifier.services
+package uk.ac.wellcome.platform.archive.common.storage.services
 
 import org.scalatest.{EitherValues, FunSpec, Matchers}
-import uk.ac.wellcome.platform.archive.bagverifier.fixtures.VerifyFixtures
+import uk.ac.wellcome.platform.archive.common.fixtures.VerifyFixtures
 import uk.ac.wellcome.platform.archive.common.storage.LocationNotFound
 import uk.ac.wellcome.platform.archive.common.verify._
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3ObjectVerifierTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3ObjectVerifierTest.scala
@@ -48,8 +48,8 @@ trait BetterVerifierTestCases[Namespace, Context]
           }
 
         result shouldBe a[VerifiedSuccess]
-        val verifiedSuccess = result.asInstanceOf[VerifiedSuccess]
 
+        val verifiedSuccess = result.asInstanceOf[VerifiedSuccess]
         verifiedSuccess.location shouldBe verifiableLocation
       }
     }
@@ -73,6 +73,151 @@ trait BetterVerifierTestCases[Namespace, Context]
           }
 
         result shouldBe a[VerifiedFailure]
+
+        val verifiedFailure = result.asInstanceOf[VerifiedFailure]
+
+        verifiedFailure.location shouldBe verifiableLocation
+        verifiedFailure.e shouldBe a[LocationNotFound[_]]
+        verifiedFailure.e.getMessage should include(
+          "Location not available!"
+        )
+      }
+    }
+  }
+
+  it("fails if the checksum is incorrect") {
+    withContext { implicit context =>
+      withNamespace { implicit namespace =>
+        val checksum = randomChecksum
+
+        val location = createObjectLocationWith(namespace)
+        putString(location, randomAlphanumeric)
+
+        val verifiableLocation = createVerifiableLocationWith(
+          location = location,
+          checksum = checksum
+        )
+
+        val result =
+          withVerifier {
+            _.verify(verifiableLocation)
+          }
+
+        result shouldBe a[VerifiedFailure]
+
+        val verifiedFailure = result.asInstanceOf[VerifiedFailure]
+
+        verifiedFailure.location shouldBe verifiableLocation
+        verifiedFailure.e shouldBe a[FailedChecksumNoMatch]
+        verifiedFailure.e.getMessage should startWith(
+          "Checksum values do not match"
+        )
+      }
+    }
+  }
+
+  it("fails if the checksum is correct but the expected length is wrong") {
+    withContext { implicit context =>
+      withNamespace { implicit namespace =>
+        val contentHashingAlgorithm = MD5
+        val contentString = "HelloWorld"
+        // md5("HelloWorld")
+        val contentStringChecksum = ChecksumValue(
+          "68e109f0f40ca72a15e05cc22786f8e6"
+        )
+
+        val location = createObjectLocationWith(namespace)
+        val checksum = Checksum(contentHashingAlgorithm, contentStringChecksum)
+
+        val verifiableLocation = createVerifiableLocationWith(
+          location = location,
+          checksum = checksum,
+          length = Some(contentString.getBytes().length - 1)
+        )
+
+        putString(location, contentString)
+
+        val result =
+          withVerifier {
+            _.verify(verifiableLocation)
+          }
+
+        result shouldBe a[VerifiedFailure]
+
+        val verifiedFailure = result.asInstanceOf[VerifiedFailure]
+
+        verifiedFailure.location shouldBe verifiableLocation
+        verifiedFailure.e shouldBe a[Throwable]
+        verifiedFailure.e.getMessage should startWith(
+          "Lengths do not match:"
+        )
+      }
+    }
+  }
+
+  it("succeeds if the checksum is correct and the lengths match") {
+    withContext { implicit context =>
+      withNamespace { implicit namespace =>
+        val contentHashingAlgorithm = MD5
+        val contentString = "HelloWorld"
+        // md5("HelloWorld")
+        val contentStringChecksum = ChecksumValue(
+          "68e109f0f40ca72a15e05cc22786f8e6"
+        )
+
+        val location = createObjectLocationWith(namespace)
+        val checksum = Checksum(contentHashingAlgorithm, contentStringChecksum)
+
+        val verifiableLocation = createVerifiableLocationWith(
+          location = location,
+          checksum = checksum,
+          length = Some(contentString.getBytes().length)
+        )
+
+        putString(location, contentString)
+
+        val result =
+          withVerifier {
+            _.verify(verifiableLocation)
+          }
+
+        result shouldBe a[VerifiedSuccess]
+
+        val verifiedSuccess = result.asInstanceOf[VerifiedSuccess]
+        verifiedSuccess.location shouldBe verifiableLocation
+      }
+    }
+  }
+
+  it("supports different checksum algorithms") {
+    withContext { implicit context =>
+      withNamespace { implicit namespace =>
+        val contentHashingAlgorithm = SHA256
+        val contentString = "HelloWorld"
+        // sha256("HelloWorld")
+        val contentStringChecksum = ChecksumValue(
+          "872e4e50ce9990d8b041330c47c9ddd11bec6b503ae9386a99da8584e9bb12c4"
+        )
+
+        val location = createObjectLocationWith(namespace)
+        val checksum = Checksum(contentHashingAlgorithm, contentStringChecksum)
+
+        val verifiableLocation = createVerifiableLocationWith(
+          location = location,
+          checksum = checksum
+        )
+
+        putString(location, contentString)
+
+        val result =
+          withVerifier {
+            _.verify(verifiableLocation)
+          }
+
+        result shouldBe a[VerifiedSuccess]
+
+        val verifiedSuccess = result.asInstanceOf[VerifiedSuccess]
+        verifiedSuccess.location shouldBe verifiableLocation
       }
     }
   }
@@ -112,6 +257,14 @@ class BetterS3ObjectVerifierTest
       }
 
     result shouldBe a[VerifiedFailure]
+
+    val verifiedFailure = result.asInstanceOf[VerifiedFailure]
+
+    verifiedFailure.location shouldBe verifiableLocation
+    verifiedFailure.e shouldBe a[LocationNotFound[_]]
+    verifiedFailure.e.getMessage should include(
+      "Location not available!"
+    )
   }
 
   it("fails if the key doesn't exist in the bucket") {
@@ -131,179 +284,14 @@ class BetterS3ObjectVerifierTest
         }
 
       result shouldBe a[VerifiedFailure]
-    }
-  }
-}
 
-class S3ObjectVerifierTest
-    extends FunSpec
-    with Matchers
-    with EitherValues
-    with VerifyFixtures {
-
-  // TODO: Rewrite these tests to use traits and test cases
-
-  it("returns a failure if the bucket doesn't exist") {
-    val badVerifiableLocation = createVerifiableLocation
-    val verifiedLocation = objectVerifier.verify(badVerifiableLocation)
-
-    verifiedLocation shouldBe a[VerifiedFailure]
-    val verifiedFailure = verifiedLocation.asInstanceOf[VerifiedFailure]
-
-    verifiedFailure.location shouldBe badVerifiableLocation
-    verifiedFailure.e shouldBe a[LocationNotFound[_]]
-    verifiedFailure.e.getMessage should include(
-      "Location not available!"
-    )
-  }
-
-  it("returns a failure if the object doesn't exist") {
-    withLocalS3Bucket { bucket =>
-      val badLocation = createObjectLocationWith(bucket)
-      val verifiableLocation =
-        createVerifiableLocationWith(location = badLocation)
-
-      val verifiedLocation = objectVerifier.verify(verifiableLocation)
-
-      verifiedLocation shouldBe a[VerifiedFailure]
-      val verifiedFailure = verifiedLocation.asInstanceOf[VerifiedFailure]
+      val verifiedFailure = result.asInstanceOf[VerifiedFailure]
 
       verifiedFailure.location shouldBe verifiableLocation
       verifiedFailure.e shouldBe a[LocationNotFound[_]]
       verifiedFailure.e.getMessage should include(
         "Location not available!"
       )
-    }
-  }
-
-  it("returns a failure if the checksum is incorrect") {
-    withLocalS3Bucket { bucket =>
-      val objectLocation = createObjectLocationWith(bucket)
-      val verifiableLocation = createVerifiableLocationWith(
-        location = objectLocation,
-        checksum = badChecksum
-      )
-
-      s3Client.putObject(
-        objectLocation.namespace,
-        objectLocation.path,
-        "HelloWorld"
-      )
-
-      val verifiedLocation = objectVerifier.verify(verifiableLocation)
-
-      verifiedLocation shouldBe a[VerifiedFailure]
-      val verifiedFailure = verifiedLocation.asInstanceOf[VerifiedFailure]
-
-      verifiedFailure.location shouldBe verifiableLocation
-      verifiedFailure.e shouldBe a[FailedChecksumNoMatch]
-      verifiedFailure.e.getMessage should startWith(
-        "Checksum values do not match"
-      )
-    }
-  }
-
-  it("fails if the checksum is correct but the expected length is wrong") {
-    withLocalS3Bucket { bucket =>
-      val contentHashingAlgorithm = MD5
-      val contentString = "HelloWorld"
-      // md5("HelloWorld")
-      val contentStringChecksum = ChecksumValue(
-        "68e109f0f40ca72a15e05cc22786f8e6"
-      )
-
-      val objectLocation = createObjectLocationWith(bucket)
-      val checksum = Checksum(contentHashingAlgorithm, contentStringChecksum)
-
-      val verifiableLocation = createVerifiableLocationWith(
-        location = objectLocation,
-        checksum = checksum,
-        length = Some(contentString.getBytes().length - 1)
-      )
-
-      s3Client.putObject(
-        objectLocation.namespace,
-        objectLocation.path,
-        contentString
-      )
-
-      val verifiedLocation = objectVerifier.verify(verifiableLocation)
-
-      verifiedLocation shouldBe a[VerifiedFailure]
-      val verifiedFailure = verifiedLocation.asInstanceOf[VerifiedFailure]
-
-      verifiedFailure.location shouldBe verifiableLocation
-      verifiedFailure.e shouldBe a[Throwable]
-      verifiedFailure.e.getMessage should startWith(
-        "Lengths do not match:"
-      )
-    }
-  }
-
-
-
-  it("succeeds if the checksum is correct and the lengths match") {
-    withLocalS3Bucket { bucket =>
-      val contentHashingAlgorithm = MD5
-      val contentString = "HelloWorld"
-      // md5("HelloWorld")
-      val contentStringChecksum = ChecksumValue(
-        "68e109f0f40ca72a15e05cc22786f8e6"
-      )
-
-      val objectLocation = createObjectLocationWith(bucket)
-      val checksum = Checksum(contentHashingAlgorithm, contentStringChecksum)
-
-      val verifiableLocation = createVerifiableLocationWith(
-        location = objectLocation,
-        checksum = checksum,
-        length = Some(contentString.getBytes().length)
-      )
-
-      s3Client.putObject(
-        objectLocation.namespace,
-        objectLocation.path,
-        contentString
-      )
-
-      val verifiedLocation = objectVerifier.verify(verifiableLocation)
-
-      verifiedLocation shouldBe a[VerifiedSuccess]
-      val verifiedSuccess = verifiedLocation.asInstanceOf[VerifiedSuccess]
-
-      verifiedSuccess.location shouldBe verifiableLocation
-    }
-  }
-
-  it("supports different checksum algorithms") {
-    withLocalS3Bucket { bucket =>
-      val contentHashingAlgorithm = SHA256
-      val contentString = "HelloWorld"
-      // sha256("HelloWorld")
-      val contentStringChecksum = ChecksumValue(
-        "872e4e50ce9990d8b041330c47c9ddd11bec6b503ae9386a99da8584e9bb12c4"
-      )
-
-      val objectLocation = createObjectLocationWith(bucket)
-      val checksum = Checksum(contentHashingAlgorithm, contentStringChecksum)
-
-      val verifiableLocation = createVerifiableLocationWith(
-        location = objectLocation,
-        checksum = checksum
-      )
-
-      s3Client.putObject(
-        objectLocation.namespace,
-        objectLocation.path,
-        contentString
-      )
-
-      val verifiedLocation = objectVerifier.verify(verifiableLocation)
-
-      verifiedLocation shouldBe a[VerifiedSuccess]
-      val verifiedSuccess = verifiedLocation.asInstanceOf[VerifiedSuccess]
-
-      verifiedSuccess.location shouldBe verifiableLocation
     }
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3ObjectVerifierTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3ObjectVerifierTest.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.archive.common.storage.services
 
-import org.scalatest.{EitherValues, FunSpec, Matchers}
+import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.common.fixtures.VerifyFixtures
 import uk.ac.wellcome.platform.archive.common.storage.LocationNotFound
@@ -9,7 +9,7 @@ import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.store.fixtures.{BucketNamespaceFixtures, NamespaceFixtures}
 
-trait BetterVerifierTestCases[Namespace, Context]
+trait VerifierTestCases[Namespace, Context]
   extends FunSpec
     with Matchers
     with NamespaceFixtures[ObjectLocation, Namespace]
@@ -21,7 +21,7 @@ trait BetterVerifierTestCases[Namespace, Context]
 
   def putString(location: ObjectLocation, contents: String)(implicit context: Context): Unit
 
-  def withVerifier[R](testWith: TestWith[BetterVerifier[_], R])(implicit context: Context): R
+  def withVerifier[R](testWith: TestWith[Verifier[_], R])(implicit context: Context): R
 
   it("returns a success if the checksum is correct") {
     withContext { implicit context =>
@@ -224,7 +224,7 @@ trait BetterVerifierTestCases[Namespace, Context]
 }
 
 class BetterS3ObjectVerifierTest
-  extends BetterVerifierTestCases[Bucket, Unit]
+  extends VerifierTestCases[Bucket, Unit]
     with BucketNamespaceFixtures {
   override def withContext[R](testWith: TestWith[Unit, R]): R =
     testWith(())
@@ -236,7 +236,7 @@ class BetterS3ObjectVerifierTest
       contents
     )
 
-  override def withVerifier[R](testWith: TestWith[BetterVerifier[_], R])(implicit context: Unit): R =
+  override def withVerifier[R](testWith: TestWith[Verifier[_], R])(implicit context: Unit): R =
     testWith(new S3ObjectVerifier())
 
   implicit val context: Unit = ()

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/VerifierTestCases.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/VerifierTestCases.scala
@@ -8,7 +8,7 @@ import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.store.fixtures.NamespaceFixtures
 
 trait VerifierTestCases[Namespace, Context]
-  extends FunSpec
+    extends FunSpec
     with Matchers
     with NamespaceFixtures[ObjectLocation, Namespace]
     with VerifyFixtures {
@@ -17,9 +17,11 @@ trait VerifierTestCases[Namespace, Context]
 
   def createObjectLocationWith(namespace: Namespace): ObjectLocation
 
-  def putString(location: ObjectLocation, contents: String)(implicit context: Context): Unit
+  def putString(location: ObjectLocation, contents: String)(
+    implicit context: Context): Unit
 
-  def withVerifier[R](testWith: TestWith[Verifier[_], R])(implicit context: Context): R
+  def withVerifier[R](testWith: TestWith[Verifier[_], R])(
+    implicit context: Context): R
 
   it("returns a success if the checksum is correct") {
     withContext { implicit context =>

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/VerifierTestCases.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/VerifierTestCases.scala
@@ -1,13 +1,11 @@
-package uk.ac.wellcome.platform.archive.common.storage.services
+package uk.ac.wellcome.platform.archive.common.verify
 
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.common.fixtures.VerifyFixtures
 import uk.ac.wellcome.platform.archive.common.storage.LocationNotFound
-import uk.ac.wellcome.platform.archive.common.verify._
 import uk.ac.wellcome.storage.ObjectLocation
-import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
-import uk.ac.wellcome.storage.store.fixtures.{BucketNamespaceFixtures, NamespaceFixtures}
+import uk.ac.wellcome.storage.store.fixtures.NamespaceFixtures
 
 trait VerifierTestCases[Namespace, Context]
   extends FunSpec
@@ -219,79 +217,6 @@ trait VerifierTestCases[Namespace, Context]
         val verifiedSuccess = result.asInstanceOf[VerifiedSuccess]
         verifiedSuccess.location shouldBe verifiableLocation
       }
-    }
-  }
-}
-
-class BetterS3ObjectVerifierTest
-  extends VerifierTestCases[Bucket, Unit]
-    with BucketNamespaceFixtures {
-  override def withContext[R](testWith: TestWith[Unit, R]): R =
-    testWith(())
-
-  override def putString(location: ObjectLocation, contents: String)(implicit context: Unit): Unit =
-    s3Client.putObject(
-      location.namespace,
-      location.path,
-      contents
-    )
-
-  override def withVerifier[R](testWith: TestWith[Verifier[_], R])(implicit context: Unit): R =
-    testWith(new S3ObjectVerifier())
-
-  implicit val context: Unit = ()
-
-  it("fails if the bucket doesn't exist") {
-    val checksum = randomChecksum
-
-    val location = createObjectLocation
-
-    val verifiableLocation = createVerifiableLocationWith(
-      location = location,
-      checksum = checksum
-    )
-
-    val result =
-      withVerifier {
-        _.verify(verifiableLocation)
-      }
-
-    result shouldBe a[VerifiedFailure]
-
-    val verifiedFailure = result.asInstanceOf[VerifiedFailure]
-
-    verifiedFailure.location shouldBe verifiableLocation
-    verifiedFailure.e shouldBe a[LocationNotFound[_]]
-    verifiedFailure.e.getMessage should include(
-      "Location not available!"
-    )
-  }
-
-  it("fails if the key doesn't exist in the bucket") {
-    withLocalS3Bucket { bucket =>
-      val checksum = randomChecksum
-
-      val location = createObjectLocationWith(bucket)
-
-      val verifiableLocation = createVerifiableLocationWith(
-        location = location,
-        checksum = checksum
-      )
-
-      val result =
-        withVerifier {
-          _.verify(verifiableLocation)
-        }
-
-      result shouldBe a[VerifiedFailure]
-
-      val verifiedFailure = result.asInstanceOf[VerifiedFailure]
-
-      verifiedFailure.location shouldBe verifiableLocation
-      verifiedFailure.e shouldBe a[LocationNotFound[_]]
-      verifiedFailure.e.getMessage should include(
-        "Location not available!"
-      )
     }
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/memory/MemoryVerifierTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/memory/MemoryVerifierTest.scala
@@ -4,21 +4,26 @@ import java.net.URI
 
 import org.scalatest.EitherValues
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.archive.common.verify.{Verifier, VerifierTestCases}
+import uk.ac.wellcome.platform.archive.common.verify.{
+  Verifier,
+  VerifierTestCases
+}
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
 import uk.ac.wellcome.storage.streaming.Codec._
 import uk.ac.wellcome.storage.streaming.InputStreamWithLengthAndMetadata
 
 class MemoryVerifierTest
-  extends VerifierTestCases[String, MemoryStreamStore[ObjectLocation]]
+    extends VerifierTestCases[String, MemoryStreamStore[ObjectLocation]]
     with EitherValues {
-  override def withContext[R](testWith: TestWith[MemoryStreamStore[ObjectLocation], R]): R =
+  override def withContext[R](
+    testWith: TestWith[MemoryStreamStore[ObjectLocation], R]): R =
     testWith(
       MemoryStreamStore[ObjectLocation]()
     )
 
-  override def putString(location: ObjectLocation, contents: String)(implicit streamStore: MemoryStreamStore[ObjectLocation]): Unit =
+  override def putString(location: ObjectLocation, contents: String)(
+    implicit streamStore: MemoryStreamStore[ObjectLocation]): Unit =
     streamStore.put(location)(
       InputStreamWithLengthAndMetadata(
         stringCodec.toStream(contents).right.value,
@@ -26,7 +31,8 @@ class MemoryVerifierTest
       )
     ) shouldBe a[Right[_, _]]
 
-  override def withVerifier[R](testWith: TestWith[Verifier[_], R])(implicit streamStore: MemoryStreamStore[ObjectLocation]): R =
+  override def withVerifier[R](testWith: TestWith[Verifier[_], R])(
+    implicit streamStore: MemoryStreamStore[ObjectLocation]): R =
     testWith(
       new MemoryVerifier(streamStore)
     )

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/memory/MemoryVerifierTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/memory/MemoryVerifierTest.scala
@@ -1,0 +1,48 @@
+package uk.ac.wellcome.platform.archive.common.verify.memory
+
+import java.net.URI
+
+import org.scalatest.EitherValues
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.platform.archive.common.verify.{Verifier, VerifierTestCases}
+import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
+import uk.ac.wellcome.storage.streaming.Codec._
+import uk.ac.wellcome.storage.streaming.InputStreamWithLengthAndMetadata
+
+class MemoryVerifierTest
+  extends VerifierTestCases[String, MemoryStreamStore[ObjectLocation]]
+    with EitherValues {
+  override def withContext[R](testWith: TestWith[MemoryStreamStore[ObjectLocation], R]): R =
+    testWith(
+      MemoryStreamStore[ObjectLocation]()
+    )
+
+  override def putString(location: ObjectLocation, contents: String)(implicit streamStore: MemoryStreamStore[ObjectLocation]): Unit =
+    streamStore.put(location)(
+      InputStreamWithLengthAndMetadata(
+        stringCodec.toStream(contents).right.value,
+        metadata = Map.empty
+      )
+    ) shouldBe a[Right[_, _]]
+
+  override def withVerifier[R](testWith: TestWith[Verifier[_], R])(implicit streamStore: MemoryStreamStore[ObjectLocation]): R =
+    testWith(
+      new MemoryVerifier(streamStore)
+    )
+
+  override def createObjectLocationWith(namespace: String): ObjectLocation =
+    ObjectLocation(
+      namespace = namespace,
+      path = randomAlphanumeric
+    )
+
+  override def withNamespace[R](testWith: TestWith[String, R]): R =
+    testWith(randomAlphanumeric)
+
+  override def createId(implicit namespace: String): ObjectLocation =
+    createObjectLocationWith(namespace)
+
+  override def resolve(location: ObjectLocation): URI =
+    new URI(s"mem://${location.namespace}/${location.path}")
+}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/s3/S3ObjectVerifierTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/s3/S3ObjectVerifierTest.scala
@@ -1,0 +1,81 @@
+package uk.ac.wellcome.platform.archive.common.verify.s3
+
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.platform.archive.common.storage.LocationNotFound
+import uk.ac.wellcome.platform.archive.common.verify._
+import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
+import uk.ac.wellcome.storage.store.fixtures.BucketNamespaceFixtures
+
+class S3ObjectVerifierTest
+  extends VerifierTestCases[Bucket, Unit]
+    with BucketNamespaceFixtures {
+  override def withContext[R](testWith: TestWith[Unit, R]): R =
+    testWith(())
+
+  override def putString(location: ObjectLocation, contents: String)(implicit context: Unit): Unit =
+    s3Client.putObject(
+      location.namespace,
+      location.path,
+      contents
+    )
+
+  override def withVerifier[R](testWith: TestWith[Verifier[_], R])(implicit context: Unit): R =
+    testWith(new S3ObjectVerifier())
+
+  implicit val context: Unit = ()
+
+  it("fails if the bucket doesn't exist") {
+    val checksum = randomChecksum
+
+    val location = createObjectLocation
+
+    val verifiableLocation = createVerifiableLocationWith(
+      location = location,
+      checksum = checksum
+    )
+
+    val result =
+      withVerifier {
+        _.verify(verifiableLocation)
+      }
+
+    result shouldBe a[VerifiedFailure]
+
+    val verifiedFailure = result.asInstanceOf[VerifiedFailure]
+
+    verifiedFailure.location shouldBe verifiableLocation
+    verifiedFailure.e shouldBe a[LocationNotFound[_]]
+    verifiedFailure.e.getMessage should include(
+      "Location not available!"
+    )
+  }
+
+  it("fails if the key doesn't exist in the bucket") {
+    withLocalS3Bucket { bucket =>
+      val checksum = randomChecksum
+
+      val location = createObjectLocationWith(bucket)
+
+      val verifiableLocation = createVerifiableLocationWith(
+        location = location,
+        checksum = checksum
+      )
+
+      val result =
+        withVerifier {
+          _.verify(verifiableLocation)
+        }
+
+      result shouldBe a[VerifiedFailure]
+
+      val verifiedFailure = result.asInstanceOf[VerifiedFailure]
+
+      verifiedFailure.location shouldBe verifiableLocation
+      verifiedFailure.e shouldBe a[LocationNotFound[_]]
+      verifiedFailure.e.getMessage should include(
+        "Location not available!"
+      )
+    }
+  }
+}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/s3/S3ObjectVerifierTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/s3/S3ObjectVerifierTest.scala
@@ -1,7 +1,10 @@
 package uk.ac.wellcome.platform.archive.common.verify.s3
 
+import java.net.URI
+
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.common.storage.LocationNotFound
+import uk.ac.wellcome.platform.archive.common.storage.services.S3Resolvable
 import uk.ac.wellcome.platform.archive.common.verify._
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
@@ -24,6 +27,13 @@ class S3ObjectVerifierTest
     testWith(new S3ObjectVerifier())
 
   implicit val context: Unit = ()
+
+  implicit val s3Resolvable: S3Resolvable = new S3Resolvable()
+
+  import uk.ac.wellcome.platform.archive.common.storage.Resolvable._
+
+  override def resolve(location: ObjectLocation): URI =
+    location.resolve
 
   it("fails if the bucket doesn't exist") {
     val checksum = randomChecksum

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/s3/S3ObjectVerifierTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/s3/S3ObjectVerifierTest.scala
@@ -11,19 +11,21 @@ import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.store.fixtures.BucketNamespaceFixtures
 
 class S3ObjectVerifierTest
-  extends VerifierTestCases[Bucket, Unit]
+    extends VerifierTestCases[Bucket, Unit]
     with BucketNamespaceFixtures {
   override def withContext[R](testWith: TestWith[Unit, R]): R =
     testWith(())
 
-  override def putString(location: ObjectLocation, contents: String)(implicit context: Unit): Unit =
+  override def putString(location: ObjectLocation, contents: String)(
+    implicit context: Unit): Unit =
     s3Client.putObject(
       location.namespace,
       location.path,
       contents
     )
 
-  override def withVerifier[R](testWith: TestWith[Verifier[_], R])(implicit context: Unit): R =
+  override def withVerifier[R](testWith: TestWith[Verifier[_], R])(
+    implicit context: Unit): R =
     testWith(new S3ObjectVerifier())
 
   implicit val context: Unit = ()


### PR DESCRIPTION
Most of this logic has nothing to do with S3 – we can pull it into a type class, test it thoroughly and take another step towards Docker-free tests.