### PR TITLE
When an ingest enters the pipeline, set the status to "processing"

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestStates.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestStates.scala
@@ -1,0 +1,86 @@
+package uk.ac.wellcome.platform.archive.common.ingests.services
+
+import uk.ac.wellcome.platform.archive.common.ingests.models._
+
+import scala.util.Try
+
+class IngestStatusGoingBackwardsException(val existing: Ingest.Status,
+                                          val update: Ingest.Status)
+  extends RuntimeException(
+    s"Received status update $update, but ingest already has status $existing")
+
+class CallbackStatusGoingBackwardsException(
+                                             val existing: Callback.CallbackStatus,
+                                             val update: Callback.CallbackStatus)
+  extends RuntimeException(
+    s"Received callback status update $update, but ingest already has status $existing")
+
+class NoCallbackException
+  extends RuntimeException(
+    "Received callback status update, but ingest doesn't have a callback")
+
+object IngestStates {
+  def applyUpdate(ingest: Ingest, update: IngestUpdate): Try[Ingest] = Try {
+    update match {
+      case _: IngestEventUpdate =>
+        ingest.copy(
+          events = ingest.events ++ update.events
+        )
+
+      case statusUpdate: IngestStatusUpdate =>
+        if (!statusUpdateIsAllowed(ingest.status, statusUpdate.status)) {
+          throw new IngestStatusGoingBackwardsException(
+            ingest.status,
+            statusUpdate.status)
+        }
+
+        ingest.copy(
+          status = statusUpdate.status,
+          events = ingest.events ++ update.events
+        )
+
+      case callbackStatusUpdate: IngestCallbackStatusUpdate =>
+        ingest.callback match {
+          case Some(callback) =>
+            if (!callbackStatusUpdateIsAllowed(
+                  callback.status,
+                  callbackStatusUpdate.callbackStatus)) {
+              throw new CallbackStatusGoingBackwardsException(
+                callback.status,
+                callbackStatusUpdate.callbackStatus
+              )
+            }
+
+            ingest.copy(
+              callback =
+                Some(callback.copy(status = callbackStatusUpdate.callbackStatus)),
+              events = ingest.events ++ update.events
+            )
+
+          case None => throw new NoCallbackException()
+        }
+    }
+  }
+
+  private def statusUpdateIsAllowed(initial: Ingest.Status,
+                                    update: Ingest.Status): Boolean =
+    initial match {
+      case status if status == update => true
+
+      case Ingest.Accepted   => true
+      case Ingest.Processing => update != Ingest.Accepted
+      case Ingest.Completed  => false
+      case Ingest.Failed     => false
+    }
+
+  private def callbackStatusUpdateIsAllowed(
+                                             initial: Callback.CallbackStatus,
+                                             update: Callback.CallbackStatus): Boolean =
+    initial match {
+      case status if status == update => true
+
+      case Callback.Pending   => true
+      case Callback.Succeeded => false
+      case Callback.Failed    => false
+    }
+}

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestStates.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestStates.scala
@@ -6,18 +6,18 @@ import scala.util.Try
 
 class IngestStatusGoingBackwardsException(val existing: Ingest.Status,
                                           val update: Ingest.Status)
-  extends RuntimeException(
-    s"Received status update $update, but ingest already has status $existing")
+    extends RuntimeException(
+      s"Received status update $update, but ingest already has status $existing")
 
 class CallbackStatusGoingBackwardsException(
-                                             val existing: Callback.CallbackStatus,
-                                             val update: Callback.CallbackStatus)
-  extends RuntimeException(
-    s"Received callback status update $update, but ingest already has status $existing")
+  val existing: Callback.CallbackStatus,
+  val update: Callback.CallbackStatus)
+    extends RuntimeException(
+      s"Received callback status update $update, but ingest already has status $existing")
 
 class NoCallbackException
