### PR TITLE
Bump the scala-storage lib

### DIFF
--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
@@ -80,13 +80,11 @@ trait BagsApiFixture
     val brokenIndex =
       new MemoryStore[
         Version[String, Int],
-        HybridIndexedStoreEntry[Version[String, Int],
-                                String,
+        HybridIndexedStoreEntry[String,
                                 Map[String, String]]](
         initialEntries = Map.empty) with MemoryMaxima[
         String,
-        HybridIndexedStoreEntry[Version[String, Int],
-                                String,
+        HybridIndexedStoreEntry[String,
                                 Map[String, String]]] {
         override def max(id: String) =
           Left(NoMaximaValueError(new Throwable("BOOM!")))

--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
@@ -80,12 +80,10 @@ trait BagsApiFixture
     val brokenIndex =
       new MemoryStore[
         Version[String, Int],
-        HybridIndexedStoreEntry[String,
-                                Map[String, String]]](
+        HybridIndexedStoreEntry[String, Map[String, String]]](
         initialEntries = Map.empty) with MemoryMaxima[
         String,
-        HybridIndexedStoreEntry[String,
-                                Map[String, String]]] {
+        HybridIndexedStoreEntry[String, Map[String, String]]] {
         override def max(id: String) =
           Left(NoMaximaValueError(new Throwable("BOOM!")))
       }

--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestStarterTest.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestStarterTest.scala
@@ -65,7 +65,7 @@ class IngestStarterTest
     val messageSender = new MemoryMessageSender()
 
     val brokenTracker = new MemoryIngestTracker(
-      underlying = new MemoryVersionedStore[IngestID, Int, Ingest](
+      underlying = new MemoryVersionedStore[IngestID, Ingest](
         new MemoryStore[Version[IngestID, Int], Ingest](
           initialEntries = Map.empty) with MemoryMaxima[IngestID, Ingest]
       )

--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/fixtures/IngestsApiFixture.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/fixtures/IngestsApiFixture.scala
@@ -72,7 +72,7 @@ trait IngestsApiFixture
     val messageSender = new MemoryMessageSender()
 
     val brokenTracker = new MemoryIngestTracker(
-      underlying = new MemoryVersionedStore[IngestID, Int, Ingest](
+      underlying = new MemoryVersionedStore[IngestID, Ingest](
         new MemoryStore[Version[IngestID, Int], Ingest](
           initialEntries = Map.empty) with MemoryMaxima[IngestID, Ingest]
       )

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
@@ -80,7 +80,11 @@ class UnpackerFeatureTest
   it("sends a failed Ingest update if it cannot read the bag") {
     withBagUnpackerApp(stepName = "unpacker") {
       case (_, _, queue, ingests, outgoing) =>
-        val payload = createSourceLocationPayload
+        val payload = createSourceLocationPayloadWith(
+          sourceLocation = createObjectLocationWith(
+            bucket = createBucket
+          )
+        )
         sendNotificationToSQS(queue, payload)
 
         eventually {

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagReader.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagReader.scala
@@ -55,7 +55,7 @@ trait BagReader[IS <: InputStreamWithLength] {
               BagUnavailable(s"Error loading ${path.value}: ${e.getMessage}"))
         }
 
-      case Left(err: DoesNotExistError) =>
+      case Left(_: DoesNotExistError) =>
         Right(None)
 
       case Left(err) =>

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/config/builders/StorageManifestDaoBuilder.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/config/builders/StorageManifestDaoBuilder.scala
@@ -68,10 +68,11 @@ object StorageManifestDaoBuilder {
 //        )
 //    }
 
-    type DynamoStoreEntry = HybridIndexedStoreEntry[ObjectLocation,
-                                                    Map[String, String]]
+    type DynamoStoreEntry =
+      HybridIndexedStoreEntry[ObjectLocation, Map[String, String]]
 
-    implicit val indexedStore: DynamoHashRangeStore[String, Int, DynamoStoreEntry] =
+    implicit val indexedStore
+      : DynamoHashRangeStore[String, Int, DynamoStoreEntry] =
       new DynamoHashRangeStore[String, Int, DynamoStoreEntry](dynamoConfig)
 
     new DynamoVersionedHybridStore[

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/config/builders/StorageManifestDaoBuilder.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/config/builders/StorageManifestDaoBuilder.scala
@@ -22,7 +22,7 @@ import uk.ac.wellcome.storage.store.dynamo.{
 import uk.ac.wellcome.storage.store.s3.{S3StreamStore, S3TypedStore}
 import uk.ac.wellcome.storage.streaming.Codec._
 import uk.ac.wellcome.storage.typesafe.{DynamoBuilder, S3Builder}
-import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix, Version}
+import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 
 object StorageManifestDaoBuilder {
   def buildVHS(
@@ -68,18 +68,11 @@ object StorageManifestDaoBuilder {
 //        )
 //    }
 
-    implicit val indexedStore
-      : DynamoHashRangeStore[String,
-                             Int,
-                             HybridIndexedStoreEntry[Version[String, Int],
-                                                     ObjectLocation,
-                                                     Map[String, String]]] =
-      new DynamoHashRangeStore[
-        String,
-        Int,
-        HybridIndexedStoreEntry[Version[String, Int],
-                                ObjectLocation,
-                                Map[String, String]]](dynamoConfig)
+    type DynamoStoreEntry = HybridIndexedStoreEntry[ObjectLocation,
+                                                    Map[String, String]]
+
+    implicit val indexedStore: DynamoHashRangeStore[String, Int, DynamoStoreEntry] =
+      new DynamoHashRangeStore[String, Int, DynamoStoreEntry](dynamoConfig)
 
     new DynamoVersionedHybridStore[
       String,

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Verifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Verifier.scala
@@ -36,8 +36,8 @@ trait Verifier[IS <: InputStream with HasLength] extends Logging {
       }
 
       inputStream <- streamStore.get(objectLocation) match {
-        case Right(stream)                => Right(Some(stream.identifiedT))
-        case Left(err: DoesNotExistError) => Right(None)
+        case Right(stream)              => Right(Some(stream.identifiedT))
+        case Left(_: DoesNotExistError) => Right(None)
         case Left(storageError) =>
           Left(
             LocationError(verifiableLocation, storageError.e.getMessage)

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageManifestVHSFixture.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageManifestVHSFixture.scala
@@ -11,29 +11,17 @@ import uk.ac.wellcome.storage.store.HybridIndexedStoreEntry
 import uk.ac.wellcome.storage.store.memory._
 
 trait StorageManifestVHSFixture extends EitherValues {
+  type StoreEntry = HybridIndexedStoreEntry[String, Map[String, String]]
+
   type StorageManifestIndex =
-    MemoryStore[Version[String, Int],
-                HybridIndexedStoreEntry[Version[String, Int],
-                                        String,
-                                        Map[String, String]]] with MemoryMaxima[
-      String,
-      HybridIndexedStoreEntry[Version[String, Int],
-                              String,
-                              Map[String, String]]]
+    MemoryStore[Version[String, Int],StoreEntry]
+      with MemoryMaxima[String, StoreEntry]
 
   type StorageManifestTypedStore = MemoryTypedStore[String, StorageManifest]
 
   def createIndex: StorageManifestIndex =
-    new MemoryStore[
-      Version[String, Int],
-      HybridIndexedStoreEntry[Version[String, Int],
-                              String,
-                              Map[String, String]]](initialEntries = Map.empty)
-    with MemoryMaxima[
-      String,
-      HybridIndexedStoreEntry[Version[String, Int],
-                              String,
-                              Map[String, String]]]
+    new MemoryStore[Version[String, Int], StoreEntry](initialEntries = Map.empty)
+      with MemoryMaxima[String, StoreEntry]
 
   def createTypedStore: StorageManifestTypedStore = {
     val memoryStoreForStreamStore =

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageManifestVHSFixture.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageManifestVHSFixture.scala
@@ -14,14 +14,14 @@ trait StorageManifestVHSFixture extends EitherValues {
   type StoreEntry = HybridIndexedStoreEntry[String, Map[String, String]]
 
   type StorageManifestIndex =
-    MemoryStore[Version[String, Int],StoreEntry]
-      with MemoryMaxima[String, StoreEntry]
+    MemoryStore[Version[String, Int], StoreEntry] with MemoryMaxima[String,
+                                                                    StoreEntry]
 
   type StorageManifestTypedStore = MemoryTypedStore[String, StorageManifest]
 
   def createIndex: StorageManifestIndex =
-    new MemoryStore[Version[String, Int], StoreEntry](initialEntries = Map.empty)
-      with MemoryMaxima[String, StoreEntry]
+    new MemoryStore[Version[String, Int], StoreEntry](
+      initialEntries = Map.empty) with MemoryMaxima[String, StoreEntry]
 
   def createTypedStore: StorageManifestTypedStore = {
     val memoryStoreForStreamStore =

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/s3/S3ObjectVerifierTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/s3/S3ObjectVerifierTest.scala
@@ -3,7 +3,10 @@ package uk.ac.wellcome.platform.archive.common.verify.s3
 import java.net.URI
 
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.archive.common.storage.{LocationError, LocationNotFound}
+import uk.ac.wellcome.platform.archive.common.storage.{
+  LocationError,
+  LocationNotFound
+}
 import uk.ac.wellcome.platform.archive.common.storage.services.S3Resolvable
 import uk.ac.wellcome.platform.archive.common.verify._
 import uk.ac.wellcome.storage.ObjectLocation
@@ -84,7 +87,8 @@ class S3ObjectVerifierTest
 
     verifiedFailure.location shouldBe verifiableLocation
     verifiedFailure.e shouldBe a[LocationError[_]]
-    verifiedFailure.e.getMessage should include("The specified bucket is not valid")
+    verifiedFailure.e.getMessage should include(
+      "The specified bucket is not valid")
   }
 
   it("fails if the key doesn't exist in the bucket") {

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/s3/S3ObjectVerifierTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/s3/S3ObjectVerifierTest.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.archive.common.verify.s3
 import java.net.URI
 
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.archive.common.storage.LocationNotFound
+import uk.ac.wellcome.platform.archive.common.storage.{LocationError, LocationNotFound}
 import uk.ac.wellcome.platform.archive.common.storage.services.S3Resolvable
 import uk.ac.wellcome.platform.archive.common.verify._
 import uk.ac.wellcome.storage.ObjectLocation
@@ -40,7 +40,7 @@ class S3ObjectVerifierTest
   it("fails if the bucket doesn't exist") {
     val checksum = randomChecksum
 
-    val location = createObjectLocation
+    val location = createObjectLocationWith(bucket = createBucket)
 
     val verifiableLocation = createVerifiableLocationWith(
       location = location,
@@ -61,6 +61,30 @@ class S3ObjectVerifierTest
     verifiedFailure.e.getMessage should include(
       "Location not available!"
     )
+  }
+
+  it("fails if the bucket name is invalid") {
+    val checksum = randomChecksum
+
+    val location = createObjectLocationWith(namespace = "ABCD")
+
+    val verifiableLocation = createVerifiableLocationWith(
+      location = location,
+      checksum = checksum
+    )
+
+    val result =
+      withVerifier {
+        _.verify(verifiableLocation)
+      }
+
+    result shouldBe a[VerifiedFailure]
+
+    val verifiedFailure = result.asInstanceOf[VerifiedFailure]
+
+    verifiedFailure.location shouldBe verifiableLocation
+    verifiedFailure.e shouldBe a[LocationError[_]]
+    verifiedFailure.e.getMessage should include("The specified bucket is not valid")
   }
 
   it("fails if the key doesn't exist in the bucket") {

--- a/ingests_common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/tracker/memory/MemoryIngestTracker.scala
+++ b/ingests_common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/tracker/memory/MemoryIngestTracker.scala
@@ -7,11 +7,10 @@ import uk.ac.wellcome.platform.archive.common.ingests.tracker.{
   IngestTrackerError
 }
 import uk.ac.wellcome.storage.Version
-import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
 import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryVersionedStore}
 
 class MemoryIngestTracker(
-  val underlying: MemoryVersionedStore[IngestID, Int, Ingest])
+  val underlying: MemoryVersionedStore[IngestID, Ingest])
     extends IngestTracker {
 
   override def listByBagId(
@@ -34,9 +33,8 @@ class MemoryIngestTracker(
 object MemoryIngestTracker {
   def apply(): MemoryIngestTracker =
     new MemoryIngestTracker(
-      underlying = new MemoryVersionedStore[IngestID, Int, Ingest](
-        new MemoryStore[Version[IngestID, Int], Ingest](
-          initialEntries = Map.empty) with MemoryMaxima[IngestID, Ingest]
+      underlying = MemoryVersionedStore[IngestID, Ingest](
+        initialEntries = Map.empty
       )
     )
 }

--- a/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/tracker/fixtures/IngestTrackerFixtures.scala
+++ b/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/tracker/fixtures/IngestTrackerFixtures.scala
@@ -44,12 +44,12 @@ trait IngestTrackerFixtures extends EitherValues with TimeTestFixture {
     with MemoryMaxima[IngestID, Ingest]
 
   protected def createMemoryVersionedStore
-    : MemoryVersionedStore[IngestID, Int, Ingest] =
-    new MemoryVersionedStore[IngestID, Int, Ingest](createMemoryStore)
+    : MemoryVersionedStore[IngestID, Ingest] =
+    new MemoryVersionedStore[IngestID, Ingest](createMemoryStore)
 
   def withMemoryIngestTracker[R](initialIngests: Seq[Ingest] = Seq.empty)(
     testWith: TestWith[MemoryIngestTracker, R])(
-    implicit store: MemoryVersionedStore[IngestID, Int, Ingest] =
+    implicit store: MemoryVersionedStore[IngestID, Ingest] =
       createMemoryVersionedStore): R = {
     initialIngests
       .map { ingest =>

--- a/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/tracker/memory/MemoryIngestTrackerTest.scala
+++ b/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/tracker/memory/MemoryIngestTrackerTest.scala
@@ -15,26 +15,26 @@ import uk.ac.wellcome.storage.{
 }
 
 class MemoryIngestTrackerTest
-    extends IngestTrackerTestCases[MemoryVersionedStore[IngestID, Int, Ingest]]
+    extends IngestTrackerTestCases[MemoryVersionedStore[IngestID, Ingest]]
     with IngestTrackerFixtures {
 
   override def withContext[R](
-    testWith: TestWith[MemoryVersionedStore[IngestID, Int, Ingest], R]): R =
+    testWith: TestWith[MemoryVersionedStore[IngestID, Ingest], R]): R =
     testWith(createMemoryVersionedStore)
 
   override def withIngestTracker[R](initialIngests: Seq[Ingest])(
     testWith: TestWith[IngestTracker, R])(
-    implicit store: MemoryVersionedStore[IngestID, Int, Ingest]): R =
+    implicit store: MemoryVersionedStore[IngestID, Ingest]): R =
     withMemoryIngestTracker(initialIngests) { tracker =>
       testWith(tracker)
     }
 
   override def withBrokenUnderlyingInitTracker[R](
     testWith: TestWith[IngestTracker, R])(
-    implicit context: MemoryVersionedStore[IngestID, Int, Ingest]): R =
+    implicit context: MemoryVersionedStore[IngestID, Ingest]): R =
     testWith(
       new MemoryIngestTracker(
-        new MemoryVersionedStore[IngestID, Int, Ingest](createMemoryStore) {
+        new MemoryVersionedStore[IngestID, Ingest](createMemoryStore) {
           override def init(id: IngestID)(t: Ingest) =
             Left(StoreWriteError(new Throwable("BOOM!")))
         }
@@ -43,10 +43,10 @@ class MemoryIngestTrackerTest
 
   override def withBrokenUnderlyingGetTracker[R](
     testWith: TestWith[IngestTracker, R])(
-    implicit context: MemoryVersionedStore[IngestID, Int, Ingest]): R =
+    implicit context: MemoryVersionedStore[IngestID, Ingest]): R =
     testWith(
       new MemoryIngestTracker(
-        new MemoryVersionedStore[IngestID, Int, Ingest](createMemoryStore) {
+        new MemoryVersionedStore[IngestID, Ingest](createMemoryStore) {
           override def getLatest(id: IngestID) =
             Left(StoreReadError(new Throwable("BOOM!")))
         }
@@ -55,10 +55,10 @@ class MemoryIngestTrackerTest
 
   override def withBrokenUnderlyingUpdateTracker[R](
     testWith: TestWith[IngestTracker, R])(
-    implicit context: MemoryVersionedStore[IngestID, Int, Ingest]): R =
+    implicit context: MemoryVersionedStore[IngestID, Ingest]): R =
     testWith(
       new MemoryIngestTracker(
-        new MemoryVersionedStore[IngestID, Int, Ingest](createMemoryStore) {
+        new MemoryVersionedStore[IngestID, Ingest](createMemoryStore) {
           override def update(id: IngestID)(f: Ingest => Ingest) =
             Left(UpdateWriteError(new Throwable("BOOM!")))
         }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object WellcomeDependencies {
     val json       = "1.1.1"
     val messaging  = "5.3.1"
     val monitoring = "2.3.0"
-    val storage = "7.18.0"
+    val storage = "7.18.6"
     val typesafe = "1.0.0"
   }
 


### PR DESCRIPTION
The key thing this gets us is that S3StreamStore is now exposing the underlying S3 exception, so we can send better messages in the unpacker.