### PR TITLE
Tidy up the Terraform

### DIFF
--- a/terraform/endpoints.tf
+++ b/terraform/endpoints.tf
@@ -14,7 +14,7 @@ resource "aws_vpc_endpoint" "pl-winslow" {
   vpc_endpoint_type = "Interface"
 
   security_group_ids = [
-    "${module.stack-colbert.interservice_sg_id}",
+    "${module.stack_staging.interservice_sg_id}",
   ]
 
   subnet_ids = [
@@ -43,7 +43,7 @@ resource "aws_vpc_endpoint" "wt-winnipeg" {
   vpc_endpoint_type = "Interface"
 
   security_group_ids = [
-    "${module.stack_letterman.interservice_sg_id}",
+    "${module.stack_prod.interservice_sg_id}",
   ]
 
   subnet_ids = [

--- a/terraform/main_colbert.tf
+++ b/terraform/main_colbert.tf
@@ -1,13 +1,13 @@
-resource "aws_api_gateway_base_path_mapping" "mapping-colbert" {
-  api_id      = "${module.stack-colbert.api_gateway_id}"
+resource "aws_api_gateway_base_path_mapping" "mapping-staging" {
+  api_id      = "${module.stack_staging.api_gateway_id}"
   domain_name = "${local.staging_domain_name}"
   base_path   = "storage"
 }
 
-module "stack-colbert" {
+module "stack_staging" {
   source = "stack"
 
-  namespace = "${local.namespace}-colbert"
+  namespace = "${local.namespace}-staging"
 
   api_url          = "${local.staging_api_url}"
   domain_name      = "${local.staging_domain_name}"

--- a/terraform/main_letterman.tf
+++ b/terraform/main_letterman.tf
@@ -1,20 +1,20 @@
-resource "aws_api_gateway_base_path_mapping" "mapping_letterman" {
-  api_id      = "${module.stack_letterman.api_gateway_id}"
+resource "aws_api_gateway_base_path_mapping" "mapping_prod" {
+  api_id      = "${module.stack_prod.api_gateway_id}"
   domain_name = "${local.domain_name}"
   base_path   = "storage"
 }
 
-module "stack_letterman" {
+module "stack_prod" {
   source = "stack"
 
-  namespace = "${local.namespace}-letterman"
+  namespace = "${local.namespace}-prod"
 
   api_url          = "${local.api_url}"
   domain_name      = "${local.domain_name}"
   cert_domain_name = "${local.cert_domain_name}"
 
-  desired_bagger_count  = 3 # 3
-  desired_ec2_instances = 1 # 1
+  desired_bagger_count  = 3
+  desired_ec2_instances = 1
 
   vpc_id   = "${local.vpc_id}"
   vpc_cidr = "${local.vpc_cidr}"

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -7,3 +7,11 @@ output "unpacker_task_role_arns" {
     "${module.stack_letterman.unpacker_task_role_arn}",
   ]
 }
+
+output "staging_domain_name" {
+  value = "${module.stack-colbert.api_domain_name}"
+}
+
+output "prod_domain_name" {
+  value = "${module.stack_letterman.api_domain_name}"
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -3,15 +3,15 @@
 
 output "unpacker_task_role_arns" {
   value = [
-    "${module.stack-colbert.unpacker_task_role_arn}",
-    "${module.stack_letterman.unpacker_task_role_arn}",
+    "${module.stack_staging.unpacker_task_role_arn}",
+    "${module.stack_prod.unpacker_task_role_arn}",
   ]
 }
 
 output "staging_domain_name" {
-  value = "${module.stack-colbert.api_domain_name}"
+  value = "${module.stack_staging.api_domain_name}"
 }
 
 output "prod_domain_name" {
-  value = "${module.stack_letterman.api_domain_name}"
+  value = "${module.stack_prod.api_domain_name}"
 }

--- a/terraform/stack/api/domain/main.tf
+++ b/terraform/stack/api/domain/main.tf
@@ -1,0 +1,14 @@
+data "aws_acm_certificate" "certificate" {
+  domain   = "${var.cert_domain_name}"
+  statuses = ["ISSUED"]
+}
+
+resource "aws_api_gateway_domain_name" "stage" {
+  domain_name = "${var.domain_name}"
+
+  regional_certificate_arn = "${data.aws_acm_certificate.certificate.arn}"
+
+  endpoint_configuration = {
+    types = ["REGIONAL"]
+  }
+}

--- a/terraform/stack/api/domain/ouputs.tf
+++ b/terraform/stack/api/domain/ouputs.tf
@@ -1,0 +1,7 @@
+output "domain_name" {
+  value = "${aws_api_gateway_domain_name.stage.domain_name}"
+}
+
+output "regional_domain_name" {
+  value = "${aws_api_gateway_domain_name.stage.regional_domain_name}"
+}

--- a/terraform/stack/api/domain/variables.tf
+++ b/terraform/stack/api/domain/variables.tf
@@ -1,0 +1,2 @@
+variable "cert_domain_name" {}
+variable "domain_name" {}

--- a/terraform/stack/api/gateway.tf
+++ b/terraform/stack/api/gateway.tf
@@ -37,7 +37,7 @@ resource "aws_api_gateway_authorizer" "cognito" {
 # Domains
 
 module "domain" {
-  source = "git::https://github.com/wellcometrust/terraform.git//api_gateway/modules/domain?ref=v18.2.3"
+  source = "./domain"
 
   domain_name      = "${var.domain_name}"
   cert_domain_name = "${var.cert_domain_name}"

--- a/terraform/stack/api/outputs.tf
+++ b/terraform/stack/api/outputs.tf
@@ -17,3 +17,7 @@ output "bags_name" {
 output "bags_role_name" {
   value = "${module.services.bags_role_name}"
 }
+
+output "gateway_domain_name" {
+  value = "${module.domain.regional_domain_name}"
+}

--- a/terraform/stack/outputs.tf
+++ b/terraform/stack/outputs.tf
@@ -9,3 +9,7 @@ output "interservice_sg_id" {
 output "unpacker_task_role_arn" {
   value = "${module.bag_unpacker.task_role_arn}"
 }
+
+output "api_domain_name" {
+  value = "${module.api.gateway_domain_name}"
+}


### PR DESCRIPTION
Closes https://github.com/wellcometrust/platform/issues/3723, which makes it easier to set up DNS if you've changed something

Plus now uses "prod"/"staging" instead of "stewart/colbert/letterman".