-  extends RuntimeException(
-    "Received callback status update, but ingest doesn't have a callback")
+    extends RuntimeException(
+      "Received callback status update, but ingest doesn't have a callback")
 
 object IngestStates {
   def applyUpdate(ingest: Ingest, update: IngestUpdate): Try[Ingest] = Try {
@@ -60,8 +60,8 @@ object IngestStates {
             }
 
             ingest.copy(
-              callback =
-                Some(callback.copy(status = callbackStatusUpdate.callbackStatus)),
+              callback = Some(
+                callback.copy(status = callbackStatusUpdate.callbackStatus)),
               events = ingest.events ++ update.events
             )
 
@@ -82,8 +82,8 @@ object IngestStates {
     }
 
   private def callbackStatusUpdateIsAllowed(
-                                             initial: Callback.CallbackStatus,
-                                             update: Callback.CallbackStatus): Boolean =
+    initial: Callback.CallbackStatus,
+    update: Callback.CallbackStatus): Boolean =
     initial match {
       case status if status == update => true
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestStates.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestStates.scala
@@ -23,7 +23,15 @@ object IngestStates {
   def applyUpdate(ingest: Ingest, update: IngestUpdate): Try[Ingest] = Try {
     update match {
       case _: IngestEventUpdate =>
+        // Update the ingest status to "processing" when we see the first
+        // event update
+        val updatedStatus = ingest.status match {
+          case Ingest.Accepted => Ingest.Processing
+          case _               => ingest.status
+        }
+
         ingest.copy(
+          status = updatedStatus,
           events = ingest.events ++ update.events
         )
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestStatesTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestStatesTest.scala
@@ -1,0 +1,282 @@
+package uk.ac.wellcome.platform.archive.common.ingests.services
+
+import java.net.URI
+
+import org.scalatest.prop.TableDrivenPropertyChecks
+import org.scalatest.{FunSpec, Matchers, TryValues}
+import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
+import uk.ac.wellcome.platform.archive.common.ingests.models.{Callback, Ingest}
+
+class IngestStatesTest
+  extends FunSpec
+    with Matchers
+    with IngestGenerators
+    with TryValues
+    with TableDrivenPropertyChecks {
+
+  describe("handling an IngestEventUpdate") {
+    it("adds an event to an ingest") {
+      val ingest = createIngestWith(events = List.empty)
+
+      val event = createIngestEvent
+      val update = createIngestEventUpdateWith(
+        id = ingest.id,
+        events = List(event)
+      )
+
+      val updatedIngest = IngestStates.applyUpdate(ingest, update).success.value
+      updatedIngest.events shouldBe Seq(event)
+    }
+
+    it("adds multiple events to an ingest") {
+      val ingest = createIngestWith(events = List.empty)
+
+      val events =
+        List(createIngestEvent, createIngestEvent, createIngestEvent)
+      val update = createIngestEventUpdateWith(
+        id = ingest.id,
+        events = events
+      )
+
+      val updatedIngest = IngestStates.applyUpdate(ingest, update).success.value
+      updatedIngest.events shouldBe events
+    }
+
+    it("preserves the existing events on an ingest") {
+      val existingEvents = List(createIngestEvent, createIngestEvent)
+      val ingest = createIngestWith(events = existingEvents)
+
+      val newEvents = List(createIngestEvent, createIngestEvent)
+      val update = createIngestEventUpdateWith(
+        id = ingest.id,
+        events = newEvents
+      )
+
+      val updatedIngest = IngestStates.applyUpdate(ingest, update).success.value
+      updatedIngest.events shouldBe existingEvents ++ newEvents
+    }
+  }
+
+  describe("handling an IngestStatusUpdate") {
+    describe("updating the events") {
+      it("adds an event to an ingest") {
+        val ingest = createIngestWith(events = List.empty)
+
+        val event = createIngestEvent
+        val update = createIngestStatusUpdateWith(
+          id = ingest.id,
+          events = List(event)
+        )
+
+        val updatedIngest = IngestStates.applyUpdate(ingest, update).success.value
+        updatedIngest.events shouldBe Seq(event)
+      }
+
+      it("adds multiple events to an ingest") {
+        val ingest = createIngestWith(events = List.empty)
+
+        val events =
+          List(createIngestEvent, createIngestEvent, createIngestEvent)
+        val update = createIngestStatusUpdateWith(
+          id = ingest.id,
+          events = events
+        )
+
+        val updatedIngest = IngestStates.applyUpdate(ingest, update).success.value
+        updatedIngest.events shouldBe events
+      }
+
+      it("preserves the existing events on an ingest") {
+        val existingEvents = List(createIngestEvent, createIngestEvent)
+        val ingest = createIngestWith(events = existingEvents)
+
+        val newEvents = List(createIngestEvent, createIngestEvent)
+        val update = createIngestStatusUpdateWith(
+          id = ingest.id,
+          events = newEvents
+        )
+
+        val updatedIngest = IngestStates.applyUpdate(ingest, update).success.value
+        updatedIngest.events shouldBe existingEvents ++ newEvents
+      }
+    }
+
+    describe("updating the status") {
+      val allowedStatusUpdates = Table(
+        ("initial", "update"),
+        (Ingest.Accepted, Ingest.Accepted),
+        (Ingest.Accepted, Ingest.Processing),
+        (Ingest.Accepted, Ingest.Completed),
+        (Ingest.Accepted, Ingest.Failed),
+        (Ingest.Processing, Ingest.Completed),
+        (Ingest.Processing, Ingest.Failed),
+        (Ingest.Completed, Ingest.Completed),
+        (Ingest.Failed, Ingest.Failed),
+      )
+
+      it("updates the status of an ingest") {
+        forAll(allowedStatusUpdates) {
+          case (initialStatus: Ingest.Status, updatedStatus: Ingest.Status) =>
+            val ingest = createIngestWith(status = initialStatus)
+
+            val update = createIngestStatusUpdateWith(
+              id = ingest.id,
+              status = updatedStatus
+            )
+
+            val updatedIngest = IngestStates.applyUpdate(ingest, update).success.value
+            updatedIngest.status shouldBe updatedStatus
+        }
+      }
+
+      val disallowedStatusUpdates = Table(
+        ("initial", "update"),
+        (Ingest.Failed, Ingest.Completed),
+        (Ingest.Failed, Ingest.Processing),
+        (Ingest.Failed, Ingest.Accepted),
+        (Ingest.Completed, Ingest.Failed),
+        (Ingest.Completed, Ingest.Processing),
+        (Ingest.Completed, Ingest.Accepted),
+        (Ingest.Processing, Ingest.Accepted),
+      )
+
+      it("does not allow the status to go backwards") {
+        forAll(disallowedStatusUpdates) {
+          case (initialStatus: Ingest.Status, updatedStatus: Ingest.Status) =>
+            val ingest = createIngestWith(status = initialStatus)
+
+            val update = createIngestStatusUpdateWith(
+              id = ingest.id,
+              status = updatedStatus
+            )
+
+            IngestStates.applyUpdate(ingest, update).failure.exception shouldBe a[IngestStatusGoingBackwardsException]
+        }
+      }
+    }
+  }
+
+  describe("handling a CallbackStatusUpdate") {
+    describe("updating the events") {
+      it("adds an event to an ingest") {
+        val ingest = createIngestWith(events = List.empty)
+
+        val event = createIngestEvent
+        val update = createIngestCallbackStatusUpdateWith(
+          id = ingest.id,
+          events = List(event)
+        )
+
+        val updatedIngest = IngestStates.applyUpdate(ingest, update).success.value
+        updatedIngest.events shouldBe Seq(event)
+      }
+
+      it("adds multiple events to an ingest") {
+        val ingest = createIngestWith(events = List.empty)
+
+        val events =
+          List(createIngestEvent, createIngestEvent, createIngestEvent)
+        val update = createIngestCallbackStatusUpdateWith(
+          id = ingest.id,
+          events = events
+        )
+
+        val updatedIngest = IngestStates.applyUpdate(ingest, update).success.value
+        updatedIngest.events shouldBe events
+      }
+
+      it("preserves the existing events on an ingest") {
+        val existingEvents = List(createIngestEvent, createIngestEvent)
+        val ingest = createIngestWith(events = existingEvents)
+
+        val newEvents = List(createIngestEvent, createIngestEvent)
+        val update = createIngestCallbackStatusUpdateWith(
+          id = ingest.id,
+          events = newEvents
+        )
+
+        val updatedIngest = IngestStates.applyUpdate(ingest, update).success.value
+        updatedIngest.events shouldBe existingEvents ++ newEvents
+      }
+    }
+
+    describe("updating the callback status") {
+      val allowedCallbackStatusUpdates = Table(
+        ("initial", "update"),
+        (Callback.Pending, Callback.Pending),
+        (Callback.Pending, Callback.Succeeded),
+        (Callback.Pending, Callback.Failed),
+        (Callback.Succeeded, Callback.Succeeded),
+        (Callback.Failed, Callback.Failed),
+      )
+
+      it("updates the status of a callback") {
+        forAll(allowedCallbackStatusUpdates) {
+          case (
+            initialStatus: Callback.CallbackStatus,
+            updatedStatus: Callback.CallbackStatus) =>
+            val ingest = createIngestWith(
+              callback = Some(
+                Callback(
+                  uri = new URI("https://example.org/callback"),
+                  status = initialStatus
+                ))
+            )
+
+            val update = createIngestCallbackStatusUpdateWith(
+              id = ingest.id,
+              callbackStatus = updatedStatus
+            )
+
+            val updatedIngest = IngestStates.applyUpdate(ingest, update).success.value
+            updatedIngest.callback.get.status shouldBe updatedStatus
+        }
+      }
+
+      val disallowedCallbackStatusUpdates = Table(
+        ("initial", "update"),
+        (Callback.Succeeded, Callback.Pending),
+        (Callback.Succeeded, Callback.Failed),
+        (Callback.Failed, Callback.Pending),
+        (Callback.Failed, Callback.Succeeded),
+      )
+
+      it("does not allow the callback status to go backwards") {
+        forAll(disallowedCallbackStatusUpdates) {
+          case (
+            initialStatus: Callback.CallbackStatus,
+            updatedStatus: Callback.CallbackStatus) =>
+            val ingest = createIngestWith(
+              callback = Some(
+                Callback(
+                  uri = new URI("https://example.org/callback"),
+                  status = initialStatus
+                ))
+            )
+
+            val update = createIngestCallbackStatusUpdateWith(
+              id = ingest.id,
+              callbackStatus = updatedStatus
+            )
+
+            val err = IngestStates.applyUpdate(ingest, update).failure.exception
+
+            err shouldBe a[CallbackStatusGoingBackwardsException]
+        }
+      }
+
+      it("errors if the ingest does not have a callback") {
+        val ingest = createIngestWith(
+          callback = None
+        )
+        val update = createIngestCallbackStatusUpdateWith(
+          id = ingest.id
+        )
+
+        val err = IngestStates.applyUpdate(ingest, update).failure.exception
+
+        err shouldBe a[NoCallbackException]
+      }
+    }
+  }
+}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestStatesTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestStatesTest.scala
@@ -8,7 +8,7 @@ import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.models.{Callback, Ingest}
 
 class IngestStatesTest
-  extends FunSpec
+    extends FunSpec
     with Matchers
     with IngestGenerators
     with TryValues
@@ -71,7 +71,8 @@ class IngestStatesTest
 
           val update = createIngestEventUpdate
 
-          val updatedIngest = IngestStates.applyUpdate(ingest, update).success.value
+          val updatedIngest =
+            IngestStates.applyUpdate(ingest, update).success.value
           updatedIngest.status shouldBe expectedStatus
       }
     }
@@ -88,7 +89,8 @@ class IngestStatesTest
           events = List(event)
         )
 
-        val updatedIngest = IngestStates.applyUpdate(ingest, update).success.value
+        val updatedIngest =
+          IngestStates.applyUpdate(ingest, update).success.value
         updatedIngest.events shouldBe Seq(event)
       }
 
@@ -102,7 +104,8 @@ class IngestStatesTest
           events = events
         )
 
