### PR TITLE
Refactor the verifier for more checks, and check the first half of Payload-Oxum

### DIFF
--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/BagRegisterFeatureTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/BagRegisterFeatureTest.scala
@@ -22,41 +22,42 @@ class BagRegisterFeatureTest
         val version = randomInt(1, 15)
 
         withLocalS3Bucket { bucket =>
-          withBag(bucket, space, version) { case (bagRootLocation, bagInfo) =>
-            val bagId = BagId(
-              space = space,
-              externalIdentifier = bagInfo.externalIdentifier
-            )
-
-            val payload = createEnrichedBagInformationPayloadWith(
-              context = createPipelineContextWith(
-                storageSpace = space
-              ),
-              bagRootLocation = bagRootLocation,
-              version = version
-            )
-
-            sendNotificationToSQS(queuePair.queue, payload)
-
-            eventually {
-              val storageManifest =
-                storageManifestDao.getLatest(bagId).right.value
-
-              storageManifest.space shouldBe bagId.space
-              storageManifest.info shouldBe bagInfo
-              storageManifest.manifest.files should have size 1
-
-              storageManifest.locations should have size 1
-
-              storageManifest.createdDate.isAfter(createdAfterDate) shouldBe true
-
-              assertBagRegisterSucceeded(
-                ingestId = payload.ingestId,
-                ingests = ingests
+          withBag(bucket, space, version) {
+            case (bagRootLocation, bagInfo) =>
+              val bagId = BagId(
+                space = space,
+                externalIdentifier = bagInfo.externalIdentifier
               )
 
-              assertQueueEmpty(queuePair.queue)
-            }
+              val payload = createEnrichedBagInformationPayloadWith(
+                context = createPipelineContextWith(
+                  storageSpace = space
+                ),
+                bagRootLocation = bagRootLocation,
+                version = version
+              )
+
+              sendNotificationToSQS(queuePair.queue, payload)
+
+              eventually {
+                val storageManifest =
+                  storageManifestDao.getLatest(bagId).right.value
+
+                storageManifest.space shouldBe bagId.space
+                storageManifest.info shouldBe bagInfo
+                storageManifest.manifest.files should have size 1
+
+                storageManifest.locations should have size 1
+
+                storageManifest.createdDate.isAfter(createdAfterDate) shouldBe true
+
+                assertBagRegisterSucceeded(
+                  ingestId = payload.ingestId,
+                  ingests = ingests
+                )
+
+                assertQueueEmpty(queuePair.queue)
+              }
           }
         }
     }

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/BagRegisterFeatureTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/BagRegisterFeatureTest.scala
@@ -29,7 +29,12 @@ class BagRegisterFeatureTest
         )
 
         withLocalS3Bucket { bucket =>
-          withBag(bucket, externalIdentifier, space, version, dataFileCount = dataFileCount) {
+          withBag(
+            bucket,
+            externalIdentifier,
+            space,
+            version,
+            dataFileCount = dataFileCount) {
             case (bagRootLocation, bagInfo) =>
               val payload = createEnrichedBagInformationPayloadWith(
                 context = createPipelineContextWith(

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/BagRegisterFeatureTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/BagRegisterFeatureTest.scala
@@ -20,15 +20,17 @@ class BagRegisterFeatureTest
         val createdAfterDate = Instant.now()
         val space = createStorageSpace
         val version = randomInt(1, 15)
+        val dataFileCount = randomInt(1, 15)
+        val externalIdentifier = createExternalIdentifier
+
+        val bagId = BagId(
+          space = space,
+          externalIdentifier = externalIdentifier
+        )
 
         withLocalS3Bucket { bucket =>
-          withBag(bucket, space, version) {
+          withBag(bucket, externalIdentifier, space, version, dataFileCount = dataFileCount) {
             case (bagRootLocation, bagInfo) =>
-              val bagId = BagId(
-                space = space,
-                externalIdentifier = bagInfo.externalIdentifier
-              )
-
               val payload = createEnrichedBagInformationPayloadWith(
                 context = createPipelineContextWith(
                   storageSpace = space
@@ -45,7 +47,7 @@ class BagRegisterFeatureTest
 
                 storageManifest.space shouldBe bagId.space
                 storageManifest.info shouldBe bagInfo
-                storageManifest.manifest.files should have size 1
+                storageManifest.manifest.files should have size dataFileCount
 
                 storageManifest.locations should have size 1
 

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/BagRegisterFeatureTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/BagRegisterFeatureTest.scala
@@ -18,12 +18,11 @@ class BagRegisterFeatureTest
     withBagRegisterWorker {
       case (_, storageManifestDao, ingests, _, queuePair) =>
         val createdAfterDate = Instant.now()
-        val bagInfo = createBagInfo
         val space = createStorageSpace
         val version = randomInt(1, 15)
 
         withLocalS3Bucket { bucket =>
-          withBag(bucket, bagInfo, space, version) { bagRootLocation =>
+          withBag(bucket, space, version) { case (bagRootLocation, bagInfo) =>
             val bagId = BagId(
               space = space,
               externalIdentifier = bagInfo.externalIdentifier

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
@@ -7,12 +7,22 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
-import uk.ac.wellcome.platform.archive.bag_register.services.{BagRegisterWorker, Register}
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagInfo, ExternalIdentifier}
+import uk.ac.wellcome.platform.archive.bag_register.services.{
+  BagRegisterWorker,
+  Register
+}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagInfo,
+  ExternalIdentifier
+}
 import uk.ac.wellcome.platform.archive.common.bagit.services.s3.S3BagReader
 import uk.ac.wellcome.platform.archive.common.fixtures._
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestID, IngestStatusUpdate}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  Ingest,
+  IngestID,
+  IngestStatusUpdate
+}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
 import uk.ac.wellcome.storage.ObjectLocation
@@ -96,13 +106,18 @@ trait BagRegisterFixtures
   // The bag register inspects the paths to a bag's entries to
   // check they are in the correct format post-replicator,
   // hence the version directory.
-  def withBag[R](bucket: Bucket,
-                 externalIdentifier: ExternalIdentifier,
-                 space: StorageSpace,
-                 version: Int,
-                 dataFileCount: Int)(
-    testWith: TestWith[(ObjectLocation, BagInfo), R]): R =
-    withS3Bag(bucket, externalIdentifier = externalIdentifier, space = space, dataFileCount = dataFileCount, bagRootDirectory = Some(s"v$version")) {
+  def withBag[R](
+    bucket: Bucket,
+    externalIdentifier: ExternalIdentifier,
+    space: StorageSpace,
+    version: Int,
+    dataFileCount: Int)(testWith: TestWith[(ObjectLocation, BagInfo), R]): R =
+    withS3Bag(
+      bucket,
+      externalIdentifier = externalIdentifier,
+      space = space,
+      dataFileCount = dataFileCount,
+      bagRootDirectory = Some(s"v$version")) {
       case (bagRoot, bagInfo) =>
         testWith((bagRoot.join(s"v$version"), bagInfo))
     }

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
@@ -7,19 +7,12 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
-import uk.ac.wellcome.platform.archive.bag_register.services.{
-  BagRegisterWorker,
-  Register
-}
-import uk.ac.wellcome.platform.archive.common.bagit.models.BagInfo
+import uk.ac.wellcome.platform.archive.bag_register.services.{BagRegisterWorker, Register}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{BagInfo, ExternalIdentifier}
 import uk.ac.wellcome.platform.archive.common.bagit.services.s3.S3BagReader
 import uk.ac.wellcome.platform.archive.common.fixtures._
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  Ingest,
-  IngestID,
-  IngestStatusUpdate
-}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestID, IngestStatusUpdate}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
 import uk.ac.wellcome.storage.ObjectLocation
@@ -103,9 +96,13 @@ trait BagRegisterFixtures
   // The bag register inspects the paths to a bag's entries to
   // check they are in the correct format post-replicator,
   // hence the version directory.
-  def withBag[R](bucket: Bucket, space: StorageSpace, version: Int)(
+  def withBag[R](bucket: Bucket,
+                 externalIdentifier: ExternalIdentifier,
+                 space: StorageSpace,
+                 version: Int,
+                 dataFileCount: Int)(
     testWith: TestWith[(ObjectLocation, BagInfo), R]): R =
-    withS3Bag(bucket, space = space, bagRootDirectory = Some(s"v$version")) {
+    withS3Bag(bucket, externalIdentifier = externalIdentifier, space = space, dataFileCount = dataFileCount, bagRootDirectory = Some(s"v$version")) {
       case (bagRoot, bagInfo) =>
         testWith((bagRoot.join(s"v$version"), bagInfo))
     }

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
@@ -104,14 +104,12 @@ trait BagRegisterFixtures
   // check they are in the correct format post-replicator,
   // hence the version directory.
   def withBag[R](bucket: Bucket,
-                 bagInfo: BagInfo,
                  space: StorageSpace,
-                 version: Int)(testWith: TestWith[ObjectLocation, R]): R =
+                 version: Int)(testWith: TestWith[(ObjectLocation, BagInfo), R]): R =
     withS3Bag(
       bucket,
-      bagInfo = bagInfo,
       space = space,
-      bagRootDirectory = Some(s"v$version")) { bagRoot =>
-      testWith(bagRoot.join(s"v$version"))
+      bagRootDirectory = Some(s"v$version")) { case (bagRoot, bagInfo) =>
+      testWith((bagRoot.join(s"v$version"), bagInfo))
     }
 }

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
@@ -103,13 +103,10 @@ trait BagRegisterFixtures
   // The bag register inspects the paths to a bag's entries to
   // check they are in the correct format post-replicator,
   // hence the version directory.
-  def withBag[R](bucket: Bucket,
-                 space: StorageSpace,
-                 version: Int)(testWith: TestWith[(ObjectLocation, BagInfo), R]): R =
-    withS3Bag(
-      bucket,
-      space = space,
-      bagRootDirectory = Some(s"v$version")) { case (bagRoot, bagInfo) =>
-      testWith((bagRoot.join(s"v$version"), bagInfo))
+  def withBag[R](bucket: Bucket, space: StorageSpace, version: Int)(
+    testWith: TestWith[(ObjectLocation, BagInfo), R]): R =
+    withS3Bag(bucket, space = space, bagRootDirectory = Some(s"v$version")) {
+      case (bagRoot, bagInfo) =>
+        testWith((bagRoot.join(s"v$version"), bagInfo))
     }
 }

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
@@ -37,7 +37,12 @@ class BagRegisterWorkerTest
         val externalIdentifier = createExternalIdentifier
 
         withLocalS3Bucket { bucket =>
-          withBag(bucket, externalIdentifier, space = space, dataFileCount = dataFileCount, version = version) {
+          withBag(
+            bucket,
+            externalIdentifier,
+            space = space,
+            dataFileCount = dataFileCount,
+            version = version) {
             case (bagRootLocation, bagInfo) =>
               val payload = createEnrichedBagInformationPayloadWith(
                 context = createPipelineContextWith(
@@ -91,9 +96,19 @@ class BagRegisterWorkerTest
         val externalIdentifier = createExternalIdentifier
 
         withLocalS3Bucket { bucket =>
-          withBag(bucket, externalIdentifier, space = space, version = 1, dataFileCount) {
+          withBag(
+            bucket,
+            externalIdentifier,
+            space = space,
+            version = 1,
+            dataFileCount) {
             case (location1, bagInfo1) =>
-              withBag(bucket, externalIdentifier, space = space, version = 2, dataFileCount) {
+              withBag(
+                bucket,
+                externalIdentifier,
+                space = space,
+                version = 2,
+                dataFileCount) {
                 case (location2, bagInfo2) =>
                   val payload1 = createEnrichedBagInformationPayloadWith(
                     context = createPipelineContextWith(

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
@@ -31,13 +31,12 @@ class BagRegisterWorkerTest
     withBagRegisterWorker {
       case (service, storageManifestDao, ingests, _, _) =>
         val createdAfterDate = Instant.now()
-        val bagInfo = createBagInfo
         val space = createStorageSpace
         val version = randomInt(1, 15)
 
         withLocalS3Bucket { bucket =>
-          withBag(bucket, bagInfo, space = space, version = version) {
-            bagRootLocation =>
+          withBag(bucket, space = space, version = version) {
+            case (bagRootLocation, bagInfo) =>
               val payload = createEnrichedBagInformationPayloadWith(
                 context = createPipelineContextWith(
                   storageSpace = space
@@ -85,12 +84,11 @@ class BagRegisterWorkerTest
   it("stores multiple versions of a bag") {
     withBagRegisterWorker {
       case (service, storageManifestDao, _, _, _) =>
-        val bagInfo = createBagInfo
         val space = createStorageSpace
 
         withLocalS3Bucket { bucket =>
-          withBag(bucket, bagInfo, space = space, version = 1) { location1 =>
-            withBag(bucket, bagInfo, space = space, version = 2) { location2 =>
+          withBag(bucket, space = space, version = 1) { case (location1, bagInfo) =>
+            withBag(bucket, space = space, version = 2) { case (location2, bagInfo) =>
               val payload1 = createEnrichedBagInformationPayloadWith(
                 context = createPipelineContextWith(
                   storageSpace = space

--- a/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/BagRootFinderFeatureTest.scala
+++ b/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/BagRootFinderFeatureTest.scala
@@ -22,7 +22,7 @@ class BagRootFinderFeatureTest
 
   it("detects a bag in the root of the bagLocation") {
     withLocalS3Bucket { bucket =>
-      withS3Bag(bucket) { unpackedBagLocation =>
+      withS3Bag(bucket) { case (unpackedBagLocation, _) =>
         // TODO: Bag root location should really be a prefix here
         val payload = createUnpackedBagLocationPayloadWith(
           unpackedBagLocation = unpackedBagLocation.asPrefix
@@ -66,7 +66,7 @@ class BagRootFinderFeatureTest
   it("detects a bag in a subdirectory of the bagLocation") {
     withLocalS3Bucket { bucket =>
       withS3Bag(bucket, bagRootDirectory = Some("subdir")) {
-        unpackedBagLocation =>
+        case (unpackedBagLocation, _) =>
           val bagRootLocation = unpackedBagLocation.join("subdir")
 
           val payload = createUnpackedBagLocationPayloadWith(
@@ -112,7 +112,7 @@ class BagRootFinderFeatureTest
   it("errors if the bag is nested too deep") {
     withLocalS3Bucket { bucket =>
       withS3Bag(bucket, bagRootDirectory = Some("subdir1/subdir2/subdir3")) {
-        unpackedBagLocation =>
+        case (unpackedBagLocation, _) =>
           val payload =
             createUnpackedBagLocationPayloadWith(unpackedBagLocation.asPrefix)
 

--- a/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/BagRootFinderFeatureTest.scala
+++ b/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/BagRootFinderFeatureTest.scala
@@ -22,43 +22,45 @@ class BagRootFinderFeatureTest
 
   it("detects a bag in the root of the bagLocation") {
     withLocalS3Bucket { bucket =>
-      withS3Bag(bucket) { case (unpackedBagLocation, _) =>
-        // TODO: Bag root location should really be a prefix here
-        val payload = createUnpackedBagLocationPayloadWith(
-          unpackedBagLocation = unpackedBagLocation.asPrefix
-        )
+      withS3Bag(bucket) {
+        case (unpackedBagLocation, _) =>
+          // TODO: Bag root location should really be a prefix here
+          val payload = createUnpackedBagLocationPayloadWith(
+            unpackedBagLocation = unpackedBagLocation.asPrefix
+          )
 
-        val expectedPayload = createBagRootLocationPayloadWith(
-          context = payload.context,
-          bagRootLocation = unpackedBagLocation
-        )
+          val expectedPayload = createBagRootLocationPayloadWith(
+            context = payload.context,
+            bagRootLocation = unpackedBagLocation
+          )
 
-        withLocalSqsQueue { queue =>
-          val ingests = new MemoryMessageSender()
-          val outgoing = new MemoryMessageSender()
-          withWorkerService(
-            queue,
-            ingests,
-            outgoing,
-            stepName = "finding bag root") { _ =>
-            sendNotificationToSQS(queue, payload)
+          withLocalSqsQueue { queue =>
+            val ingests = new MemoryMessageSender()
+            val outgoing = new MemoryMessageSender()
+            withWorkerService(
+              queue,
+              ingests,
+              outgoing,
+              stepName = "finding bag root") { _ =>
+              sendNotificationToSQS(queue, payload)
 
-            eventually {
-              assertQueueEmpty(queue)
+              eventually {
+                assertQueueEmpty(queue)
 
-              outgoing.getMessages[BagRootPayload] shouldBe Seq(expectedPayload)
+                outgoing.getMessages[BagRootPayload] shouldBe Seq(
+                  expectedPayload)
 
-              assertTopicReceivesIngestEvents(
-                payload.ingestId,
-                ingests,
-                expectedDescriptions = Seq(
-                  "Finding bag root started",
-                  "Finding bag root succeeded"
+                assertTopicReceivesIngestEvents(
+                  payload.ingestId,
+                  ingests,
+                  expectedDescriptions = Seq(
+                    "Finding bag root started",
+                    "Finding bag root succeeded"
+                  )
                 )
-              )
+              }
             }
           }
-        }
       }
     }
   }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -23,74 +23,116 @@ class BagVerifier()(
   verifier: Verifier[_]
 ) extends Logging {
 
+  type InternalResult[T] = Either[IngestFailed[VerificationSummary], T]
+
   def verify(root: ObjectLocation, externalIdentifier: ExternalIdentifier)
     : Try[IngestStepResult[VerificationSummary]] =
     Try {
-      implicit val bagVerifiable: BagVerifiable =
-        new BagVerifiable(root)
       val startTime = Instant.now()
 
-      bagReader.get(root) match {
-        case Left(bagUnavailable) =>
+      val stepResult
+        : Either[IngestFailed[VerificationSummary], VerificationSuccessSummary] = for {
+        bag <- getBag(root, startTime = startTime)
+
+        _ <- verifyExternalIdentifier(
+          bag = bag,
+          externalIdentifier = externalIdentifier,
+          root = root,
+          startTime = startTime
+        )
+
+        result <- verifyChecksums(
+          root = root,
+          bag = bag,
+          startTime = startTime
+        )
+      } yield result
+
+      stepResult match {
+        case Left(ingestFailed)    => ingestFailed
+        case Right(successSummary) => IngestStepSucceeded(successSummary: VerificationSuccessSummary)
+      }
+    }
+
+  private def getBag(root: ObjectLocation,
+                     startTime: Instant): InternalResult[Bag] =
+    bagReader.get(root) match {
+      case Left(bagUnavailable) =>
+        Left(
           IngestFailed(
             summary =
               VerificationSummary.incomplete(root, bagUnavailable, startTime),
             e = bagUnavailable,
             maybeUserFacingMessage = Some(bagUnavailable.msg)
           )
+        )
 
-        case Right(bag) =>
-          if (bag.info.externalIdentifier != externalIdentifier) {
-            IngestFailed(
-              summary = VerificationFailureSummary(
-                rootLocation = root,
-                verification = None,
-                startTime = startTime,
-                endTime = Instant.now()
-              ),
-              e = new Throwable(
-                "External identifier in bag-info.txt does not match request"),
-              maybeUserFacingMessage = Some(
-                s"External identifier in bag-info.txt does not match request: ${bag.info.externalIdentifier.underlying} is not ${externalIdentifier.underlying}"
-              )
-            )
-          } else {
-            VerificationSummary.create(root, bag.verify, startTime) match {
-              case success @ VerificationSuccessSummary(_, _, _, _) =>
-                IngestStepSucceeded(success)
-              case failure @ VerificationFailureSummary(
-                    _,
-                    Some(verification),
-                    _,
-                    _) =>
-                val verificationFailureMessage =
-                  verification.failure
-                    .map { verifiedFailure =>
-                      s"${verifiedFailure.location.uri}: ${verifiedFailure.e.getMessage}"
-                    }
-                    .mkString("\n")
-
-                warn(s"Errors verifying $root:\n$verificationFailureMessage")
-
-                val errorCount = verification.failure.size
-
-                val userFacingMessage =
-                  if (errorCount == 1)
-                    "There was 1 error verifying the bag"
-                  else
-                    s"There were $errorCount errors verifying the bag"
-
-                IngestFailed(failure, InvalidBag(bag), Some(userFacingMessage))
-
-              case failure @ VerificationFailureSummary(_, None, _, _) =>
-                IngestFailed(failure, InvalidBag(bag))
-
-              case incomplete @ VerificationIncompleteSummary(_, _, _, _) =>
-                IngestFailed(incomplete, incomplete.e)
-            }
-          }
-      }
+      case Right(bag) => Right(bag)
     }
+
+  private def verifyExternalIdentifier(
+    bag: Bag,
+    externalIdentifier: ExternalIdentifier,
+    root: ObjectLocation,
+    startTime: Instant): InternalResult[Unit] =
+    if (bag.info.externalIdentifier != externalIdentifier) {
+      Left(
+        IngestFailed(
+          summary = VerificationFailureSummary(
+            rootLocation = root,
+            verification = None,
+            startTime = startTime,
+            endTime = Instant.now()
+          ),
+          e = new Throwable(
+            "External identifier in bag-info.txt does not match request"),
+          maybeUserFacingMessage = Some(
+            s"External identifier in bag-info.txt does not match request: ${bag.info.externalIdentifier.underlying} is not ${externalIdentifier.underlying}"
+          )
+        )
+      )
+    } else {
+      Right(())
+    }
+
+  private def verifyChecksums(
+    root: ObjectLocation,
+    bag: Bag,
+    startTime: Instant
+  ): InternalResult[VerificationSuccessSummary] = {
+    implicit val bagVerifiable: BagVerifiable =
+      new BagVerifiable(root)
+
+    VerificationSummary.create(root, bag.verify, startTime) match {
+      case success @ VerificationSuccessSummary(_, _, _, _) =>
+        Right(success)
+      case failure @ VerificationFailureSummary(_, Some(verification), _, _) =>
+        val verificationFailureMessage =
+          verification.failure
+            .map { verifiedFailure =>
+              s"${verifiedFailure.location.uri}: ${verifiedFailure.e.getMessage}"
+            }
+            .mkString("\n")
+
+        warn(s"Errors verifying $root:\n$verificationFailureMessage")
+
+        val errorCount = verification.failure.size
+
+        val userFacingMessage =
+          if (errorCount == 1)
+            "There was 1 error verifying the bag"
+          else
+            s"There were $errorCount errors verifying the bag"
+
+        Left(IngestFailed(failure, InvalidBag(bag), Some(userFacingMessage)))
+
+      case failure @ VerificationFailureSummary(_, None, _, _) =>
+        Left(IngestFailed(failure, InvalidBag(bag)))
+
+      case incomplete @ VerificationIncompleteSummary(_, _, _, _) =>
+        Left(IngestFailed(incomplete, incomplete.e))
+    }
+  }
 }
 
 case class InvalidBag(bag: Bag)

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -10,7 +10,10 @@ import uk.ac.wellcome.platform.archive.common.bagit.services.{
   BagVerifiable
 }
 import uk.ac.wellcome.platform.archive.common.storage.Resolvable
-import uk.ac.wellcome.platform.archive.common.storage.models.{IngestStepResult, _}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  IngestStepResult,
+  _
+}
 import uk.ac.wellcome.platform.archive.common.verify.Verification._
 import uk.ac.wellcome.platform.archive.common.verify._
 import uk.ac.wellcome.storage.ObjectLocation
@@ -133,13 +136,12 @@ class BagVerifier()(
 
       case Right(incomplete: VerificationIncomplete) =>
         IngestFailed(
-          summary =
-            VerificationIncompleteSummary(
-              rootLocation = root,
-              e = incomplete,
-              startTime = startTime,
-              endTime = Instant.now()
-            ),
+          summary = VerificationIncompleteSummary(
+            rootLocation = root,
+            e = incomplete,
+            startTime = startTime,
+            endTime = Instant.now()
+          ),
           e = incomplete,
           maybeUserFacingMessage = None
         )
@@ -173,13 +175,12 @@ class BagVerifier()(
             s"There were $errorCount errors verifying the bag"
 
         IngestFailed(
-          summary =
-            VerificationFailureSummary(
-              rootLocation = root,
-              verification = Some(result),
-              startTime = startTime,
-              endTime = Instant.now()
-            ),
+          summary = VerificationFailureSummary(
+            rootLocation = root,
+            verification = Some(result),
+            startTime = startTime,
+            endTime = Instant.now()
+          ),
           e = new Throwable(userFacingMessage),
           maybeUserFacingMessage = Some(userFacingMessage)
         )

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -46,6 +46,8 @@ class BagVerifier()(
             startTime = startTime
           )
 
+          _ <- verifyPayloadOxumFileCount(bag)
+
           result <- verifyChecksums(
             root = root,
             bag = bag,
@@ -101,6 +103,21 @@ class BagVerifier()(
     Try { bag.verify } match {
       case Failure(err)    => Left(BagVerifierError(err))
       case Success(result) => Right(result)
+    }
+  }
+
+  private def verifyPayloadOxumFileCount(bag: Bag): InternalResult[Unit] = {
+    val payloadOxumCount = bag.info.payloadOxum.numberOfPayloadFiles
+    val manifestCount = bag.manifest.files.size
+
+    if (payloadOxumCount != bag.manifest.files.size) {
+      val message =
+        s"Payload-Oxum has the wrong number of payload files: $payloadOxumCount, but bag manifest has $manifestCount"
+      Left(
+        BagVerifierError(new Throwable(message), userMessage = Some(message))
+      )
+    } else {
+      Right(())
     }
   }
 

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -41,17 +41,14 @@ class BagVerifier()(
 
           _ <- verifyExternalIdentifier(
             bag = bag,
-            externalIdentifier = externalIdentifier,
-            root = root,
-            startTime = startTime
+            externalIdentifier = externalIdentifier
           )
 
           _ <- verifyPayloadOxumFileCount(bag)
 
           result <- verifyChecksums(
             root = root,
-            bag = bag,
-            startTime = startTime
+            bag = bag
           )
         } yield result
 
@@ -74,9 +71,7 @@ class BagVerifier()(
 
   private def verifyExternalIdentifier(
     bag: Bag,
-    externalIdentifier: ExternalIdentifier,
-    root: ObjectLocation,
-    startTime: Instant): InternalResult[Unit] =
+    externalIdentifier: ExternalIdentifier): InternalResult[Unit] =
     if (bag.info.externalIdentifier != externalIdentifier) {
       val message =
         "External identifier in bag-info.txt does not match request: " +
@@ -94,8 +89,7 @@ class BagVerifier()(
 
   private def verifyChecksums(
     root: ObjectLocation,
-    bag: Bag,
-    startTime: Instant
+    bag: Bag
   ): InternalResult[VerificationResult] = {
     implicit val bagVerifiable: BagVerifiable =
       new BagVerifiable(root)

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
@@ -34,9 +34,6 @@ class BagVerifierFeatureTest
     val outgoing = new MemoryMessageSender()
 
     val externalIdentifier = createExternalIdentifier
-    val bagInfo = createBagInfoWith(
-      externalIdentifier = externalIdentifier
-    )
 
     withLocalSqsQueueAndDlq {
       case QueuePair(queue, dlq) =>
@@ -46,7 +43,7 @@ class BagVerifierFeatureTest
           queue,
           stepName = "verification") { _ =>
           withLocalS3Bucket { bucket =>
-            withS3Bag(bucket, bagInfo = bagInfo) { bagRootLocation =>
+            withS3Bag(bucket, externalIdentifier = externalIdentifier) { case (bagRootLocation, bagInfo) =>
               val payload = createEnrichedBagInformationPayloadWith(
                 context = createPipelineContextWith(
                   externalIdentifier = externalIdentifier
@@ -84,9 +81,6 @@ class BagVerifierFeatureTest
     val outgoing = new MemoryMessageSender()
 
     val externalIdentifier = createExternalIdentifier
-    val bagInfo = createBagInfoWith(
-      externalIdentifier = externalIdentifier
-    )
 
     withLocalSqsQueueAndDlq {
       case QueuePair(queue, dlq) =>
@@ -98,9 +92,9 @@ class BagVerifierFeatureTest
           withLocalS3Bucket { bucket =>
             withS3Bag(
               bucket,
-              bagInfo = bagInfo,
+              externalIdentifier = externalIdentifier,
               createDataManifest = dataManifestWithWrongChecksum) {
-              bagRootLocation =>
+              case (bagRootLocation, bagInfo) =>
                 val payload = createEnrichedBagInformationPayloadWith(
                   context = createPipelineContextWith(
                     externalIdentifier = externalIdentifier

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
@@ -10,7 +10,10 @@ import uk.ac.wellcome.platform.archive.bagverifier.models.{
 }
 import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagUnavailable
-import uk.ac.wellcome.platform.archive.common.fixtures.{FileEntry, S3BagLocationFixtures}
+import uk.ac.wellcome.platform.archive.common.fixtures.{
+  FileEntry,
+  S3BagLocationFixtures
+}
 import uk.ac.wellcome.platform.archive.common.storage.LocationNotFound
 import uk.ac.wellcome.platform.archive.common.storage.models.{
   IngestFailed,
@@ -38,13 +41,13 @@ class BagVerifierTest
 
   it("passes a bag with correct checksum values") {
     withLocalS3Bucket { bucket =>
-      withS3Bag(
-        bucket,
-        dataFileCount = dataFileCount) {
+      withS3Bag(bucket, dataFileCount = dataFileCount) {
         case (root, bagInfo) =>
           withVerifier { verifier =>
             val ingestStep =
-              verifier.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+              verifier.verify(
+                root,
+                externalIdentifier = bagInfo.externalIdentifier)
             val result = ingestStep.success.get
 
             result shouldBe a[IngestStepSucceeded[_]]
@@ -65,32 +68,35 @@ class BagVerifierTest
       withS3Bag(
         bucket,
         dataFileCount = dataFileCount,
-        createDataManifest = dataManifestWithWrongChecksum) { case (root, bagInfo) =>
-        withVerifier { verifier =>
-          val ingestStep =
-            verifier.verify(root, externalIdentifier = bagInfo.externalIdentifier)
-          val result = ingestStep.success.get
+        createDataManifest = dataManifestWithWrongChecksum) {
+        case (root, bagInfo) =>
+          withVerifier { verifier =>
+            val ingestStep =
+              verifier.verify(
+                root,
+                externalIdentifier = bagInfo.externalIdentifier)
+            val result = ingestStep.success.get
 
-          result shouldBe a[IngestFailed[_]]
-          result.summary shouldBe a[VerificationFailureSummary]
+            result shouldBe a[IngestFailed[_]]
+            result.summary shouldBe a[VerificationFailureSummary]
 
-          val summary = result.summary
-            .asInstanceOf[VerificationFailureSummary]
-          val verification = summary.verification.value
+            val summary = result.summary
+              .asInstanceOf[VerificationFailureSummary]
+            val verification = summary.verification.value
 
-          verification.success should have size expectedFileCount - 1
-          verification.failure should have size 1
+            verification.success should have size expectedFileCount - 1
+            verification.failure should have size 1
 
-          val location = verification.failure.head
-          val error = location.e
+            val location = verification.failure.head
+            val error = location.e
 
-          error shouldBe a[FailedChecksumNoMatch]
-          error.getMessage should include("Checksum values do not match!")
+            error shouldBe a[FailedChecksumNoMatch]
+            error.getMessage should include("Checksum values do not match!")
 
-          val userFacingMessage =
-            result.asInstanceOf[IngestFailed[_]].maybeUserFacingMessage
-          userFacingMessage.get shouldBe "There was 1 error verifying the bag"
-        }
+            val userFacingMessage =
+              result.asInstanceOf[IngestFailed[_]].maybeUserFacingMessage
+            userFacingMessage.get shouldBe "There was 1 error verifying the bag"
+          }
       }
     }
   }
@@ -100,56 +106,62 @@ class BagVerifierTest
       withS3Bag(
         bucket,
         dataFileCount = dataFileCount,
-        createTagManifest = tagManifestWithWrongChecksum) { case (root, bagInfo) =>
-        withVerifier { verifier =>
-          val ingestStep =
-            verifier.verify(root, externalIdentifier = bagInfo.externalIdentifier)
-          val result = ingestStep.success.get
+        createTagManifest = tagManifestWithWrongChecksum) {
+        case (root, bagInfo) =>
+          withVerifier { verifier =>
+            val ingestStep =
+              verifier.verify(
+                root,
+                externalIdentifier = bagInfo.externalIdentifier)
+            val result = ingestStep.success.get
 
-          result shouldBe a[IngestFailed[_]]
-          result.summary shouldBe a[VerificationFailureSummary]
+            result shouldBe a[IngestFailed[_]]
+            result.summary shouldBe a[VerificationFailureSummary]
 
-          val summary = result.summary
-            .asInstanceOf[VerificationFailureSummary]
-          val verification = summary.verification.value
+            val summary = result.summary
+              .asInstanceOf[VerificationFailureSummary]
+            val verification = summary.verification.value
 
-          verification.success should have size expectedFileCount - 1
-          verification.failure should have size 1
+            verification.success should have size expectedFileCount - 1
+            verification.failure should have size 1
 
-          val location = verification.failure.head
-          val error = location.e
+            val location = verification.failure.head
+            val error = location.e
 
-          error shouldBe a[FailedChecksumNoMatch]
-          error.getMessage should include("Checksum values do not match!")
-        }
+            error shouldBe a[FailedChecksumNoMatch]
+            error.getMessage should include("Checksum values do not match!")
+          }
       }
     }
   }
 
   it("fails a bag with multiple incorrect checksums in the file manifest") {
     withLocalS3Bucket { bucket =>
-      withS3Bag(bucket, dataFileCount = dataFileCount) { case (root, bagInfo) =>
-        // Now scribble over the contents of all the data files in the bag
-        listKeysInBucket(bucket).foreach { key =>
-          if (key.contains("/data/")) {
-            s3Client.putObject(
-              bucket.name,
-              key,
-              randomAlphanumeric
-            )
+      withS3Bag(bucket, dataFileCount = dataFileCount) {
+        case (root, bagInfo) =>
+          // Now scribble over the contents of all the data files in the bag
+          listKeysInBucket(bucket).foreach { key =>
+            if (key.contains("/data/")) {
+              s3Client.putObject(
+                bucket.name,
+                key,
+                randomAlphanumeric
+              )
+            }
           }
-        }
 
-        withVerifier { verifier =>
-          val ingestStep =
-            verifier.verify(root, externalIdentifier = bagInfo.externalIdentifier)
-          val result = ingestStep.success.get
-          result shouldBe a[IngestFailed[_]]
+          withVerifier { verifier =>
+            val ingestStep =
+              verifier.verify(
+                root,
+                externalIdentifier = bagInfo.externalIdentifier)
+            val result = ingestStep.success.get
+            result shouldBe a[IngestFailed[_]]
 
-          val userFacingMessage =
-            result.asInstanceOf[IngestFailed[_]].maybeUserFacingMessage
-          userFacingMessage.get shouldBe s"There were $dataFileCount errors verifying the bag"
-        }
+            val userFacingMessage =
+              result.asInstanceOf[IngestFailed[_]].maybeUserFacingMessage
+            userFacingMessage.get shouldBe s"There were $dataFileCount errors verifying the bag"
+          }
       }
     }
   }
@@ -166,29 +178,32 @@ class BagVerifierTest
       withS3Bag(
         bucket,
         dataFileCount = dataFileCount,
-        createDataManifest = createDataManifestWithExtraFile) { case (root, bagInfo) =>
-        withVerifier { verifier =>
-          val ingestStep =
-            verifier.verify(root, externalIdentifier = bagInfo.externalIdentifier)
-          val result = ingestStep.success.get
+        createDataManifest = createDataManifestWithExtraFile) {
+        case (root, bagInfo) =>
+          withVerifier { verifier =>
+            val ingestStep =
+              verifier.verify(
+                root,
+                externalIdentifier = bagInfo.externalIdentifier)
+            val result = ingestStep.success.get
 
-          result shouldBe a[IngestFailed[_]]
-          debug(s"result = $result")
-          result.summary shouldBe a[VerificationFailureSummary]
+            result shouldBe a[IngestFailed[_]]
+            debug(s"result = $result")
+            result.summary shouldBe a[VerificationFailureSummary]
 
-          val summary = result.summary
-            .asInstanceOf[VerificationFailureSummary]
-          val verification = summary.verification.value
+            val summary = result.summary
+              .asInstanceOf[VerificationFailureSummary]
+            val verification = summary.verification.value
 
-          verification.success should have size expectedFileCount - 1
-          verification.failure should have size 1
+            verification.success should have size expectedFileCount - 1
+            verification.failure should have size 1
 
-          val location = verification.failure.head
-          val error = location.e
+            val location = verification.failure.head
+            val error = location.e
 
-          error shouldBe a[LocationNotFound[_]]
-          error.getMessage should startWith("Location not available!")
-        }
+            error shouldBe a[LocationNotFound[_]]
+            error.getMessage should startWith("Location not available!")
+          }
       }
     }
   }
@@ -197,26 +212,29 @@ class BagVerifierTest
     def noDataManifest(files: StringTuple): Option[FileEntry] = None
 
     withLocalS3Bucket { bucket =>
-      withS3Bag(bucket, createDataManifest = noDataManifest) { case (root, _) =>
-        withVerifier { verifier =>
-          val ingestStep =
-            verifier.verify(root, externalIdentifier = createExternalIdentifier)
-          val result = ingestStep.success.get
+      withS3Bag(bucket, createDataManifest = noDataManifest) {
+        case (root, _) =>
+          withVerifier { verifier =>
+            val ingestStep =
+              verifier.verify(
+                root,
+                externalIdentifier = createExternalIdentifier)
+            val result = ingestStep.success.get
 
-          result shouldBe a[IngestFailed[_]]
-          result.summary shouldBe a[VerificationIncompleteSummary]
+            result shouldBe a[IngestFailed[_]]
+            result.summary shouldBe a[VerificationIncompleteSummary]
 
-          val summary = result.summary
-            .asInstanceOf[VerificationIncompleteSummary]
-          val error = summary.e
+            val summary = result.summary
+              .asInstanceOf[VerificationIncompleteSummary]
+            val error = summary.e
 
-          error shouldBe a[BagUnavailable]
-          error.getMessage should include("Error loading manifest-sha256.txt")
+            error shouldBe a[BagUnavailable]
+            error.getMessage should include("Error loading manifest-sha256.txt")
 
-          val userFacingMessage =
-            result.asInstanceOf[IngestFailed[_]].maybeUserFacingMessage
-          userFacingMessage.get shouldBe "Error loading manifest-sha256.txt: no such file!"
-        }
+            val userFacingMessage =
+              result.asInstanceOf[IngestFailed[_]].maybeUserFacingMessage
+            userFacingMessage.get shouldBe "Error loading manifest-sha256.txt: no such file!"
+          }
       }
     }
   }
@@ -225,27 +243,30 @@ class BagVerifierTest
     def noTagManifest(files: StringTuple): Option[FileEntry] = None
 
     withLocalS3Bucket { bucket =>
-      withS3Bag(bucket, createTagManifest = noTagManifest) { case (root, _) =>
-        withVerifier { verifier =>
-          val ingestStep =
-            verifier.verify(root, externalIdentifier = createExternalIdentifier)
-          val result = ingestStep.success.get
+      withS3Bag(bucket, createTagManifest = noTagManifest) {
+        case (root, _) =>
+          withVerifier { verifier =>
+            val ingestStep =
+              verifier.verify(
+                root,
+                externalIdentifier = createExternalIdentifier)
+            val result = ingestStep.success.get
 
-          result shouldBe a[IngestFailed[_]]
-          result.summary shouldBe a[VerificationIncompleteSummary]
+            result shouldBe a[IngestFailed[_]]
+            result.summary shouldBe a[VerificationIncompleteSummary]
 
-          val summary = result.summary
-            .asInstanceOf[VerificationIncompleteSummary]
-          val error = summary.e
+            val summary = result.summary
+              .asInstanceOf[VerificationIncompleteSummary]
+            val error = summary.e
 
-          error shouldBe a[BagUnavailable]
-          error.getMessage should include(
-            "Error loading tagmanifest-sha256.txt")
+            error shouldBe a[BagUnavailable]
+            error.getMessage should include(
+              "Error loading tagmanifest-sha256.txt")
 
-          val userFacingMessage =
-            result.asInstanceOf[IngestFailed[_]].maybeUserFacingMessage
-          userFacingMessage.get shouldBe "Error loading tagmanifest-sha256.txt: no such file!"
-        }
+            val userFacingMessage =
+              result.asInstanceOf[IngestFailed[_]].maybeUserFacingMessage
+            userFacingMessage.get shouldBe "Error loading tagmanifest-sha256.txt: no such file!"
+          }
       }
     }
   }
@@ -258,22 +279,23 @@ class BagVerifierTest
       ExternalIdentifier(externalIdentifier + "_payload")
 
     withLocalS3Bucket { bucket =>
-      withS3Bag(bucket, externalIdentifier = bagInfoExternalIdentifier) { case (root, _) =>
-        withVerifier { verifier =>
-          val ingestStep = verifier.verify(
-            root,
-            externalIdentifier = payloadExternalIdentifier
-          )
-          val result = ingestStep.success.get
+      withS3Bag(bucket, externalIdentifier = bagInfoExternalIdentifier) {
+        case (root, _) =>
+          withVerifier { verifier =>
+            val ingestStep = verifier.verify(
+              root,
+              externalIdentifier = payloadExternalIdentifier
+            )
+            val result = ingestStep.success.get
 
-          result shouldBe a[IngestFailed[_]]
-          result.summary shouldBe a[VerificationIncompleteSummary]
+            result shouldBe a[IngestFailed[_]]
+            result.summary shouldBe a[VerificationIncompleteSummary]
 
-          val userFacingMessage =
-            result.asInstanceOf[IngestFailed[_]].maybeUserFacingMessage
-          userFacingMessage.get should startWith(
-            "External identifier in bag-info.txt does not match request")
-        }
+            val userFacingMessage =
+              result.asInstanceOf[IngestFailed[_]].maybeUserFacingMessage
+            userFacingMessage.get should startWith(
+              "External identifier in bag-info.txt does not match request")
+          }
       }
     }
   }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
@@ -299,7 +299,7 @@ class BagVerifierTest
           val result = ingestStep.success.get
 
           result shouldBe a[IngestFailed[_]]
-          result.summary shouldBe a[VerificationFailureSummary]
+          result.summary shouldBe a[VerificationIncompleteSummary]
 
           val userFacingMessage =
             result.asInstanceOf[IngestFailed[_]].maybeUserFacingMessage

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
@@ -40,27 +40,28 @@ class BagVerifierWorkerTest
     withBagVerifierWorker(ingests, outgoing, stepName = "verification") {
       service =>
         withLocalS3Bucket { bucket =>
-          withS3Bag(bucket, dataFileCount = dataFileCount) { case (bagRootLocation, bagInfo) =>
-            val payload = createEnrichedBagInformationPayloadWith(
-              context = createPipelineContextWith(
-                externalIdentifier = bagInfo.externalIdentifier
-              ),
-              bagRootLocation = bagRootLocation
-            )
-
-            service.processMessage(payload) shouldBe a[Success[_]]
-
-            assertTopicReceivesIngestEvents(
-              payload.ingestId,
-              ingests,
-              expectedDescriptions = Seq(
-                "Verification started",
-                "Verification succeeded"
+          withS3Bag(bucket, dataFileCount = dataFileCount) {
+            case (bagRootLocation, bagInfo) =>
+              val payload = createEnrichedBagInformationPayloadWith(
+                context = createPipelineContextWith(
+                  externalIdentifier = bagInfo.externalIdentifier
+                ),
+                bagRootLocation = bagRootLocation
               )
-            )
 
-            outgoing.getMessages[EnrichedBagInformationPayload] shouldBe Seq(
-              payload)
+              service.processMessage(payload) shouldBe a[Success[_]]
+
+              assertTopicReceivesIngestEvents(
+                payload.ingestId,
+                ingests,
+                expectedDescriptions = Seq(
+                  "Verification started",
+                  "Verification succeeded"
+                )
+              )
+
+              outgoing.getMessages[EnrichedBagInformationPayload] shouldBe Seq(
+                payload)
           }
         }
     }
@@ -73,18 +74,19 @@ class BagVerifierWorkerTest
 
       withBagVerifierWorker(ingests, outgoing) { service =>
         withLocalS3Bucket { bucket =>
-          withS3Bag(bucket) { case (bagRootLocation, bagInfo) =>
-            val payload = createEnrichedBagInformationPayloadWith(
-              context = createPipelineContextWith(
-                externalIdentifier = bagInfo.externalIdentifier
-              ),
-              bagRootLocation = bagRootLocation
-            )
+          withS3Bag(bucket) {
+            case (bagRootLocation, bagInfo) =>
+              val payload = createEnrichedBagInformationPayloadWith(
+                context = createPipelineContextWith(
+                  externalIdentifier = bagInfo.externalIdentifier
+                ),
+                bagRootLocation = bagRootLocation
+              )
 
-            service.processMessage(payload) shouldBe a[Success[_]]
+              service.processMessage(payload) shouldBe a[Success[_]]
 
-            outgoing.getMessages[EnrichedBagInformationPayload] shouldBe Seq(
-              payload)
+              outgoing.getMessages[EnrichedBagInformationPayload] shouldBe Seq(
+                payload)
           }
         }
       }
@@ -96,17 +98,18 @@ class BagVerifierWorkerTest
 
       withBagVerifierWorker(ingests, outgoing) { service =>
         withLocalS3Bucket { bucket =>
-          withS3Bag(bucket) { case (bagRootLocation, bagInfo) =>
-            val payload = createBagRootLocationPayloadWith(
-              context = createPipelineContextWith(
-                externalIdentifier = bagInfo.externalIdentifier
-              ),
-              bagRootLocation = bagRootLocation
-            )
+          withS3Bag(bucket) {
+            case (bagRootLocation, bagInfo) =>
+              val payload = createBagRootLocationPayloadWith(
+                context = createPipelineContextWith(
+                  externalIdentifier = bagInfo.externalIdentifier
+                ),
+                bagRootLocation = bagRootLocation
+              )
 
-            service.processMessage(payload) shouldBe a[Success[_]]
+              service.processMessage(payload) shouldBe a[Success[_]]
 
-            outgoing.getMessages[BagRootLocationPayload] shouldBe Seq(payload)
+              outgoing.getMessages[BagRootLocationPayload] shouldBe Seq(payload)
           }
         }
       }
@@ -193,27 +196,28 @@ class BagVerifierWorkerTest
     withBagVerifierWorker(ingests, outgoing, stepName = "verification") {
       service =>
         withLocalS3Bucket { bucket =>
-          withS3Bag(bucket, externalIdentifier = bagInfoExternalIdentifier) { case (bagRootLocation, _) =>
-            val payload = createEnrichedBagInformationPayloadWith(
-              context = createPipelineContextWith(
-                externalIdentifier = payloadExternalIdentifier
-              ),
-              bagRootLocation = bagRootLocation
-            )
+          withS3Bag(bucket, externalIdentifier = bagInfoExternalIdentifier) {
+            case (bagRootLocation, _) =>
+              val payload = createEnrichedBagInformationPayloadWith(
+                context = createPipelineContextWith(
+                  externalIdentifier = payloadExternalIdentifier
+                ),
+                bagRootLocation = bagRootLocation
+              )
 
-            service.processMessage(payload) shouldBe a[Success[_]]
+              service.processMessage(payload) shouldBe a[Success[_]]
 
-            assertTopicReceivesIngestStatus(
-              payload.ingestId,
-              ingests,
-              status = Ingest.Failed
-            ) { events =>
-              val description = events.map {
-                _.description
-              }.head
-              description should startWith(
-                "Verification failed - External identifier in bag-info.txt does not match request")
-            }
+              assertTopicReceivesIngestStatus(
+                payload.ingestId,
+                ingests,
+                status = Ingest.Failed
+              ) { events =>
+                val description = events.map {
+                  _.description
+                }.head
+                description should startWith(
+                  "Verification failed - External identifier in bag-info.txt does not match request")
+              }
           }
         }
     }
@@ -230,22 +234,23 @@ class BagVerifierWorkerTest
     withBagVerifierWorker(ingests, outgoing, stepName = "verification") {
       service =>
         withLocalS3Bucket { bucket =>
-          withS3Bag(bucket) { case (bagRootLocation, bagInfo) =>
-            val payload = createEnrichedBagInformationPayloadWith(
-              context = createPipelineContextWith(
-                externalIdentifier = bagInfo.externalIdentifier
-              ),
-              bagRootLocation = bagRootLocation
-            )
+          withS3Bag(bucket) {
+            case (bagRootLocation, bagInfo) =>
+              val payload = createEnrichedBagInformationPayloadWith(
+                context = createPipelineContextWith(
+                  externalIdentifier = bagInfo.externalIdentifier
+                ),
+                bagRootLocation = bagRootLocation
+              )
 
-            service.processMessage(payload) shouldBe a[Failure[_]]
+              service.processMessage(payload) shouldBe a[Failure[_]]
 
-            assertTopicReceivesIngestEvent(payload.ingestId, ingests) {
-              events =>
-                events.map {
-                  _.description
-                } shouldBe List("Verification succeeded")
-            }
+              assertTopicReceivesIngestEvent(payload.ingestId, ingests) {
+                events =>
+                  events.map {
+                    _.description
+                  } shouldBe List("Verification succeeded")
+              }
           }
         }
     }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Verification.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Verification.scala
@@ -22,13 +22,13 @@ object Verification extends Logging {
               .map(verifier.verify)
               .foldLeft[VerificationResult](VerificationSuccess(Nil)) {
 
-                case (VerificationSuccess(sl), s @ VerifiedSuccess(_)) =>
+                case (VerificationSuccess(sl), s @ VerifiedSuccess(_, _)) =>
                   VerificationSuccess(s :: sl)
 
                 case (VerificationSuccess(sl), f @ VerifiedFailure(_, _)) =>
                   VerificationFailure(List(f), sl)
 
-                case (VerificationFailure(fl, sl), s @ VerifiedSuccess(_)) =>
+                case (VerificationFailure(fl, sl), s @ VerifiedSuccess(_, _)) =>
                   VerificationFailure(fl, s :: sl)
 
                 case (VerificationFailure(fl, sl), f @ VerifiedFailure(_, _)) =>

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/VerifiedLocation.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/VerifiedLocation.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.archive.common.verify
 
 sealed trait VerifiedLocation
 
-case class VerifiedSuccess(location: VerifiableLocation)
+case class VerifiedSuccess(location: VerifiableLocation, size: Long)
     extends VerifiedLocation
 case class VerifiedFailure(location: VerifiableLocation, e: Throwable)
     extends VerifiedLocation

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Verifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Verifier.scala
@@ -89,7 +89,7 @@ trait Verifier[IS <: InputStream with HasLength] extends Logging {
   }
 
   private def verifyChecksum(verifiableLocation: VerifiableLocation,
-                             inputStream: InputStream,
+                             inputStream: IS,
                              algorithm: HashingAlgorithm): VerifiedLocation =
     Checksum.create(inputStream, algorithm) match {
       // Failure to create a checksum (parsing/algorithm)
@@ -110,7 +110,7 @@ trait Verifier[IS <: InputStream with HasLength] extends Logging {
           )
         } else {
           // Happy path!
-          VerifiedSuccess(verifiableLocation)
+          VerifiedSuccess(verifiableLocation, size = inputStream.length)
         }
     }
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/models/BagInfoTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/models/BagInfoTest.scala
@@ -5,7 +5,10 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.common.bagit.models
 import uk.ac.wellcome.platform.archive.common.bagit.models.error.InvalidBagInfo
 import uk.ac.wellcome.platform.archive.common.fixtures.BagIt
-import uk.ac.wellcome.platform.archive.common.generators.{ExternalIdentifierGenerators, PayloadOxumGenerators}
+import uk.ac.wellcome.platform.archive.common.generators.{
+  ExternalIdentifierGenerators,
+  PayloadOxumGenerators
+}
 
 class BagInfoTest
     extends FunSpec

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/models/BagInfoTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/models/BagInfoTest.scala
@@ -5,19 +5,20 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.common.bagit.models
 import uk.ac.wellcome.platform.archive.common.bagit.models.error.InvalidBagInfo
 import uk.ac.wellcome.platform.archive.common.fixtures.BagIt
-import uk.ac.wellcome.platform.archive.common.generators.ExternalIdentifierGenerators
+import uk.ac.wellcome.platform.archive.common.generators.{ExternalIdentifierGenerators, PayloadOxumGenerators}
 
 class BagInfoTest
     extends FunSpec
     with BagIt
     with Matchers
-    with ExternalIdentifierGenerators {
+    with ExternalIdentifierGenerators
+    with PayloadOxumGenerators {
   case class Thing(id: String)
   val t = Thing("a")
 
   it("extracts a BagInfo object from a bagInfo file with only required fields") {
     val externalIdentifier = createExternalIdentifier
-    val payloadOxum = randomPayloadOxum
+    val payloadOxum = createPayloadOxum
     val baggingDate = randomLocalDate
     val bagInfoString =
       bagInfoFileContents(externalIdentifier, payloadOxum, baggingDate)
@@ -29,7 +30,7 @@ class BagInfoTest
   it(
     "extracts a BagInfo object from a bagInfo file with all required and optional fields") {
     val externalIdentifier = createExternalIdentifier
-    val payloadOxum = randomPayloadOxum
+    val payloadOxum = createPayloadOxum
     val baggingDate = randomLocalDate
     val sourceOrganisation = Some(randomSourceOrganisation)
     val externalDescription = Some(randomExternalDescription)
@@ -60,7 +61,7 @@ class BagInfoTest
     "returns a left of invalid bag info error if there is no external identifier in bag-info.txt") {
     val bagInfoString =
       s"""|Source-Organization: $randomSourceOrganisation
-          |Payload-Oxum: ${randomPayloadOxum.payloadBytes}.${randomPayloadOxum.numberOfPayloadFiles}
+          |Payload-Oxum: ${createPayloadOxum.payloadBytes}.${createPayloadOxum.numberOfPayloadFiles}
           |Bagging-Date: $randomLocalDate""".stripMargin
 
     BagInfo.parseBagInfo(t, IOUtils.toInputStream(bagInfoString, "UTF-8")) shouldBe Left(
@@ -95,7 +96,7 @@ class BagInfoTest
     val bagInfoString =
       s"""|External-Identifier: $createExternalIdentifier
           |Source-Organization: $randomSourceOrganisation
-          |Payload-Oxum: ${randomPayloadOxum.payloadBytes}.${randomPayloadOxum.numberOfPayloadFiles}""".stripMargin
+          |Payload-Oxum: ${createPayloadOxum.payloadBytes}.${createPayloadOxum.numberOfPayloadFiles}""".stripMargin
 
     BagInfo.parseBagInfo(t, IOUtils.toInputStream(bagInfoString, "UTF-8")) shouldBe Left(
       InvalidBagInfo(t, List("Bagging-Date")))
@@ -106,7 +107,7 @@ class BagInfoTest
     val bagInfoString =
       s"""|External-Identifier: $createExternalIdentifier
           |Source-Organization: $randomSourceOrganisation
-          |Payload-Oxum: ${randomPayloadOxum.payloadBytes}.${randomPayloadOxum.numberOfPayloadFiles}
+          |Payload-Oxum: ${createPayloadOxum.payloadBytes}.${createPayloadOxum.numberOfPayloadFiles}
           |Bagging-Date: sdfkjghl""".stripMargin
 
     BagInfo.parseBagInfo(t, IOUtils.toInputStream(bagInfoString, "UTF-8")) shouldBe Left(

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagReaderTestCases.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagReaderTestCases.scala
@@ -42,13 +42,12 @@ trait BagReaderTestCases[Context, Namespace]
     }
 
   it("gets a correctly formed bag") {
-    val bagInfo = createBagInfo
-
     withFixtures { fixtures =>
       implicit val (context, typedStore, namespace) = fixtures
       withBagReader { bagReader =>
-        withBag(bagInfo = bagInfo) { rootLocation =>
-          bagReader.get(rootLocation).right.value.info shouldBe bagInfo
+        withBag() { case (rootLocation, bagInfo) =>
+          val bag = bagReader.get(rootLocation).right.value
+          bag.info shouldBe bagInfo
         }
       }
     }
@@ -58,7 +57,7 @@ trait BagReaderTestCases[Context, Namespace]
     withFixtures { fixtures =>
       implicit val (context, typedStore, namespace) = fixtures
       withBagReader { bagReader =>
-        withBag() { rootLocation =>
+        withBag() { case (rootLocation, _) =>
           deleteFile(rootLocation, "bag-info.txt")
 
           bagReader.get(rootLocation).left.value.msg should startWith(
@@ -72,7 +71,7 @@ trait BagReaderTestCases[Context, Namespace]
     withFixtures { fixtures =>
       implicit val (context, typedStore, namespace) = fixtures
       withBagReader { bagReader =>
-        withBag() { rootLocation =>
+        withBag() { case (rootLocation, _) =>
           scrambleFile(rootLocation, "bag-info.txt")
 
           bagReader.get(rootLocation).left.value.msg should startWith(
@@ -86,7 +85,7 @@ trait BagReaderTestCases[Context, Namespace]
     withFixtures { fixtures =>
       implicit val (context, typedStore, namespace) = fixtures
       withBagReader { bagReader =>
-        withBag() { rootLocation =>
+        withBag() { case (rootLocation, _) =>
           deleteFile(rootLocation, "manifest-sha256.txt")
 
           bagReader.get(rootLocation).left.value.msg should startWith(
@@ -100,7 +99,7 @@ trait BagReaderTestCases[Context, Namespace]
     withFixtures { fixtures =>
       implicit val (context, typedStore, namespace) = fixtures
       withBagReader { bagReader =>
-        withBag() { rootLocation =>
+        withBag() { case (rootLocation, _) =>
           scrambleFile(rootLocation, "manifest-sha256.txt")
 
           bagReader.get(rootLocation).left.value.msg should startWith(
@@ -114,7 +113,7 @@ trait BagReaderTestCases[Context, Namespace]
     withFixtures { fixtures =>
       implicit val (context, typedStore, namespace) = fixtures
       withBagReader { bagReader =>
-        withBag() { rootLocation =>
+        withBag() { case (rootLocation, _) =>
           deleteFile(rootLocation, "tagmanifest-sha256.txt")
 
           bagReader.get(rootLocation).left.value.msg should startWith(
@@ -128,7 +127,7 @@ trait BagReaderTestCases[Context, Namespace]
     withFixtures { fixtures =>
       implicit val (context, typedStore, namespace) = fixtures
       withBagReader { bagReader =>
-        withBag() { rootLocation =>
+        withBag() { case (rootLocation, _) =>
           scrambleFile(rootLocation, "tagmanifest-sha256.txt")
 
           bagReader.get(rootLocation).left.value.msg should startWith(
@@ -142,7 +141,7 @@ trait BagReaderTestCases[Context, Namespace]
     withFixtures { fixtures =>
       implicit val (context, typedStore, namespace) = fixtures
       withBagReader { bagReader =>
-        withBag() { rootLocation =>
+        withBag() { case (rootLocation, _) =>
           deleteFile(rootLocation, "fetch.txt")
 
           bagReader.get(rootLocation).right.value.fetch shouldBe None
@@ -155,7 +154,7 @@ trait BagReaderTestCases[Context, Namespace]
     withFixtures { fixtures =>
       implicit val (context, typedStore, namespace) = fixtures
       withBagReader { bagReader =>
-        withBag() { rootLocation =>
+        withBag() { case (rootLocation, _) =>
           scrambleFile(rootLocation, "fetch.txt")
 
           bagReader.get(rootLocation).left.value.msg should startWith(

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagReaderTestCases.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagReaderTestCases.scala
@@ -45,9 +45,10 @@ trait BagReaderTestCases[Context, Namespace]
     withFixtures { fixtures =>
       implicit val (context, typedStore, namespace) = fixtures
       withBagReader { bagReader =>
-        withBag() { case (rootLocation, bagInfo) =>
-          val bag = bagReader.get(rootLocation).right.value
-          bag.info shouldBe bagInfo
+        withBag() {
+          case (rootLocation, bagInfo) =>
+            val bag = bagReader.get(rootLocation).right.value
+            bag.info shouldBe bagInfo
         }
       }
     }
@@ -57,11 +58,12 @@ trait BagReaderTestCases[Context, Namespace]
     withFixtures { fixtures =>
       implicit val (context, typedStore, namespace) = fixtures
       withBagReader { bagReader =>
-        withBag() { case (rootLocation, _) =>
-          deleteFile(rootLocation, "bag-info.txt")
+        withBag() {
+          case (rootLocation, _) =>
+            deleteFile(rootLocation, "bag-info.txt")
 
-          bagReader.get(rootLocation).left.value.msg should startWith(
-            "Error loading bag-info.txt")
+            bagReader.get(rootLocation).left.value.msg should startWith(
+              "Error loading bag-info.txt")
         }
       }
     }
@@ -71,11 +73,12 @@ trait BagReaderTestCases[Context, Namespace]
     withFixtures { fixtures =>
       implicit val (context, typedStore, namespace) = fixtures
       withBagReader { bagReader =>
-        withBag() { case (rootLocation, _) =>
-          scrambleFile(rootLocation, "bag-info.txt")
+        withBag() {
+          case (rootLocation, _) =>
+            scrambleFile(rootLocation, "bag-info.txt")
 
-          bagReader.get(rootLocation).left.value.msg should startWith(
-            "Error loading bag-info.txt")
+            bagReader.get(rootLocation).left.value.msg should startWith(
+              "Error loading bag-info.txt")
         }
       }
     }
@@ -85,11 +88,12 @@ trait BagReaderTestCases[Context, Namespace]
     withFixtures { fixtures =>
       implicit val (context, typedStore, namespace) = fixtures
       withBagReader { bagReader =>
-        withBag() { case (rootLocation, _) =>
-          deleteFile(rootLocation, "manifest-sha256.txt")
+        withBag() {
+          case (rootLocation, _) =>
+            deleteFile(rootLocation, "manifest-sha256.txt")
 
-          bagReader.get(rootLocation).left.value.msg should startWith(
-            "Error loading manifest-sha256.txt")
+            bagReader.get(rootLocation).left.value.msg should startWith(
+              "Error loading manifest-sha256.txt")
         }
       }
     }
@@ -99,11 +103,12 @@ trait BagReaderTestCases[Context, Namespace]
     withFixtures { fixtures =>
       implicit val (context, typedStore, namespace) = fixtures
       withBagReader { bagReader =>
-        withBag() { case (rootLocation, _) =>
-          scrambleFile(rootLocation, "manifest-sha256.txt")
+        withBag() {
+          case (rootLocation, _) =>
+            scrambleFile(rootLocation, "manifest-sha256.txt")
 
-          bagReader.get(rootLocation).left.value.msg should startWith(
-            "Error loading manifest-sha256.txt")
+            bagReader.get(rootLocation).left.value.msg should startWith(
+              "Error loading manifest-sha256.txt")
         }
       }
     }
@@ -113,11 +118,12 @@ trait BagReaderTestCases[Context, Namespace]
     withFixtures { fixtures =>
       implicit val (context, typedStore, namespace) = fixtures
       withBagReader { bagReader =>
-        withBag() { case (rootLocation, _) =>
-          deleteFile(rootLocation, "tagmanifest-sha256.txt")
+        withBag() {
+          case (rootLocation, _) =>
+            deleteFile(rootLocation, "tagmanifest-sha256.txt")
 
-          bagReader.get(rootLocation).left.value.msg should startWith(
-            "Error loading tagmanifest-sha256.txt")
+            bagReader.get(rootLocation).left.value.msg should startWith(
+              "Error loading tagmanifest-sha256.txt")
         }
       }
     }
@@ -127,11 +133,12 @@ trait BagReaderTestCases[Context, Namespace]
     withFixtures { fixtures =>
       implicit val (context, typedStore, namespace) = fixtures
       withBagReader { bagReader =>
-        withBag() { case (rootLocation, _) =>
-          scrambleFile(rootLocation, "tagmanifest-sha256.txt")
+        withBag() {
+          case (rootLocation, _) =>
+            scrambleFile(rootLocation, "tagmanifest-sha256.txt")
 
-          bagReader.get(rootLocation).left.value.msg should startWith(
-            "Error loading tagmanifest-sha256.txt")
+            bagReader.get(rootLocation).left.value.msg should startWith(
+              "Error loading tagmanifest-sha256.txt")
         }
       }
     }
@@ -141,10 +148,11 @@ trait BagReaderTestCases[Context, Namespace]
     withFixtures { fixtures =>
       implicit val (context, typedStore, namespace) = fixtures
       withBagReader { bagReader =>
-        withBag() { case (rootLocation, _) =>
-          deleteFile(rootLocation, "fetch.txt")
+        withBag() {
+          case (rootLocation, _) =>
+            deleteFile(rootLocation, "fetch.txt")
 
-          bagReader.get(rootLocation).right.value.fetch shouldBe None
+            bagReader.get(rootLocation).right.value.fetch shouldBe None
         }
       }
     }
@@ -154,11 +162,12 @@ trait BagReaderTestCases[Context, Namespace]
     withFixtures { fixtures =>
       implicit val (context, typedStore, namespace) = fixtures
       withBagReader { bagReader =>
-        withBag() { case (rootLocation, _) =>
-          scrambleFile(rootLocation, "fetch.txt")
+        withBag() {
+          case (rootLocation, _) =>
+            scrambleFile(rootLocation, "fetch.txt")
 
-          bagReader.get(rootLocation).left.value.msg should startWith(
-            "Error loading fetch.txt")
+            bagReader.get(rootLocation).left.value.msg should startWith(
+              "Error loading fetch.txt")
         }
       }
     }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/S3BagLocationFixtures.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/S3BagLocationFixtures.scala
@@ -3,8 +3,18 @@ package uk.ac.wellcome.platform.archive.common.fixtures
 import java.net.URI
 
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagFetch, BagFetchEntry, BagInfo, BagPath, ExternalIdentifier, PayloadOxum}
-import uk.ac.wellcome.platform.archive.common.generators.{BagInfoGenerators, StorageSpaceGenerators}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagFetch,
+  BagFetchEntry,
+  BagInfo,
+  BagPath,
+  ExternalIdentifier,
+  PayloadOxum
+}
+import uk.ac.wellcome.platform.archive.common.generators.{
+  BagInfoGenerators,
+  StorageSpaceGenerators
+}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
@@ -20,9 +30,8 @@ trait BagLocationFixtures[Namespace]
     with BagIt
     with StorageSpaceGenerators
     with ObjectLocationGenerators {
-  def createObjectLocationWith(
-    namespace: Namespace,
-    path: String): ObjectLocation
+  def createObjectLocationWith(namespace: Namespace,
+                               path: String): ObjectLocation
 
   def withBag[R](
     externalIdentifier: ExternalIdentifier = createExternalIdentifier,
@@ -41,14 +50,13 @@ trait BagLocationFixtures[Namespace]
     info(s"Creating Bag $externalIdentifier")
 
     val bagInfo = createBagInfoWith(
-      payloadOxum =
-        payloadOxum match {
-          case Some(oxum) => oxum
-          case _ => createPayloadOxumWith(
+      payloadOxum = payloadOxum match {
+        case Some(oxum) => oxum
+        case _ =>
+          createPayloadOxumWith(
             numberOfPayloadFiles = dataFileCount
           )
-        }
-      ,
+      },
       externalIdentifier = externalIdentifier
     )
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageRandomThings.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageRandomThings.scala
@@ -143,9 +143,6 @@ trait StorageRandomThings extends RandomThings {
   def randomExternalDescription =
     ExternalDescription(randomAlphanumericWithLength())
 
-  def randomPayloadOxum =
-    PayloadOxum(Random.nextLong().abs, Random.nextInt().abs)
-
   def randomLocalDate = {
     val startRange = -999999999
     val maxValue = 1999999998

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/BagInfoGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/BagInfoGenerators.scala
@@ -1,11 +1,7 @@
 package uk.ac.wellcome.platform.archive.common.generators
 
 import uk.ac.wellcome.platform.archive.common.bagit.models
-import uk.ac.wellcome.platform.archive.common.bagit.models.{
-  BagInfo,
-  ExternalDescription,
-  ExternalIdentifier
-}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{BagInfo, ExternalDescription, ExternalIdentifier, PayloadOxum}
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
 
 trait BagInfoGenerators
@@ -13,13 +9,14 @@ trait BagInfoGenerators
     with StorageRandomThings {
 
   def createBagInfoWith(
+    payloadOxum: PayloadOxum = randomPayloadOxum,
     externalIdentifier: ExternalIdentifier = createExternalIdentifier,
     externalDescription: Option[ExternalDescription] = Some(
       randomExternalDescription)
   ): BagInfo =
     models.BagInfo(
       externalIdentifier = externalIdentifier,
-      payloadOxum = randomPayloadOxum,
+      payloadOxum = payloadOxum,
       baggingDate = randomLocalDate,
       sourceOrganisation = Some(randomSourceOrganisation),
       externalDescription = externalDescription,

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/BagInfoGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/BagInfoGenerators.scala
@@ -1,7 +1,12 @@
 package uk.ac.wellcome.platform.archive.common.generators
 
 import uk.ac.wellcome.platform.archive.common.bagit.models
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagInfo, ExternalDescription, ExternalIdentifier, PayloadOxum}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagInfo,
+  ExternalDescription,
+  ExternalIdentifier,
+  PayloadOxum
+}
 
 trait BagInfoGenerators
     extends ExternalIdentifierGenerators

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/BagInfoGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/BagInfoGenerators.scala
@@ -2,14 +2,13 @@ package uk.ac.wellcome.platform.archive.common.generators
 
 import uk.ac.wellcome.platform.archive.common.bagit.models
 import uk.ac.wellcome.platform.archive.common.bagit.models.{BagInfo, ExternalDescription, ExternalIdentifier, PayloadOxum}
-import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
 
 trait BagInfoGenerators
     extends ExternalIdentifierGenerators
-    with StorageRandomThings {
+    with PayloadOxumGenerators {
 
   def createBagInfoWith(
-    payloadOxum: PayloadOxum = randomPayloadOxum,
+    payloadOxum: PayloadOxum = createPayloadOxum,
     externalIdentifier: ExternalIdentifier = createExternalIdentifier,
     externalDescription: Option[ExternalDescription] = Some(
       randomExternalDescription)

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadOxumGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadOxumGenerators.scala
@@ -1,0 +1,19 @@
+package uk.ac.wellcome.platform.archive.common.generators
+
+import uk.ac.wellcome.platform.archive.common.bagit.models.PayloadOxum
+import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
+
+import scala.util.Random
+
+trait PayloadOxumGenerators extends StorageRandomThings {
+  def createPayloadOxumWith(
+    payloadBytes: Long = Random.nextLong().abs,
+    numberOfPayloadFiles: Int = randomInt(from = 1, to = 10000)
+  ): PayloadOxum =
+    PayloadOxum(
+      payloadBytes = payloadBytes,
+      numberOfPayloadFiles = numberOfPayloadFiles
+    )
+
+  def createPayloadOxum: PayloadOxum = createPayloadOxumWith()
+}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/VerifierTestCases.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/VerifierTestCases.scala
@@ -51,6 +51,7 @@ trait VerifierTestCases[Namespace, Context]
 
         val verifiedSuccess = result.asInstanceOf[VerifiedSuccess]
         verifiedSuccess.location shouldBe verifiableLocation
+        verifiedSuccess.size shouldBe contentString.getBytes.size
       }
     }
   }
@@ -185,6 +186,7 @@ trait VerifierTestCases[Namespace, Context]
 
         val verifiedSuccess = result.asInstanceOf[VerifiedSuccess]
         verifiedSuccess.location shouldBe verifiableLocation
+        verifiedSuccess.size shouldBe contentString.getBytes.size
       }
     }
   }
@@ -218,6 +220,7 @@ trait VerifierTestCases[Namespace, Context]
 
         val verifiedSuccess = result.asInstanceOf[VerifiedSuccess]
         verifiedSuccess.location shouldBe verifiableLocation
+        verifiedSuccess.size shouldBe contentString.getBytes.size
       }
     }
   }


### PR DESCRIPTION
For https://github.com/wellcometrust/platform/issues/3745, https://github.com/wellcometrust/platform/issues/3765

I wanted to add the verifier check that every file in S3 is referred to by a manifest (https://github.com/wellcometrust/platform/issues/3688, because I think it's the root of https://github.com/wellcometrust/platform/issues/3743), but I discovered I had to do some verifier refactoring first.

The core of BagVerifier is now a lot simpler, and you can see which checks we're doing more easily:

```scala
      val internalResult =
        for {
          bag <- getBag(root, startTime = startTime)

          _ <- verifyExternalIdentifier(
            bag = bag,
            externalIdentifier = externalIdentifier,
            root = root,
            startTime = startTime
          )

          _ <- verifyPayloadOxumFileCount(bag)

          result <- verifyChecksums(
            root = root,
            bag = bag,
            startTime = startTime
          )
        } yield result
```

In fact I didn't end up adding that check (which requires rather more Listable and testing and stuff), but I did add a check for half the Payload-Oxum. It tells us how many payload files there are in the bag, so now we check that and fail the bag if that’s incorrect.