### PR TITLE
Add a minimal /versions endpoint to the bags API

### DIFF
--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Router.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Router.scala
@@ -93,6 +93,21 @@ class Router(storageManifestDao: StorageManifestDao, contextURL: URL)(
             }
           }
         }
+      } ~ path(Segment / Segment / "versions") { (space, externalIdentifier) =>
+        val bagId = BagId(
+          space = StorageSpace(space),
+          externalIdentifier = ExternalIdentifier(externalIdentifier)
+        )
+
+        get {
+          complete(
+            NotFound -> UserErrorResponse(
+              context = contextURL,
+              statusCode = StatusCodes.NotFound,
+              description = s"No storage manifest versions found for $bagId"
+            )
+          )
+        }
       }
     }
   }

--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Router.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Router.scala
@@ -8,11 +8,24 @@ import akka.http.scaladsl.server.Route
 import grizzled.slf4j.Logging
 import io.circe.Printer
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, ExternalIdentifier}
-import uk.ac.wellcome.platform.archive.common.http.models.{InternalServerErrorResponse, UserErrorResponse}
-import uk.ac.wellcome.platform.archive.common.storage.models.{StorageManifest, StorageSpace}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagId,
+  ExternalIdentifier
+}
+import uk.ac.wellcome.platform.archive.common.http.models.{
+  InternalServerErrorResponse,
+  UserErrorResponse
+}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  StorageManifest,
+  StorageSpace
+}
 import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
-import uk.ac.wellcome.platform.storage.bags.api.models.{DisplayResultList, ResponseDisplayBag, ResultListEntry}
+import uk.ac.wellcome.platform.storage.bags.api.models.{
+  DisplayResultList,
+  ResponseDisplayBag,
+  ResultListEntry
+}
 import uk.ac.wellcome.storage.{NoVersionExistsError, ReadError}
 
 import scala.concurrent.ExecutionContext
@@ -71,7 +84,9 @@ class Router(storageManifestDao: StorageManifestDao, contextURL: URL)(
                   )
                 )
               case Left(storageError) =>
