### PR TITLE
Pass around less information inside the bag root finder

### DIFF
--- a/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/models/RootFinderSummary.scala
+++ b/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/models/RootFinderSummary.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.storage.bag_root_finder.models
 import java.time.Instant
 
 import uk.ac.wellcome.platform.archive.common.operation.models.Summary
-import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 
 sealed trait RootFinderSummary extends Summary {
@@ -12,14 +11,12 @@ sealed trait RootFinderSummary extends Summary {
 
 case class RootFinderFailureSummary(
   location: ObjectLocationPrefix,
-  space: StorageSpace,
   startTime: Instant,
   endTime: Option[Instant]
 ) extends RootFinderSummary
 
 case class RootFinderSuccessSummary(
   location: ObjectLocationPrefix,
-  space: StorageSpace,
   startTime: Instant,
   bagRootLocation: ObjectLocation,
   endTime: Option[Instant]

--- a/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/BagRootFinder.scala
+++ b/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/BagRootFinder.scala
@@ -3,12 +3,10 @@ package uk.ac.wellcome.platform.storage.bag_root_finder.services
 import java.time.Instant
 
 import com.amazonaws.services.s3.AmazonS3
-import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
 import uk.ac.wellcome.platform.archive.common.storage.models.{
   IngestFailed,
   IngestStepResult,
-  IngestStepSucceeded,
-  StorageSpace
+  IngestStepSucceeded
 }
 import uk.ac.wellcome.platform.archive.common.storage.services.S3BagLocator
 import uk.ac.wellcome.platform.storage.bag_root_finder.models._
@@ -21,9 +19,7 @@ class BagRootFinder()(implicit s3Client: AmazonS3) {
 
   type IngestStep = Try[IngestStepResult[RootFinderSummary]]
 
-  def getSummary(ingestId: IngestID,
-                 unpackLocation: ObjectLocationPrefix,
-                 storageSpace: StorageSpace): IngestStep =
+  def getSummary(unpackLocation: ObjectLocationPrefix): IngestStep =
     Try {
       val startTime = Instant.now()
 
@@ -32,7 +28,6 @@ class BagRootFinder()(implicit s3Client: AmazonS3) {
           IngestStepSucceeded(
             RootFinderSuccessSummary(
               location = unpackLocation,
-              space = storageSpace,
               bagRootLocation = rootLocation,
               startTime = startTime,
               endTime = Some(Instant.now())
@@ -43,7 +38,6 @@ class BagRootFinder()(implicit s3Client: AmazonS3) {
           IngestFailed(
             RootFinderFailureSummary(
               location = unpackLocation,
-              space = storageSpace,
               startTime = startTime,
               endTime = Some(Instant.now())
             ),

--- a/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/BagRootFinderWorker.scala
+++ b/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/BagRootFinderWorker.scala
@@ -38,9 +38,7 @@ class BagRootFinderWorker[IngestDestination, OutgoingDestination](
       _ <- ingestUpdater.start(ingestId = payload.ingestId)
 
       summary <- bagRootFinder.getSummary(
-        ingestId = payload.ingestId,
-        unpackLocation = payload.unpackedBagLocation,
-        storageSpace = payload.storageSpace
+        unpackLocation = payload.unpackedBagLocation
       )
 
       _ <- sendIngestInformation(payload)(summary)


### PR DESCRIPTION
A quick refactoring spotted while working on #258 – we pass around internal info we don’t need.