### PR TITLE
Improve the unpacker user-facing messages some more

### DIFF
--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3Unpacker.scala
@@ -14,7 +14,12 @@ import uk.ac.wellcome.storage.streaming.{
   InputStreamWithLength,
   InputStreamWithLengthAndMetadata
 }
-import uk.ac.wellcome.storage.{DoesNotExistError, ObjectLocation, StorageError, StoreReadError}
+import uk.ac.wellcome.storage.{
+  DoesNotExistError,
+  ObjectLocation,
+  StorageError,
+  StoreReadError
+}
 
 class S3Unpacker()(implicit s3Client: AmazonS3) extends Unpacker {
   private val s3StreamStore = new S3StreamStore()

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
@@ -80,10 +80,12 @@ class UnpackerFeatureTest
   it("sends a failed Ingest update if it cannot read the bag") {
     withBagUnpackerApp(stepName = "unpacker") {
       case (_, _, queue, ingests, outgoing) =>
+        val sourceLocation = createObjectLocationWith(
+          bucket = createBucket
+        )
+
         val payload = createSourceLocationPayloadWith(
-          sourceLocation = createObjectLocationWith(
-            bucket = createBucket
-          )
+          sourceLocation = sourceLocation
         )
         sendNotificationToSQS(queue, payload)
 
@@ -101,7 +103,7 @@ class UnpackerFeatureTest
                 ingestUpdates.tail.head.asInstanceOf[IngestStatusUpdate]
               ingestFailed.status shouldBe Ingest.Failed
               ingestFailed.events.head.description shouldBe
-                s"Unpacker failed - There is no archive at ${payload.sourceLocation}"
+                s"Unpacker failed - There is no S3 bucket ${sourceLocation.namespace}"
           }
         }
     }

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
@@ -115,7 +115,8 @@ trait UnpackerTestCases[Namespace]
       ingestResult.summary.bytesUnpacked shouldBe 0
 
       val ingestFailed = ingestResult.asInstanceOf[IngestFailed[UnpackSummary]]
-      ingestFailed.maybeUserFacingMessage.get should startWith("There is no archive at")
+      ingestFailed.maybeUserFacingMessage.get should startWith(
+        "There is no archive at")
     }
   }
 

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
@@ -115,8 +115,7 @@ trait UnpackerTestCases[Namespace]
       ingestResult.summary.bytesUnpacked shouldBe 0
 
       val ingestFailed = ingestResult.asInstanceOf[IngestFailed[UnpackSummary]]
-      ingestFailed.maybeUserFacingMessage shouldBe Some(
-        s"There is no archive at $srcLocation")
+      ingestFailed.maybeUserFacingMessage.get should startWith("There is no archive at")
     }
   }
 

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3UnpackerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3UnpackerTest.scala
@@ -178,39 +178,6 @@ class S3UnpackerTest extends UnpackerTestCases[Bucket] with S3Fixtures {
       }
     }
 
-    it("if the bucket is in the wrong region") {
-      val (archiveFile, _, _) = createTgzArchiveWithRandomFiles()
-      val dstLocation = createObjectLocationPrefix
-
-      withLocalS3Bucket { srcBucket =>
-        withStreamStore { implicit streamStore =>
-          withArchive(srcBucket, archiveFile) { archiveLocation =>
-            implicit val badS3Client: AmazonS3 =
-              S3ClientFactory.create(
-                region = "eu-west-1",
-                endpoint = "http://localhost:33333",
-                accessKey = "accessKey1",
-                secretKey = "verySecretKey1"
-              )
-
-            val badUnpacker: S3Unpacker =
-              new S3Unpacker()(badS3Client)
-
-            val result =
-              badUnpacker.unpack(
-                ingestId = createIngestID,
-                srcLocation = archiveLocation,
-                dstLocation = dstLocation
-              )
-
-            assertIsError(result) { maybeMessage =>
-              maybeMessage.get shouldBe s"Cannot read s3://${archiveLocation.namespace}/${archiveLocation.path} -- can only read archives in region eu-west-1, but this is in localhost"
-            }
-          }
-        }
-      }
-    }
-
     it("if the bucket name is invalid") {
       val srcLocation = createObjectLocationWith(namespace = "ABCD")
       val dstLocation = createObjectLocationPrefix

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3UnpackerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3UnpackerTest.scala
@@ -210,6 +210,24 @@ class S3UnpackerTest extends UnpackerTestCases[Bucket] with S3Fixtures {
         }
       }
     }
+
+    it("if the bucket name is invalid") {
+      val srcLocation = createObjectLocationWith(namespace = "ABCD")
+      val dstLocation = createObjectLocationPrefix
+
+      withStreamStore { implicit streamStore =>
+        val result =
+          unpacker.unpack(
+            ingestId = createIngestID,
+            srcLocation = srcLocation,
+            dstLocation = dstLocation
+          )
+
+        assertIsError(result) { maybeMessage =>
+          maybeMessage.get shouldBe s"${srcLocation.namespace} is not a valid S3 bucket name"
+        }
+      }
+    }
   }
 
   private def assertIsError(result: Try[IngestStepResult[UnpackSummary]])(

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3UnpackerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3UnpackerTest.scala
@@ -1,13 +1,17 @@
 package uk.ac.wellcome.platform.archive.bagunpacker.services.s3
 
 import com.amazonaws.services.s3.AmazonS3
+import org.scalatest.Assertion
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.bagunpacker.models.UnpackSummary
 import uk.ac.wellcome.platform.archive.bagunpacker.services.{
   Unpacker,
   UnpackerTestCases
 }
-import uk.ac.wellcome.platform.archive.common.storage.models.IngestFailed
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  IngestFailed,
+  IngestStepResult
+}
 import uk.ac.wellcome.storage.{Identified, ObjectLocation}
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
@@ -18,6 +22,8 @@ import uk.ac.wellcome.storage.streaming.{
   InputStreamWithLength,
   InputStreamWithLengthAndMetadata
 }