-                error(s"Error while trying to look up $bagId v = $maybeVersion", storageError.e)
+                error(
+                  s"Error while trying to look up $bagId v = $maybeVersion",
+                  storageError.e)
                 complete(
                   InternalServerError -> InternalServerErrorResponse(
                     context = contextURL,
@@ -124,14 +139,15 @@ class Router(storageManifestDao: StorageManifestDao, contextURL: URL)(
               case Success(Some(version)) =>
                 buildResultsList(
                   storageManifestDao.listVersions(bagId, before = version),
-                  notFoundMessage = s"No storage manifest versions found for $bagId before v$version"
-
+                  notFoundMessage =
+                    s"No storage manifest versions found for $bagId before v$version"
                 )
 
               case Success(None) =>
                 buildResultsList(
                   storageManifestDao.listVersions(bagId),
-                  notFoundMessage = s"No storage manifest versions found for $bagId"
+                  notFoundMessage =
+                    s"No storage manifest versions found for $bagId"
                 )
 
               // Note: if the version is empty, we'll always be able to parse it,
@@ -141,7 +157,8 @@ class Router(storageManifestDao: StorageManifestDao, contextURL: URL)(
                   BadRequest -> UserErrorResponse(
                     context = contextURL,
                     statusCode = StatusCodes.BadRequest,
-                    description = s"Cannot parse version string: ${maybeVersion.get}"
+                    description =
+                      s"Cannot parse version string: ${maybeVersion.get}"
                   )
                 )
             }
@@ -157,8 +174,11 @@ class Router(storageManifestDao: StorageManifestDao, contextURL: URL)(
     queryParam match {
       case Some(versionString) =>
         versionRegex.findFirstMatchIn(versionString) match {
-          case Some(regexMatch) => Success(Some(regexMatch.group("version").toInt))
-          case None             => Failure(new Throwable(s"Could not parse version string: $versionString"))
+          case Some(regexMatch) =>
+            Success(Some(regexMatch.group("version").toInt))
+          case None =>
+            Failure(
+              new Throwable(s"Could not parse version string: $versionString"))
         }
 
       case None => Success(None)

--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Router.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Router.scala
@@ -10,19 +10,18 @@ import io.circe.Printer
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, ExternalIdentifier}
 import uk.ac.wellcome.platform.archive.common.http.models.{InternalServerErrorResponse, UserErrorResponse}
-import uk.ac.wellcome.platform.archive.common.storage.models.{StorageManifest, StorageSpace}
+import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
 import uk.ac.wellcome.platform.storage.bags.api.models.{DisplayResultList, ResponseDisplayBag, ResultListEntry}
-import uk.ac.wellcome.storage.{NoVersionExistsError, ReadError}
+import uk.ac.wellcome.storage.NoVersionExistsError
 
 import scala.concurrent.ExecutionContext
 import scala.util.matching.Regex
+import scala.util.{Failure, Success, Try}
 
 class Router(storageManifestDao: StorageManifestDao, contextURL: URL)(
   implicit val ec: ExecutionContext)
     extends Logging {
-
-  private val versionRegex: Regex = new Regex("^v(\\d+)$", "version")
 
   def routes: Route = {
     import akka.http.scaladsl.server.Directives._
@@ -39,18 +38,16 @@ class Router(storageManifestDao: StorageManifestDao, contextURL: URL)(
 
         get {
           parameter('version.as[String] ?) { maybeVersion =>
-            val result: Either[ReadError, StorageManifest] =
-              maybeVersion match {
-                case Some(versionString) =>
-                  versionRegex.findFirstMatchIn(versionString) match {
-                    case Some(regexMatch) =>
-                      storageManifestDao.get(
-                        bagId,
-                        version = regexMatch.group("version").toInt)
-                    case None => Left(NoVersionExistsError())
-                  }
-                case None => storageManifestDao.getLatest(bagId)
-              }
+            val result = parseVersion(maybeVersion) match {
+              case Success(Some(version)) =>
+                storageManifestDao.get(bagId, version = version)
+
+              case Success(None) =>
+                storageManifestDao.getLatest(bagId)
+
+              case Failure(_) =>
+                Left(NoVersionExistsError())
+            }
 
             result match {
               case Right(storageManifest) =>
@@ -117,4 +114,17 @@ class Router(storageManifestDao: StorageManifestDao, contextURL: URL)(
       }
     }
   }
+
+  private val versionRegex: Regex = new Regex("^v(\\d+)$", "version")
+
+  private def parseVersion(queryParam: Option[String]): Try[Option[Int]] =
+    queryParam match {
+      case Some(versionString) =>
+        versionRegex.findFirstMatchIn(versionString) match {
+          case Some(regexMatch) => Success(Some(regexMatch.group("version").toInt))
+          case None             => Failure(new Throwable(s"Could not parse version string: $versionString"))
+        }
+
+      case None => Success(None)
+    }
 }

--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Router.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Router.scala
@@ -8,20 +8,11 @@ import akka.http.scaladsl.server.Route
 import grizzled.slf4j.Logging
 import io.circe.Printer
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.platform.archive.common.bagit.models.{
-  BagId,
-  ExternalIdentifier
-}
-import uk.ac.wellcome.platform.archive.common.http.models.{
-  InternalServerErrorResponse,
-  UserErrorResponse
-}
-import uk.ac.wellcome.platform.archive.common.storage.models.{
-  StorageManifest,
-  StorageSpace
-}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, ExternalIdentifier}
+import uk.ac.wellcome.platform.archive.common.http.models.{InternalServerErrorResponse, UserErrorResponse}
+import uk.ac.wellcome.platform.archive.common.storage.models.{StorageManifest, StorageSpace}
 import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
-import uk.ac.wellcome.platform.storage.bags.api.models.ResponseDisplayBag
+import uk.ac.wellcome.platform.storage.bags.api.models.{DisplayResultList, ResponseDisplayBag, ResultListEntry}
 import uk.ac.wellcome.storage.{NoVersionExistsError, ReadError}
 
 import scala.concurrent.ExecutionContext
@@ -114,7 +105,10 @@ class Router(storageManifestDao: StorageManifestDao, contextURL: URL)(
 
             case Right(manifests) =>
               complete(
-                manifests
+                DisplayResultList(
+                  context = contextURL.toString,
+                  results = manifests.map { ResultListEntry(_) }
+                )
               )
 
             case Left(err) => throw err.e

--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Router.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Router.scala
@@ -99,14 +99,26 @@ class Router(storageManifestDao: StorageManifestDao, contextURL: URL)(
           externalIdentifier = ExternalIdentifier(externalIdentifier)
         )
 
+        val matchingManifests = storageManifestDao.listVersions(bagId)
+
         get {
-          complete(
-            NotFound -> UserErrorResponse(
-              context = contextURL,
-              statusCode = StatusCodes.NotFound,
-              description = s"No storage manifest versions found for $bagId"
-            )
-          )
+          matchingManifests match {
+            case Right(Nil) =>
+              complete(
+                NotFound -> UserErrorResponse(
+                  context = contextURL,
+                  statusCode = StatusCodes.NotFound,
+                  description = s"No storage manifest versions found for $bagId"
+                )
+              )
+
+            case Right(manifests) =>
+              complete(
+                manifests
+              )
+
+            case Left(err) => throw err.e
+          }
         }
       }
     }

--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Router.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Router.scala
@@ -71,7 +71,7 @@ class Router(storageManifestDao: StorageManifestDao, contextURL: URL)(
                   )
                 )
               case Left(storageError) =>
-                error("Internal server error", storageError.e)
+                error(s"Error while trying to look up $bagId v = $maybeVersion", storageError.e)
                 complete(
                   InternalServerError -> InternalServerErrorResponse(
                     context = contextURL,
@@ -108,7 +108,14 @@ class Router(storageManifestDao: StorageManifestDao, contextURL: URL)(
                 )
               )
 
-            case Left(err) => throw err.e
+            case Left(err) =>
+              error(s"Error while trying to look up versions of $bagId", err.e)
+              complete(
+                InternalServerError -> InternalServerErrorResponse(
+                  context = contextURL,
+                  statusCode = StatusCodes.InternalServerError
+                )
+              )
           }
 
         get {

--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/models/DisplayResultList.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/models/DisplayResultList.scala
@@ -1,0 +1,26 @@
+package uk.ac.wellcome.platform.storage.bags.api.models
+
+import io.circe.generic.extras.JsonKey
+import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
+
+case class ResultListEntry(
+  id: String,
+  version: String,
+  createdDate: String,
+  @JsonKey("type") ontologyType: String = "Bag"
+)
+
+case object ResultListEntry {
+  def apply(manifest: StorageManifest): ResultListEntry =
+    ResultListEntry(
+      id = manifest.id.toString,
+      version = s"v${manifest.version}",
+      createdDate = manifest.createdDate.toString
+    )
+}
+
+case class DisplayResultList(
+  @JsonKey("@context") context: String,
+  results: Seq[ResultListEntry],
+  @JsonKey("type") ontologyType: String = "ResultList"
+)

--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
@@ -324,7 +324,76 @@ class BagsApiFeatureTest
     }
 
     it("finds multiple versions of a manifest") {
-      true shouldBe false
+      val storageManifest = createStorageManifest
+
+      val multipleManifests = (1 to 5)
+        .map { version =>
+          version -> storageManifest.copy(
+            createdDate = randomInstant,
+            version = version
+          )
+        }
+        .toMap
+
+      val initialManifests = multipleManifests.values.toSeq.sortBy { _.version }
+
+      withConfiguredApp(initialManifests) { case (_, metrics, baseUrl) =>
+        val expectedJson =
+          s"""
+             |{
+             |  "@context": "http://api.wellcomecollection.org/storage/v1/context.json",
+             |  "type": "ResultList",
+             |  "results": [
+             |    {
+             |      "type": "Bag",
+             |      "id": "${storageManifest.id.toString}",
+             |      "version": "v5",
+             |      "createdDate": "${DateTimeFormatter.ISO_INSTANT.format(multipleManifests(5).createdDate)}"
+             |    },
+             |    {
+             |      "type": "Bag",
+             |      "id": "${ storageManifest.id.toString }",
+             |      "version": "v4",
+             |      "createdDate": "${ DateTimeFormatter.ISO_INSTANT.format(multipleManifests(4).createdDate) }"
+             |    },
+             |    {
+             |      "type": "Bag",
+             |      "id": "${ storageManifest.id.toString }",
+             |      "version": "v3",
+             |      "createdDate": "${ DateTimeFormatter.ISO_INSTANT.format(multipleManifests(3).createdDate) }"
+             |    },
+             |    {
+             |      "type": "Bag",
+             |      "id": "${ storageManifest.id.toString }",
+             |      "version": "v2",
+             |      "createdDate": "${ DateTimeFormatter.ISO_INSTANT.format(multipleManifests(2).createdDate) }"
+             |    },
+             |    {
+             |      "type": "Bag",
+             |      "id": "${ storageManifest.id.toString }",
+             |      "version": "v1",
+             |      "createdDate": "${ DateTimeFormatter.ISO_INSTANT.format(multipleManifests(1).createdDate) }"
+             |    }
+             |  ]
+             |}
+              """.stripMargin
+
+        val url =
+          s"$baseUrl/bags/${storageManifest.id.space}/${storageManifest.id.externalIdentifier}/versions"
+
+        whenGetRequestReady(url) { response =>
+          response.status shouldBe StatusCodes.OK
+
+          withStringEntity(response.entity) { actualJson =>
+            assertJsonStringsAreEqual(actualJson, expectedJson)
+          }
+
+          assertMetricSent(
+            metrics,
+            result = HttpMetricResults.Success
+          )
+        }
+      }
     }
 
     it("supports searching for manifests before a given version") {

--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
@@ -244,16 +244,24 @@ class BagsApiFeatureTest
     }
 
     it("returns a 500 error if looking up the bag fails") {
-      withBrokenApp {
-        case (_, metrics, baseUrl) =>
-          val bagId = createBagId
-          whenGetRequestReady(
-            s"$baseUrl/bags/${bagId.space}/${bagId.externalIdentifier}") {
-            response =>
-              assertIsInternalServerErrorResponse(response)
+      withBrokenApp { case (metrics, baseUrl) =>
+        whenGetRequestReady(s"$baseUrl/bags/$createBagId") {
+          response =>
+            assertIsInternalServerErrorResponse(response)
 
-              assertMetricSent(metrics, result = HttpMetricResults.ServerError)
-          }
+            assertMetricSent(metrics, result = HttpMetricResults.ServerError)
+        }
+      }
+    }
+
+    it("returns a 500 error if looking up a specific version of a bag fails") {
+      withBrokenApp { case (metrics, baseUrl) =>
+        whenGetRequestReady(s"$baseUrl/bags/${createBagId}?version=v1") {
+          response =>
+            assertIsInternalServerErrorResponse(response)
+
+            assertMetricSent(metrics, result = HttpMetricResults.ServerError)
+        }
       }
     }
   }
@@ -503,8 +511,15 @@ class BagsApiFeatureTest
       }
     }
 
-    it("returns a 500 if looking up the versions fails") {
-      true shouldBe false
+    it("returns a 500 if looking up the lists of versions fails") {
+      withBrokenApp { case (metrics, baseUrl) =>
+        whenGetRequestReady(s"$baseUrl/bags/$createBagId/versions") {
+          response =>
+            assertIsInternalServerErrorResponse(response)
+
+            assertMetricSent(metrics, result = HttpMetricResults.ServerError)
+        }
+      }
     }
   }
 }

