### PR TITLE
Unpacker includes a list of how many files/bytes it's unpacked

### DIFF
--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
@@ -49,7 +49,9 @@ class BagAuditor(versionPicker: VersionPicker) {
               startTime = startTime,
               endTime = Instant.now(),
               version = version
-            )
+            ),
+            maybeUserFacingMessage =
+              Some(s"Assigned bag version v$version")
           )
 
         case Left(auditError) =>

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditor.scala
@@ -50,8 +50,7 @@ class BagAuditor(versionPicker: VersionPicker) {
               endTime = Instant.now(),
               version = version
             ),
-            maybeUserFacingMessage =
-              Some(s"Assigned bag version v$version")
+            maybeUserFacingMessage = Some(s"Assigned bag version v$version")
           )
 
         case Left(auditError) =>

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
@@ -47,24 +47,9 @@ class BagAuditorWorker[IngestDestination, OutgoingDestination](
         storageSpace = payload.storageSpace
       )
 
-      _ <- sendIngestInformation(payload)(auditStep)
       _ <- ingestUpdater.send(payload.ingestId, auditStep)
       _ <- sendSuccessful(payload)(auditStep)
     } yield auditStep
-
-  // TODO: Use the user-facing message for this
-  private def sendIngestInformation(payload: BagRootLocationPayload)(
-    step: IngestStepResult[AuditSummary]): Try[Unit] =
-    step match {
-      case IngestStepSucceeded(summary: AuditSuccessSummary, _) =>
-        ingestUpdater.sendEvent(
-          ingestId = payload.ingestId,
-          messages = Seq(
-            s"Assigned bag version ${summary.version}"
-          )
-        )
-      case _ => Success(())
-    }
 
   private def sendSuccessful(payload: BagRootLocationPayload)(
     step: IngestStepResult[AuditSummary]): Try[Unit] =

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
@@ -52,10 +52,11 @@ class BagAuditorWorker[IngestDestination, OutgoingDestination](
       _ <- sendSuccessful(payload)(auditStep)
     } yield auditStep
 
+  // TODO: Use the user-facing message for this
   private def sendIngestInformation(payload: BagRootLocationPayload)(
     step: IngestStepResult[AuditSummary]): Try[Unit] =
     step match {
-      case IngestStepSucceeded(summary: AuditSuccessSummary) =>
+      case IngestStepSucceeded(summary: AuditSuccessSummary, _) =>
         ingestUpdater.sendEvent(
           ingestId = payload.ingestId,
           messages = Seq(
@@ -68,7 +69,7 @@ class BagAuditorWorker[IngestDestination, OutgoingDestination](
   private def sendSuccessful(payload: BagRootLocationPayload)(
     step: IngestStepResult[AuditSummary]): Try[Unit] =
     step match {
-      case IngestStepSucceeded(summary: AuditSuccessSummary) =>
+      case IngestStepSucceeded(summary: AuditSuccessSummary, _) =>
         outgoingPublisher.sendIfSuccessful(
           step,
           EnrichedBagInformationPayload(

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
@@ -69,8 +69,7 @@ class BagAuditorFeatureTest
               ingests,
               expectedDescriptions = Seq(
                 "Auditing bag started",
-                "Assigned bag version 1",
-                "Auditing bag succeeded"
+                "Auditing bag succeeded - Assigned bag version v1"
               )
             )
           }
@@ -120,8 +119,7 @@ class BagAuditorFeatureTest
               ingests,
               expectedDescriptions = Seq(
                 "Auditing bag started",
-                "Assigned bag version 1",
-                "Auditing bag succeeded"
+                "Auditing bag succeeded - Assigned bag version v1"
               )
             )
           }
@@ -140,11 +138,9 @@ class BagAuditorFeatureTest
               ingests,
               expectedDescriptions = Seq(
                 "Auditing bag started",
-                "Assigned bag version 1",
-                "Auditing bag succeeded",
+                "Auditing bag succeeded - Assigned bag version v1",
                 "Auditing bag started",
-                "Assigned bag version 2",
-                "Auditing bag succeeded"
+                "Auditing bag succeeded - Assigned bag version v2"
               )
             )
           }

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorTest.scala
@@ -42,6 +42,8 @@ class BagAuditorTest
       )
 
       val result = maybeAudit.success.get
