### PR TITLE
Improve the errors from the bag verifier

### DIFF
--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -33,7 +33,8 @@ class BagVerifier()(
       bagReader.get(root) match {
         case Left(bagUnavailable) =>
           IngestFailed(
-            summary = VerificationSummary.incomplete(root, bagUnavailable, startTime),
+            summary =
+              VerificationSummary.incomplete(root, bagUnavailable, startTime),
             e = bagUnavailable,
             maybeUserFacingMessage = Some(bagUnavailable.msg)
           )
@@ -57,12 +58,17 @@ class BagVerifier()(
             VerificationSummary.create(root, bag.verify, startTime) match {
               case success @ VerificationSuccessSummary(_, _, _, _) =>
                 IngestStepSucceeded(success)
-              case failure @ VerificationFailureSummary(_, Some(verification), _, _) =>
+              case failure @ VerificationFailureSummary(
+                    _,
+                    Some(verification),
+                    _,
+                    _) =>
                 val verificationFailureMessage =
-                  verification.failure.map { verifiedFailure =>
-                    s"${verifiedFailure.location.uri}: ${verifiedFailure.e.getMessage}"
-                  }
-                  .mkString("\n")
+                  verification.failure
+                    .map { verifiedFailure =>
+                      s"${verifiedFailure.location.uri}: ${verifiedFailure.e.getMessage}"
+                    }
+                    .mkString("\n")
 
                 warn(s"Errors verifying $root:\n$verificationFailureMessage")
 

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -65,7 +65,16 @@ class BagVerifier()(
                   .mkString("\n")
 
                 warn(s"Errors verifying $root:\n$verificationFailureMessage")
-                IngestFailed(failure, InvalidBag(bag))
+
+                val errorCount = verification.failure.size
+
+                val userFacingMessage =
+                  if (errorCount == 1)
+                    "There was 1 error verifying the bag"
+                  else
+                    s"There were $errorCount errors verifying the bag"
+
+                IngestFailed(failure, InvalidBag(bag), Some(userFacingMessage))
 
               case failure @ VerificationFailureSummary(_, None, _, _) =>
                 IngestFailed(failure, InvalidBag(bag))

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -31,9 +31,12 @@ class BagVerifier()(
       val startTime = Instant.now()
 
       bagReader.get(root) match {
-        // TODO: Provide more specific messages here
-        case Left(e) =>
-          IngestFailed(VerificationSummary.incomplete(root, e, startTime), e)
+        case Left(bagUnavailable) =>
+          IngestFailed(
+            summary = VerificationSummary.incomplete(root, bagUnavailable, startTime),
+            e = bagUnavailable,
+            maybeUserFacingMessage = Some(bagUnavailable.msg)
+          )
 
         case Right(bag) =>
           if (bag.info.externalIdentifier != externalIdentifier) {

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
@@ -124,7 +124,7 @@ class BagVerifierFeatureTest
                         ingestUpdates.tail.head
                           .asInstanceOf[IngestStatusUpdate]
                       ingestFailed.status shouldBe Ingest.Failed
-                      ingestFailed.events.head.description shouldBe "Verification failed"
+                      ingestFailed.events.head.description shouldBe "Verification failed - There was 1 error verifying the bag"
                   }
 
                   outgoing.messages shouldBe empty

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
@@ -151,36 +151,32 @@ class BagVerifierTest
     )
 
     withLocalS3Bucket { bucket =>
-      withS3Bag(
-        bucket,
-        bagInfo = bagInfo,
-        dataFileCount = dataFileCount) { root =>
-
-        // Now scribble over the contents of all the data files in the bag
-        listKeysInBucket(bucket).foreach { key =>
-          if (key.contains("/data/")) {
-            s3Client.putObject(
-              bucket.name,
-              key,
-              randomAlphanumeric
-            )
+      withS3Bag(bucket, bagInfo = bagInfo, dataFileCount = dataFileCount) {
+        root =>
+          // Now scribble over the contents of all the data files in the bag
+          listKeysInBucket(bucket).foreach { key =>
+            if (key.contains("/data/")) {
+              s3Client.putObject(
+                bucket.name,
+                key,
+                randomAlphanumeric
+              )
+            }
           }
-        }
 
-        withVerifier { verifier =>
-          val ingestStep =
-            verifier.verify(root, externalIdentifier = externalIdentifier)
-          val result = ingestStep.success.get
-          result shouldBe a[IngestFailed[_]]
+          withVerifier { verifier =>
+            val ingestStep =
+              verifier.verify(root, externalIdentifier = externalIdentifier)
+            val result = ingestStep.success.get
+            result shouldBe a[IngestFailed[_]]
 
-          val userFacingMessage =
-            result.asInstanceOf[IngestFailed[_]].maybeUserFacingMessage
-          userFacingMessage.get shouldBe s"There were $dataFileCount errors verifying the bag"
-        }
+            val userFacingMessage =
+              result.asInstanceOf[IngestFailed[_]].maybeUserFacingMessage
+            userFacingMessage.get shouldBe s"There were $dataFileCount errors verifying the bag"
+          }
       }
     }
   }
-
 
   it("fails a bag if the file manifest refers to a non-existent file") {
     val externalIdentifier = createExternalIdentifier

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
@@ -202,6 +202,10 @@ class BagVerifierTest
 
           error shouldBe a[BagUnavailable]
           error.getMessage should include("Error loading manifest-sha256.txt")
+
+          val userFacingMessage =
+            result.asInstanceOf[IngestFailed[_]].maybeUserFacingMessage
+          userFacingMessage.get shouldBe "Error loading manifest-sha256.txt: no such file!"
         }
       }
     }
@@ -227,6 +231,10 @@ class BagVerifierTest
           error shouldBe a[BagUnavailable]
           error.getMessage should include(
             "Error loading tagmanifest-sha256.txt")
+
+          val userFacingMessage =
+            result.asInstanceOf[IngestFailed[_]].maybeUserFacingMessage
+          userFacingMessage.get shouldBe "Error loading tagmanifest-sha256.txt: no such file!"
         }
       }
     }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Checksum.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Checksum.scala
@@ -97,7 +97,8 @@ case class FailedChecksumCreation(algorithm: HashingAlgorithm, e: Throwable)
     extends Throwable(s"Could not create checksum: ${e.getMessage}")
     with FailedChecksum
 case class FailedChecksumNoMatch(actual: Checksum, expected: Checksum)
-    extends Throwable(s"Checksum values do not match! Expected: $expected, saw: $actual")
+    extends Throwable(
+      s"Checksum values do not match! Expected: $expected, saw: $actual")
     with FailedChecksum
 case class FailedChecksumLocationNotFound[T](location: VerifiableLocation)
     extends Throwable("VerifiableLocation not found!")

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Checksum.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Checksum.scala
@@ -14,7 +14,10 @@ import scala.util.Try
 case class Checksum(
   algorithm: HashingAlgorithm,
   value: ChecksumValue
-)
+) {
+  override def toString: String =
+    s"${algorithm.pathRepr}:$value"
+}
 
 case object Checksum extends Logging {
   def create(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Checksum.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Checksum.scala
@@ -93,7 +93,7 @@ sealed trait FailedChecksum
 case class FailedChecksumCreation(algorithm: HashingAlgorithm, e: Throwable)
     extends Throwable(s"Could not create checksum: ${e.getMessage}")
     with FailedChecksum
-case class FailedChecksumNoMatch(a: Checksum, b: Checksum)
+case class FailedChecksumNoMatch(actual: Checksum, expected: Checksum)
     extends Throwable("Checksum values do not match!")
     with FailedChecksum
 case class FailedChecksumLocationNotFound[T](location: VerifiableLocation)

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Checksum.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Checksum.scala
@@ -97,7 +97,7 @@ case class FailedChecksumCreation(algorithm: HashingAlgorithm, e: Throwable)
     extends Throwable(s"Could not create checksum: ${e.getMessage}")
     with FailedChecksum
 case class FailedChecksumNoMatch(actual: Checksum, expected: Checksum)
-    extends Throwable("Checksum values do not match!")
+    extends Throwable(s"Checksum values do not match! Expected: $expected, saw: $actual")
     with FailedChecksum
 case class FailedChecksumLocationNotFound[T](location: VerifiableLocation)
     extends Throwable("VerifiableLocation not found!")

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Verifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Verifier.scala
@@ -104,8 +104,8 @@ trait Verifier[IS <: InputStream with HasLength] extends Logging {
           VerifiedFailure(
             verifiableLocation,
             FailedChecksumNoMatch(
-              checksum,
-              verifiableLocation.checksum
+              actual = checksum,
+              expected = verifiableLocation.checksum
             )
           )
         } else {

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/ChecksumTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/ChecksumTest.scala
@@ -1,27 +1,39 @@
 package uk.ac.wellcome.platform.archive.common.storage.services
 
-import org.apache.commons.io.IOUtils
+import java.io.InputStream
+
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.{EitherValues, FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
 import uk.ac.wellcome.platform.archive.common.verify.{
   Checksum,
   ChecksumValue,
   SHA256
 }
+import uk.ac.wellcome.storage.streaming.Codec._
 
 import scala.util.Success
 
 class ChecksumTest
     extends FunSpec
     with Matchers
+    with EitherValues
     with ScalaFutures
     with StorageRandomThings {
 
-  private def toInputStream(s: String) =
-    IOUtils.toInputStream(s, "UTF-8");
+  private def toInputStream(s: String): InputStream =
+    stringCodec.toStream(s).right.value
 
-  val algorithm = SHA256
+  val algorithm: SHA256.type = SHA256
+
+  it("creates a useful string representation") {
+    val checksum = Checksum(
+      SHA256,
+      ChecksumValue("1234567890")
+    )
+
+    checksum.toString shouldBe "sha256:1234567890"
+  }
 
   it("calculates the checksum") {
     val content = "text"

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/VerifierTestCases.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/VerifierTestCases.scala
@@ -110,7 +110,7 @@ trait VerifierTestCases[Namespace, Context]
         verifiedFailure.location shouldBe verifiableLocation
         verifiedFailure.e shouldBe a[FailedChecksumNoMatch]
         verifiedFailure.e.getMessage should startWith(
-          "Checksum values do not match"
+          s"Checksum values do not match! Expected: $checksum"
         )
       }
     }


### PR DESCRIPTION
Improvements:

* If the bag is malformed (e.g. no bag-info.txt), we'll expose those error messages directly. For example:

    > Verifying failed - Error loading manifest-sha256.txt: no such file!

* All the verifier failures are now logged internally, for example:

    > Errors verifying nqekgiix/M8TijdiT/QDxbEBoa:
    > http://localhost:33333/nqekgiix/M8TijdiT/QDxbEBoa/data/dir0/1.txt: Checksum values do not match! Expected: sha256:badDigest, saw: sha256:5aee3da76d46986f296ba30c62e64fe1bd4df115194a823fda540cc68ea9d9e8

  Also, that including "expected"/"saw" in the error message is new, to help with diagnostics.

* The user-facing message now tells you if there were verification failures:

    > Verifying failed - There was 1 error verifying the bag
    > Verifying failed - There were 5 errors verifying the bag

I've been thinking about this some more, and additionally realised:

* We shouldn't expose the bucket/ObjectLocation in the user-facing message, because it's the unpacker bucket, which is an internal detail
* We shouldn't expose *any* information in post-replicator verifiers, because the bag we were given was correct (checked pre-replication) – a verification error post-replicator suggests an internal error

For https://github.com/wellcometrust/platform/issues/3745