--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
@@ -322,5 +322,17 @@ class BagsApiFeatureTest
         }
       }
     }
+
+    it("finds multiple versions of a manifest") {
+      true shouldBe false
+    }
+
+    it("supports searching for manifests before a given version") {
+      true shouldBe false
+    }
+
+    it("returns a 500 if looking up the versions fails") {
+      true shouldBe false
+    }
   }
 }

--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
@@ -243,9 +243,7 @@ class BagsApiFeatureTest
       }
     }
 
-    // TODO: Come back and restore this test when we can reliably
-    // break the underlying tracker.
-    ignore("returns a 500 error if looking up the bag fails") {
+    it("returns a 500 error if looking up the bag fails") {
       withBrokenApp {
         case (_, metrics, baseUrl) =>
           val bagId = createBagId

--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
@@ -259,4 +259,24 @@ class BagsApiFeatureTest
       }
     }
   }
+
+  describe("GET /bags/:space/:id/versions") {
+    it("returns a 404 NotFound if there are no manifests for this bag ID") {
+      withConfiguredApp() { case (_, metrics, baseUrl) =>
+        val bagId = createBagId
+        whenGetRequestReady(
+          s"$baseUrl/bags/${bagId.space}/${bagId.externalIdentifier}/versions") {
+          response =>
+            assertIsUserErrorResponse(
+              response,
+              description = s"No storage manifest versions found for $bagId",
+              statusCode = StatusCodes.NotFound,
+              label = "Not Found"
+            )
+
+            assertMetricSent(metrics, result = HttpMetricResults.UserError)
+        }
+      }
+    }
+  }
 }