+      result.maybeUserFacingMessage shouldBe Some("Assigned bag version v1")
+
       val summary = result.summary
         .asInstanceOf[AuditSuccessSummary]
 
@@ -63,12 +65,10 @@ class BagAuditorTest
       )
 
       val result = maybeAudit.success.get
-
       result shouldBe a[IngestFailed[_]]
 
-      val ingestFailed = result.asInstanceOf[IngestFailed[_]]
-      ingestFailed.summary shouldBe a[AuditFailureSummary]
-      ingestFailed.maybeUserFacingMessage shouldBe Some(
+      result.summary shouldBe a[AuditFailureSummary]
+      result.maybeUserFacingMessage shouldBe Some(
         "Cannot update existing bag: a bag with the supplied external identifier does not exist in this space")
     }
   }
@@ -95,12 +95,10 @@ class BagAuditorTest
       )
 
       val result = maybeAudit.success.get
-
       result shouldBe a[IngestFailed[_]]
 
-      val ingestFailed = result.asInstanceOf[IngestFailed[_]]
-      ingestFailed.summary shouldBe a[AuditFailureSummary]
-      ingestFailed.maybeUserFacingMessage shouldBe Some(
+      result.summary shouldBe a[AuditFailureSummary]
+      result.maybeUserFacingMessage shouldBe Some(
         "Cannot create new bag: a bag with the supplied external identifier already exists in this space")
     }
   }