-        val updatedIngest = IngestStates.applyUpdate(ingest, update).success.value
+        val updatedIngest =
+          IngestStates.applyUpdate(ingest, update).success.value
         updatedIngest.events shouldBe events
       }
 
@@ -116,7 +119,8 @@ class IngestStatesTest
           events = newEvents
         )
 
-        val updatedIngest = IngestStates.applyUpdate(ingest, update).success.value
+        val updatedIngest =
+          IngestStates.applyUpdate(ingest, update).success.value
         updatedIngest.events shouldBe existingEvents ++ newEvents
       }
     }
@@ -144,7 +148,8 @@ class IngestStatesTest
               status = updatedStatus
             )
 
-            val updatedIngest = IngestStates.applyUpdate(ingest, update).success.value
+            val updatedIngest =
+              IngestStates.applyUpdate(ingest, update).success.value
             updatedIngest.status shouldBe updatedStatus
         }
       }
@@ -170,7 +175,10 @@ class IngestStatesTest
               status = updatedStatus
             )
 
-            IngestStates.applyUpdate(ingest, update).failure.exception shouldBe a[IngestStatusGoingBackwardsException]
+            IngestStates
+              .applyUpdate(ingest, update)
+              .failure
+              .exception shouldBe a[IngestStatusGoingBackwardsException]
         }
       }
     }