--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
@@ -475,7 +475,6 @@ class BagsApiFeatureTest
       }
     }
 
-
     it("returns a 500 if looking up the versions fails") {
       true shouldBe false
     }

--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
@@ -21,9 +21,8 @@ import uk.ac.wellcome.platform.archive.common.storage.services.{
 import uk.ac.wellcome.platform.archive.common.storage.services.memory.MemoryStorageManifestDao
 import uk.ac.wellcome.platform.storage.bags.api.BagsApi
 import uk.ac.wellcome.storage._
-import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
 import uk.ac.wellcome.storage.store.HybridStoreEntry
-import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryVersionedStore}
+import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
 
 import scala.concurrent.ExecutionContext.Implicits.global
 
@@ -79,33 +78,27 @@ trait BagsApiFixture
   }
 
   def withBrokenApp[R](
-    testWith: TestWith[(StorageManifestDao, MemoryMetrics[Unit], String), R])
+    testWith: TestWith[(MemoryMetrics[Unit], String), R])
     : R = {
-
-    // TODO: This should be a MaximaReadError really.
-    val brokenIndex =
-      new MemoryStore[
-        Version[BagId, Int],
-        HybridStoreEntry[StorageManifest, EmptyMetadata]](
-        initialEntries = Map.empty) with MemoryMaxima[
-        BagId,
-        HybridStoreEntry[StorageManifest, EmptyMetadata]] {
-        override def max(id: BagId) =
-          Left(MaximaReadError(new Throwable("BOOM!")))
-      }
-
-    val brokenVhs = new MemoryStorageManifestDao(
-      new MemoryVersionedStore[
-        BagId,
-        HybridStoreEntry[StorageManifest, EmptyMetadata]](
-        brokenIndex
-      )
+    val versionedStore = MemoryVersionedStore[BagId, HybridStoreEntry[StorageManifest, EmptyMetadata]](
+      initialEntries = Map.empty
     )
+
+    val brokenDao = new MemoryStorageManifestDao(versionedStore) {
+      override def getLatest(id: BagId): scala.Either[ReadError, StorageManifest] =
+        Left(StoreReadError(new Throwable("BOOM!")))
+
+      override def get(id: BagId, version: Int): Either[ReadError, StorageManifest] =
+        Left(StoreReadError(new Throwable("BOOM!")))
+
+      override def listVersions(bagId: BagId): Either[ReadError, Seq[StorageManifest]] =
+        Left(StoreReadError(new Throwable("BOOM!")))
+    }
 
     val metrics = new MemoryMetrics[Unit]()
 
-    withApp(metrics, brokenVhs) { _ =>
-      testWith((brokenVhs, metrics, httpServerConfig.externalBaseURL))
+    withApp(metrics, brokenDao) { _ =>
+      testWith((metrics, httpServerConfig.externalBaseURL))
     }
   }
 }

--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
@@ -78,20 +78,24 @@ trait BagsApiFixture
   }
 
   def withBrokenApp[R](
-    testWith: TestWith[(MemoryMetrics[Unit], String), R])
-    : R = {
-    val versionedStore = MemoryVersionedStore[BagId, HybridStoreEntry[StorageManifest, EmptyMetadata]](
+    testWith: TestWith[(MemoryMetrics[Unit], String), R]): R = {
+    val versionedStore = MemoryVersionedStore[
+      BagId,
+      HybridStoreEntry[StorageManifest, EmptyMetadata]](
       initialEntries = Map.empty
     )
 
     val brokenDao = new MemoryStorageManifestDao(versionedStore) {
-      override def getLatest(id: BagId): scala.Either[ReadError, StorageManifest] =
+      override def getLatest(
+        id: BagId): scala.Either[ReadError, StorageManifest] =
         Left(StoreReadError(new Throwable("BOOM!")))
 
-      override def get(id: BagId, version: Int): Either[ReadError, StorageManifest] =
+      override def get(id: BagId,
+                       version: Int): Either[ReadError, StorageManifest] =
         Left(StoreReadError(new Throwable("BOOM!")))
 
-      override def listVersions(bagId: BagId): Either[ReadError, Seq[StorageManifest]] =
+      override def listVersions(
+        bagId: BagId): Either[ReadError, Seq[StorageManifest]] =
         Left(StoreReadError(new Throwable("BOOM!")))
     }
 

--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
@@ -91,7 +91,7 @@ trait BagsApiFixture
         BagId,
         HybridStoreEntry[StorageManifest, EmptyMetadata]] {
         override def max(id: BagId) =
-          Left(NoMaximaValueError(new Throwable("BOOM!")))
+          Left(MaximaReadError(new Throwable("BOOM!")))
       }
 
     val brokenVhs = new MemoryStorageManifestDao(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/http/HttpMetrics.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/http/HttpMetrics.scala
@@ -16,6 +16,7 @@ class HttpMetrics(name: String, metrics: Metrics[Future, _]) extends Logging {
   def sendMetric(resp: HttpResponse): Future[Unit] =
     sendMetricForStatus(resp.status)
 
+  // TODO: Can this pattern match on ClientError, ServerError, etc?
   def sendMetricForStatus(status: StatusCode): Future[Unit] = {
     val httpMetric = if (status.isSuccess()) {
       HttpMetricResults.Success

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestDao.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestDao.scala
@@ -26,8 +26,8 @@ trait StorageManifestDao {
       )
       .map { _.identifiedT.t }
 
-  def listVersions(bagId: BagId,
-                   before: Option[Int]): Either[ReadError, Seq[StorageManifest]]
+  protected def listVersions(bagId: BagId,
+                             before: Option[Int]): Either[ReadError, Seq[StorageManifest]]
 
   def listVersions(bagId: BagId): Either[ReadError, Seq[StorageManifest]] =
     listVersions(bagId, before = None)

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestDao.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestDao.scala
@@ -26,8 +26,9 @@ trait StorageManifestDao {
       )
       .map { _.identifiedT.t }
 
-  protected def listVersions(bagId: BagId,
-                             before: Option[Int]): Either[ReadError, Seq[StorageManifest]]
+  protected def listVersions(
+    bagId: BagId,
+    before: Option[Int]): Either[ReadError, Seq[StorageManifest]]
 
   def listVersions(bagId: BagId): Either[ReadError, Seq[StorageManifest]] =
     listVersions(bagId, before = None)


### PR DESCRIPTION
Following the model defined in https://github.com/wellcometrust/platform/pull/3733, for https://github.com/wellcometrust/platform/issues/3731

This is missing a couple of pieces:

* The manifests don't have URLs on them; you have to know what to do with the version
* There's no `"latest": true` flag yet

Both are small frills that can be tackled in a separate PR (or dropped).

Plus better test coverage of the bags API. (Tests for internal server errors are back, and they're logging better info to boot.)