### PR TITLE
Don't expose information about the unpacked location

### DIFF
--- a/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/BagRootFinder.scala
+++ b/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/BagRootFinder.scala
@@ -47,11 +47,7 @@ class BagRootFinder()(implicit s3Client: AmazonS3) {
               startTime = startTime,
               endTime = Some(Instant.now())
             ),
-            err,
-            maybeUserFacingMessage =
-              // TODO: Add a toString method on ObjectLocationPrefix
-              Some(
-                s"Unable to find root of the bag at ${unpackLocation.namespace}/${unpackLocation.path}")
+            err
           )
       }
     }

--- a/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/BagRootFinderWorker.scala
+++ b/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/BagRootFinderWorker.scala
@@ -43,23 +43,9 @@ class BagRootFinderWorker[IngestDestination, OutgoingDestination](
         storageSpace = payload.storageSpace
       )
 
-      _ <- sendIngestInformation(payload)(summary)
       _ <- ingestUpdater.send(payload.ingestId, summary)
       _ <- sendSuccessful(payload)(summary)
     } yield summary
-
-  private def sendIngestInformation(payload: UnpackedBagLocationPayload)(
-    step: IngestStepResult[RootFinderSummary]): Try[Unit] =
-    step match {
-      case IngestStepSucceeded(summary: RootFinderSuccessSummary) =>
-        ingestUpdater.sendEvent(
-          ingestId = payload.ingestId,
-          messages = Seq(
-            s"Detected bag root as ${summary.bagRootLocation}",
-          )
-        )
-      case _ => Success(())
-    }
 
   private def sendSuccessful(payload: PipelinePayload)(
     step: IngestStepResult[RootFinderSummary]): Try[Unit] =

--- a/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/BagRootFinderFeatureTest.scala
+++ b/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/BagRootFinderFeatureTest.scala
@@ -24,7 +24,6 @@ class BagRootFinderFeatureTest
     withLocalS3Bucket { bucket =>
       withS3Bag(bucket) {
         case (bagRootLocation, storageSpace) =>
-          // TODO: Bag root location should really be a prefix here
           val payload = createUnpackedBagLocationPayloadWith(
             unpackedBagLocation = bagRootLocation.asPrefix,
             storageSpace = storageSpace
@@ -56,7 +55,6 @@ class BagRootFinderFeatureTest
                   ingests,
                   expectedDescriptions = Seq(
                     "Finding bag root started",
-                    s"Detected bag root as $bagRootLocation",
                     "Finding bag root succeeded"
                   )
                 )
@@ -104,7 +102,6 @@ class BagRootFinderFeatureTest
                   ingests,
                   expectedDescriptions = Seq(
                     "Finding bag root started",
-                    s"Detected bag root as $bagRootLocation",
                     "Finding bag root succeeded"
                   )
                 )
@@ -147,7 +144,7 @@ class BagRootFinderFeatureTest
                     val ingestFailed =
                       ingestUpdates.tail.head.asInstanceOf[IngestStatusUpdate]
                     ingestFailed.status shouldBe Ingest.Failed
-                    ingestFailed.events.head.description shouldBe s"Finding bag root failed - Unable to find root of the bag at $unpackedBagLocation"
+                    ingestFailed.events.head.description shouldBe s"Finding bag root failed"
                 }
               }
             }
@@ -183,7 +180,7 @@ class BagRootFinderFeatureTest
                 val ingestFailed =
                   ingestUpdates.tail.head.asInstanceOf[IngestStatusUpdate]
                 ingestFailed.status shouldBe Ingest.Failed
-                ingestFailed.events.head.description shouldBe s"Finding bag root failed - Unable to find root of the bag at $unpackedBagLocation"
+                ingestFailed.events.head.description shouldBe s"Finding bag root failed"
             }
           }
       }


### PR DESCRIPTION
The existence of the unpacked location is an internal detail of the storage service, and shouldn't be exposed to users -- just say "we couldn't find the bag root".

Closes https://github.com/wellcometrust/platform/issues/3708