+
+import scala.util.Try
 
 class S3UnpackerTest extends UnpackerTestCases[Bucket] with S3Fixtures {
   override val unpacker: Unpacker = new S3Unpacker()
@@ -95,43 +101,53 @@ class S3UnpackerTest extends UnpackerTestCases[Bucket] with S3Fixtures {
     }
   }
 
-  it("includes a user-facing message if it gets a permissions error") {
-    val (archiveFile, _, _) = createTgzArchiveWithRandomFiles()
-    val dstLocation = createObjectLocationPrefix
+  describe("includes users-facing messages if reading the archive fails") {
+    it("includes a user-facing message if it gets a permissions error") {
+      val (archiveFile, _, _) = createTgzArchiveWithRandomFiles()
+      val dstLocation = createObjectLocationPrefix
 
-    withLocalS3Bucket { srcBucket =>
-      withStreamStore { implicit streamStore =>
-        withArchive(srcBucket, archiveFile) { archiveLocation =>
-          // These credentials are one of the preconfigured accounts in the
-          // zenko s3server Docker image.
-          // See https://s3-server.readthedocs.io/en/latest/DOCKER.html#scality-access-key-id-and-scality-secret-access-key
-          // https://github.com/scality/cloudserver/blob/5e17ec8343cd181936616efc0ac8d19d06dcd97d/conf/authdata.json
-          implicit val badS3Client: AmazonS3 =
-            S3ClientFactory.create(
-              region = "localhost",
-              endpoint = "http://localhost:33333",
-              accessKey = "accessKey2",
-              secretKey = "verySecretKey2"
-            )
+      withLocalS3Bucket { srcBucket =>
+        withStreamStore { implicit streamStore =>
+          withArchive(srcBucket, archiveFile) { archiveLocation =>
+            // These credentials are one of the preconfigured accounts in the
+            // zenko s3server Docker image.
+            // See https://s3-server.readthedocs.io/en/latest/DOCKER.html#scality-access-key-id-and-scality-secret-access-key
+            // https://github.com/scality/cloudserver/blob/5e17ec8343cd181936616efc0ac8d19d06dcd97d/conf/authdata.json
+            implicit val badS3Client: AmazonS3 =
+              S3ClientFactory.create(
+                region = "localhost",
+                endpoint = "http://localhost:33333",
+                accessKey = "accessKey2",
+                secretKey = "verySecretKey2"
+              )
 
-          val badUnpacker: S3Unpacker =
-            new S3Unpacker()(badS3Client)
+            val badUnpacker: S3Unpacker =
+              new S3Unpacker()(badS3Client)
 
-          val result =
-            badUnpacker.unpack(
-              ingestId = createIngestID,
-              srcLocation = archiveLocation,
-              dstLocation = dstLocation
-            )
+            val result =
+              badUnpacker.unpack(
+                ingestId = createIngestID,
+                srcLocation = archiveLocation,
+                dstLocation = dstLocation
+              )
 
-          val ingestResult = result.success.value
-          ingestResult shouldBe a[IngestFailed[_]]
-
-          val ingestFailed = ingestResult.asInstanceOf[IngestFailed[_]]
-
-          ingestFailed.maybeUserFacingMessage.get shouldBe s"Access denied while trying to read s3://${archiveLocation.namespace}/${archiveLocation.path}"
+            assertIsError(result) { maybeMessage =>
+              maybeMessage.get shouldBe s"Access denied while trying to read s3://${archiveLocation.namespace}/${archiveLocation.path}"
+            }
+          }
         }
       }
     }
+  }
+
+  private def assertIsError(result: Try[IngestStepResult[UnpackSummary]])(
+    checkMessage: Option[String] => Assertion
+  ): Assertion = {
+    val ingestResult = result.success.value
+    ingestResult shouldBe a[IngestFailed[_]]
+
+    val ingestFailed = ingestResult.asInstanceOf[IngestFailed[_]]
+
+    checkMessage(ingestFailed.maybeUserFacingMessage)
   }
 }


### PR DESCRIPTION
New messages:

* Not all strings are valid S3 bucket names (e.g. bucket names must be lowercase), so if the SDK complains we pass that up to the user:

    > Unpacking failed - BUKKIT is not a valid S3 bucket name

* If you tell us to look in a bucket that flat out doesn't exist, previously we'd send a slightly generic "Could not read archive", now we send

    > Unpacking failed - There is no S3 bucket mygreatbukkit

* And now if the bucket exists, but the key doesn't, we send:

    > Unpacking failed - There is no archive at s3://mygreatbukkit/archive.tar.gz

  Previously we wouldn't add the `s3://` prefix; now we're consistent.

Closes https://github.com/wellcometrust/platform/issues/3735.

We can give a better error if the source bucket is in a different region (https://github.com/wellcometrust/platform/issues/3736), but I haven't found a way to test it reliably.