### PR TITLE
Improve the user-facing error messages from the unpacker

### DIFF
--- a/bag_unpacker/docker-compose.yml
+++ b/bag_unpacker/docker-compose.yml
@@ -4,6 +4,8 @@ sqs:
     - "9324:9324"
     - "4789:9324"
 s3:
-  image: scality/s3server:mem-latest
+  image: "zenko/cloudserver:8.1.8"
+  environment:
+    - "S3BACKEND=mem"
   ports:
     - "33333:8000"

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
@@ -66,8 +66,8 @@ trait Unpacker {
     }
   }
 
-  private def buildMessageFor(srcLocation: ObjectLocation,
-                              error: UnpackerError): Option[String] =
+  protected def buildMessageFor(srcLocation: ObjectLocation,
+                                error: UnpackerError): Option[String] =
     error match {
       case UnpackerStorageError(_: DoesNotExistError) =>
         Some(s"There is no archive at $srcLocation")

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
@@ -73,7 +73,8 @@ trait Unpacker {
         Some(s"There is no archive at $srcLocation")
 
       case UnpackerUnarchiverError(_) =>
-        Some(s"Error trying to unpack the archive at $srcLocation - is it the correct format?")
+        Some(
+          s"Error trying to unpack the archive at $srcLocation - is it the correct format?")
 
       case _ => None
     }

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
@@ -72,6 +72,9 @@ trait Unpacker {
       case UnpackerStorageError(_: DoesNotExistError) =>
         Some(s"There is no archive at $srcLocation")
 
+      case UnpackerUnarchiverError(_) =>
+        Some(s"Error trying to unpack the archive at $srcLocation - is it the correct format?")
+
       case _ => None
     }
 

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3Unpacker.scala
@@ -4,9 +4,16 @@ import java.io.InputStream
 
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model.AmazonS3Exception
-import uk.ac.wellcome.platform.archive.bagunpacker.services.{Unpacker, UnpackerError, UnpackerStorageError}
+import uk.ac.wellcome.platform.archive.bagunpacker.services.{
+  Unpacker,
+  UnpackerError,
+  UnpackerStorageError
+}
 import uk.ac.wellcome.storage.store.s3.S3StreamStore
-import uk.ac.wellcome.storage.streaming.{InputStreamWithLength, InputStreamWithLengthAndMetadata}
+import uk.ac.wellcome.storage.streaming.{
+  InputStreamWithLength,
+  InputStreamWithLengthAndMetadata
+}
 import uk.ac.wellcome.storage.{ObjectLocation, StorageError, StoreReadError}
 
 class S3Unpacker()(implicit s3Client: AmazonS3) extends Unpacker {
@@ -30,9 +37,8 @@ class S3Unpacker()(implicit s3Client: AmazonS3) extends Unpacker {
                                error: UnpackerError): Option[String] =
     error match {
       case UnpackerStorageError(StoreReadError(exc: AmazonS3Exception))
-        if exc.getMessage.startsWith("Access Denied") =>
-          Some(s"Access denied while trying to read s3://$srcLocation")
-
+          if exc.getMessage.startsWith("Access Denied") =>
+        Some(s"Access denied while trying to read s3://$srcLocation")
 
       case _ =>
         println(error)

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
@@ -80,7 +80,7 @@ class UnpackerFeatureTest
   it("sends a failed Ingest update if it cannot read the bag") {
     withBagUnpackerApp(stepName = "unpacker") {
       case (_, _, queue, ingests, outgoing) =>
-        val payload = createSourceLocation
+        val payload = createSourceLocationPayload
         sendNotificationToSQS(queue, payload)
 
         eventually {

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
@@ -145,7 +145,8 @@ trait UnpackerTestCases[Namespace]
           ingestResult.summary.fileCount shouldBe 0
           ingestResult.summary.bytesUnpacked shouldBe 0
 
-          val ingestFailed = ingestResult.asInstanceOf[IngestFailed[UnpackSummary]]
+          val ingestFailed =
+            ingestResult.asInstanceOf[IngestFailed[UnpackSummary]]
           ingestFailed.maybeUserFacingMessage.get should startWith(
             s"Error trying to unpack the archive at $srcLocation")
         }

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
@@ -12,6 +12,7 @@ import uk.ac.wellcome.platform.archive.common.storage.models.{
   IngestStepSucceeded
 }
 import uk.ac.wellcome.storage.store.StreamStore
+import uk.ac.wellcome.storage.streaming.Codec._
 import uk.ac.wellcome.storage.streaming.{
   InputStreamWithLength,
   StreamAssertions
@@ -116,6 +117,39 @@ trait UnpackerTestCases[Namespace]
       val ingestFailed = ingestResult.asInstanceOf[IngestFailed[UnpackSummary]]
       ingestFailed.maybeUserFacingMessage shouldBe Some(
         s"There is no archive at $srcLocation")
+    }
+  }
+
+  it("fails if the specified file is not in tar.gz format") {
+    withNamespace { srcNamespace =>
+      withNamespace { dstNamespace =>
+        withStreamStore { implicit streamStore =>
+          val srcLocation = createObjectLocationWith(
+            namespace = srcNamespace,
+            path = randomAlphanumeric
+          )
+
+          streamStore.put(srcLocation)(
+            stringCodec.toStream("hello world").right.value
+          ) shouldBe a[Right[_, _]]
+
+          val result =
+            unpacker.unpack(
+              ingestId = createIngestID,
+              srcLocation = srcLocation,
+              dstLocation = createObjectLocationPrefix
+            )
+
+          val ingestResult = result.success.value
+          ingestResult shouldBe a[IngestFailed[_]]
+          ingestResult.summary.fileCount shouldBe 0
+          ingestResult.summary.bytesUnpacked shouldBe 0
+
+          val ingestFailed = ingestResult.asInstanceOf[IngestFailed[UnpackSummary]]
+          ingestFailed.maybeUserFacingMessage.get should startWith(
+            s"Error trying to unpack the archive at $srcLocation")
+        }
+      }
     }
   }
 

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3UnpackerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3UnpackerTest.scala
@@ -127,14 +127,10 @@ class S3UnpackerTest extends UnpackerTestCases[Bucket] with S3Fixtures {
 
           val ingestResult = result.success.value
           ingestResult shouldBe a[IngestFailed[_]]
-          ingestResult.summary.fileCount shouldBe 0
-          ingestResult.summary.bytesUnpacked shouldBe 0
 
-          val underlyingError =
-            ingestResult.asInstanceOf[IngestFailed[UnpackSummary]]
-          underlyingError.e shouldBe a[Throwable]
-          underlyingError.e.getMessage should startWith(
-            "The specified bucket is not valid")
+          val ingestFailed = ingestResult.asInstanceOf[IngestFailed[_]]
+
+          ingestFailed.maybeUserFacingMessage.get shouldBe s"Access denied while trying to read s3://${archiveLocation.namespace}/${archiveLocation.path}"
         }
       }
     }

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3UnpackerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3UnpackerTest.scala
@@ -102,7 +102,6 @@ class S3UnpackerTest extends UnpackerTestCases[Bucket] with S3Fixtures {
     withLocalS3Bucket { srcBucket =>
       withStreamStore { implicit streamStore =>
         withArchive(srcBucket, archiveFile) { archiveLocation =>
-
           // These credentials are one of the preconfigured accounts in the
           // zenko s3server Docker image.
           // See https://s3-server.readthedocs.io/en/latest/DOCKER.html#scality-access-key-id-and-scality-secret-access-key

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3UnpackerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3UnpackerTest.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.platform.archive.bagunpacker.services.s3
 
+import com.amazonaws.services.s3.AmazonS3
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.bagunpacker.models.UnpackSummary
 import uk.ac.wellcome.platform.archive.bagunpacker.services.{
@@ -10,6 +11,7 @@ import uk.ac.wellcome.platform.archive.common.storage.models.IngestFailed
 import uk.ac.wellcome.storage.{Identified, ObjectLocation}
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
+import uk.ac.wellcome.storage.s3.S3ClientFactory
 import uk.ac.wellcome.storage.store.StreamStore
 import uk.ac.wellcome.storage.store.s3.S3StreamStore
 import uk.ac.wellcome.storage.streaming.{
@@ -73,6 +75,51 @@ class S3UnpackerTest extends UnpackerTestCases[Bucket] with S3Fixtures {
           val dstLocation = createObjectLocationPrefix
           val result =
             unpacker.unpack(
+              ingestId = createIngestID,
+              srcLocation = archiveLocation,
+              dstLocation = dstLocation
+            )
+
+          val ingestResult = result.success.value
+          ingestResult shouldBe a[IngestFailed[_]]
+          ingestResult.summary.fileCount shouldBe 0
+          ingestResult.summary.bytesUnpacked shouldBe 0
+
+          val underlyingError =
+            ingestResult.asInstanceOf[IngestFailed[UnpackSummary]]
+          underlyingError.e shouldBe a[Throwable]
+          underlyingError.e.getMessage should startWith(
+            "The specified bucket is not valid")
+        }
+      }
+    }
+  }
+
+  it("includes a user-facing message if it gets a permissions error") {
+    val (archiveFile, _, _) = createTgzArchiveWithRandomFiles()
+    val dstLocation = createObjectLocationPrefix
+
+    withLocalS3Bucket { srcBucket =>
+      withStreamStore { implicit streamStore =>
+        withArchive(srcBucket, archiveFile) { archiveLocation =>
+
+          // These credentials are one of the preconfigured accounts in the
+          // zenko s3server Docker image.
+          // See https://s3-server.readthedocs.io/en/latest/DOCKER.html#scality-access-key-id-and-scality-secret-access-key
+          // https://github.com/scality/cloudserver/blob/5e17ec8343cd181936616efc0ac8d19d06dcd97d/conf/authdata.json
+          implicit val badS3Client: AmazonS3 =
+            S3ClientFactory.create(
+              region = "localhost",
+              endpoint = "http://localhost:33333",
+              accessKey = "accessKey2",
+              secretKey = "verySecretKey2"
+            )
+
+          val badUnpacker: S3Unpacker =
+            new S3Unpacker()(badS3Client)
+
+          val result =
+            badUnpacker.unpack(
               ingestId = createIngestID,
               srcLocation = archiveLocation,
               dstLocation = dstLocation

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -53,7 +53,7 @@ trait PayloadGenerators
       sourceLocation = sourceLocation
     )
 
-  def createSourceLocation: SourceLocationPayload =
+  def createSourceLocationPayload: SourceLocationPayload =
     createSourceLocationPayloadWith()
 
   def createUnpackedBagLocationPayloadWith(

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/operation/services/OutgoingPublisherTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/operation/services/OutgoingPublisherTest.scala
@@ -27,7 +27,7 @@ class OutgoingPublisherTest
     forAll(successfulOperations) { operation =>
       val messageSender = new MemoryMessageSender()
       val outgoingPublisher = createOutgoingPublisherWith(messageSender)
-      val outgoing = createSourceLocation
+      val outgoing = createSourceLocationPayload
 
       val notice = outgoingPublisher.sendIfSuccessful(operation, outgoing)
 
@@ -40,7 +40,7 @@ class OutgoingPublisherTest
   it("does not send outgoing if operation failed") {
     val messageSender = new MemoryMessageSender()
     val outgoingPublisher = createOutgoingPublisherWith(messageSender)
-    val outgoing = createSourceLocation
+    val outgoing = createSourceLocationPayload
 
     val notice =
       outgoingPublisher.sendIfSuccessful(createOperationFailure(), outgoing)


### PR DESCRIPTION
This adds two new error messages to the unpacker:

* If we go to unpack a bag from S3 and discover it's in a bucket we can't read, we send the message

    > Unpacking failed - Access denied while trying to read s3://bucket/archive.tar.gz

* If we go to unpack a bag and discover it's not in tar.gz format, we send the message

    > Unpacking failed - Error trying to unpack the archive at bucket/archive.tar.gz - is it the correct format?

This is one of the things @jtweed flagged in testing. We need to be a bit more consistent about when we use S3 URIs in user-facing messages, but that's a separate patch.