--- a/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/BagRootFinderWorker.scala
+++ b/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/BagRootFinderWorker.scala
@@ -48,7 +48,7 @@ class BagRootFinderWorker[IngestDestination, OutgoingDestination](
   private def sendSuccessful(payload: PipelinePayload)(
     step: IngestStepResult[RootFinderSummary]): Try[Unit] =
     step match {
-      case IngestStepSucceeded(summary: RootFinderSuccessSummary) =>
+      case IngestStepSucceeded(summary: RootFinderSuccessSummary, _) =>
         val outgoingPayload: BagRootPayload = BagRootLocationPayload(
           context = payload.context,
           bagRootLocation = summary.bagRootLocation,

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
@@ -50,7 +50,14 @@ trait Unpacker {
 
     result match {
       case Right(summary) =>
-        Success(IngestStepSucceeded(summary))
+        val message =
+          s"Unpacked ${summary.bytesUnpacked} bytes from ${summary.fileCount} file${if (summary.fileCount != 1) "s"}"
+        Success(
+          IngestStepSucceeded(
+            summary,
+            maybeUserFacingMessage = Some(message)
+          )
+        )
 
       case Left(unpackerError) =>
         Success(

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
@@ -63,7 +63,9 @@ class UnpackerFeatureTest
               outgoing.getMessages[UnpackedBagLocationPayload] shouldBe Seq(
                 expectedPayload)
 
-              assertTopicReceivesIngestUpdates(sourceLocationPayload.ingestId, ingests) { ingestUpdates =>
+              assertTopicReceivesIngestUpdates(
+                sourceLocationPayload.ingestId,
+                ingests) { ingestUpdates =>
                 val eventDescriptions: Seq[String] =
                   ingestUpdates
                     .flatMap { _.events }

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
@@ -63,14 +63,18 @@ class UnpackerFeatureTest
               outgoing.getMessages[UnpackedBagLocationPayload] shouldBe Seq(
                 expectedPayload)
 
-              assertTopicReceivesIngestEvents(
-                sourceLocationPayload.ingestId,
-                ingests,
-                expectedDescriptions = Seq(
-                  "Unpacker started",
-                  "Unpacker succeeded"
-                )
-              )
+              assertTopicReceivesIngestUpdates(sourceLocationPayload.ingestId, ingests) { ingestUpdates =>
+                val eventDescriptions: Seq[String] =
+                  ingestUpdates
+                    .flatMap { _.events }
+                    .map { _.description }
+                    .distinct
+
+                eventDescriptions should have size 2
+
+                eventDescriptions(0) shouldBe "Unpacker started"
+                eventDescriptions(1) should fullyMatch regex """Unpacker succeeded - Unpacked \d+ bytes from \d+ files"""
+              }
             }
           }
         }

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
@@ -53,6 +53,9 @@ trait UnpackerTestCases[Namespace]
             val unpacked = summaryResult.success.value
             unpacked shouldBe a[IngestStepSucceeded[_]]
 
+            unpacked.maybeUserFacingMessage.get should fullyMatch regex
+              """Unpacked \d+ bytes from \d+ files"""
+
             val summary = unpacked.summary
             summary.fileCount shouldBe filesInArchive.size
             summary.bytesUnpacked shouldBe totalBytes(filesInArchive)
@@ -86,6 +89,9 @@ trait UnpackerTestCases[Namespace]
 
             val unpacked = summaryResult.success.value
             unpacked shouldBe a[IngestStepSucceeded[_]]
+
+            unpacked.maybeUserFacingMessage.get should fullyMatch regex
+              """Unpacked \d+ bytes from \d+ files"""
 
             val summary = unpacked.summary
             summary.fileCount shouldBe filesInArchive.size

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdater.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdater.scala
@@ -35,10 +35,13 @@ class IngestUpdater[Destination](stepName: String,
           )
         )
 
-      case IngestStepSucceeded(_) =>
+      case IngestStepSucceeded(_, maybeMessage) =>
         IngestUpdate.event(
           id = ingestId,
-          description = s"${stepName.capitalize} succeeded"
+          description = eventDescription(
+            s"${stepName.capitalize} succeeded",
+            maybeMessage
+          )
         )
 
       case IngestStepStarted(_) =>

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/operation/services/OutgoingPublisher.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/operation/services/OutgoingPublisher.scala
@@ -15,7 +15,7 @@ class OutgoingPublisher[Destination](
                                                 outgoing: => O): Try[Unit] = {
     debug(s"Sending outgoing message for result $result")
     result match {
-      case IngestStepSucceeded(_) | IngestCompleted(_) =>
+      case IngestStepSucceeded(_, _) | IngestCompleted(_) =>
         debug(
           msg =
             "Ingest step succeeded/completed: " +


### PR DESCRIPTION
I have a weird problem: ingest 0046a6ac-1736-4648-aafd-d2a8234310a1 reports "Unpacking succeeded", but there's no sign of it in the unpacker bucket!

I wondered if I'd mucked up the packaging somehow, and it wasn't finding anything – this PR modifies the unpacker so it now says:

> Unpacking succeeded - Unpacked 1234 bytes from 5678 files

It turns out that's not the issue here, as testified by the logs:

> 09:35:38.566 [main-actor-system-akka.actor.default-dispatcher-10] INFO u.a.w.p.a.c.s.m.IngestStepWorker$$anon$1 - Successful: id=0046a6ac-1736-4648-aafd-d2a8234310a1, src=wellcomecollection-storage-staging-bagger-drop/b21000633-with-payload-oxum.tar.gz, dst=ObjectLocationPrefix(wellcomecollection-storage-staging-ingests,unpacked/alex-testing/0046a6ac-1736-4648-aafd-d2a8234310a1), files=14, bytesSize=1226293, size=1 MB, durationSeconds=0, duration=<not-completed>

But it means I don't have to check the logs next time (and I still have a missing bag!).