@@ -187,7 +195,8 @@ class IngestStatesTest
           events = List(event)
         )
 
-        val updatedIngest = IngestStates.applyUpdate(ingest, update).success.value
+        val updatedIngest =
+          IngestStates.applyUpdate(ingest, update).success.value
         updatedIngest.events shouldBe Seq(event)
       }
 
@@ -201,7 +210,8 @@ class IngestStatesTest
           events = events
         )
 
-        val updatedIngest = IngestStates.applyUpdate(ingest, update).success.value
+        val updatedIngest =
+          IngestStates.applyUpdate(ingest, update).success.value
         updatedIngest.events shouldBe events
       }
 
@@ -215,7 +225,8 @@ class IngestStatesTest
           events = newEvents
         )
 
-        val updatedIngest = IngestStates.applyUpdate(ingest, update).success.value
+        val updatedIngest =
+          IngestStates.applyUpdate(ingest, update).success.value
         updatedIngest.events shouldBe existingEvents ++ newEvents
       }
     }
@@ -233,8 +244,8 @@ class IngestStatesTest
       it("updates the status of a callback") {
         forAll(allowedCallbackStatusUpdates) {
           case (
-            initialStatus: Callback.CallbackStatus,
-            updatedStatus: Callback.CallbackStatus) =>
+              initialStatus: Callback.CallbackStatus,
+              updatedStatus: Callback.CallbackStatus) =>
             val ingest = createIngestWith(
               callback = Some(
                 Callback(
@@ -248,7 +259,8 @@ class IngestStatesTest
               callbackStatus = updatedStatus
             )
 
-            val updatedIngest = IngestStates.applyUpdate(ingest, update).success.value
+            val updatedIngest =
+              IngestStates.applyUpdate(ingest, update).success.value
             updatedIngest.callback.get.status shouldBe updatedStatus
         }
       }
@@ -264,8 +276,8 @@ class IngestStatesTest
       it("does not allow the callback status to go backwards") {
         forAll(disallowedCallbackStatusUpdates) {
           case (
-            initialStatus: Callback.CallbackStatus,
-            updatedStatus: Callback.CallbackStatus) =>
+              initialStatus: Callback.CallbackStatus,
+              updatedStatus: Callback.CallbackStatus) =>
             val ingest = createIngestWith(
               callback = Some(
                 Callback(

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestStatesTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestStatesTest.scala
@@ -55,6 +55,26 @@ class IngestStatesTest
       val updatedIngest = IngestStates.applyUpdate(ingest, update).success.value
       updatedIngest.events shouldBe existingEvents ++ newEvents
     }
+
+    val eventStatusUpdates = Table(
+      ("initial", "expected"),
+      (Ingest.Accepted, Ingest.Processing),
+      (Ingest.Processing, Ingest.Processing),
+      (Ingest.Completed, Ingest.Completed),
+      (Ingest.Failed, Ingest.Failed),
+    )
+
+    it("updates the status to Processing when it sees the first event update") {
+      forAll(eventStatusUpdates) {
+        case (initialStatus: Ingest.Status, expectedStatus: Ingest.Status) =>
+          val ingest = createIngestWith(status = initialStatus)
+
+          val update = createIngestEventUpdate
+
+          val updatedIngest = IngestStates.applyUpdate(ingest, update).success.value
+          updatedIngest.status shouldBe expectedStatus
+      }
+    }
   }
 
   describe("handling an IngestStatusUpdate") {


### PR DESCRIPTION
Closes https://github.com/wellcometrust/platform/issues/3698

I also pulled the logic for doing the ingest updates out of the IngestTracker, and into a standalone IngestStates object.