### PR TITLE
Check for unreferenced files in the bag

### DIFF
--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/Main.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/Main.scala
@@ -30,6 +30,9 @@ import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 import scala.concurrent.ExecutionContext
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.common.verify.s3.S3ObjectVerifier
+import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
+import uk.ac.wellcome.storage.listing.Listing
+import uk.ac.wellcome.storage.listing.s3.S3ObjectLocationListing
 
 object Main extends WellcomeTypesafeApp {
   runWithConfig { config: Config =>
@@ -59,6 +62,9 @@ object Main extends WellcomeTypesafeApp {
 
     implicit val s3Resolvable =
       new S3Resolvable()
+
+    implicit val s3Listing: Listing[ObjectLocationPrefix, ObjectLocation] =
+      S3ObjectLocationListing()
 
     val verifier =
       new BagVerifier()

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -160,7 +160,7 @@ class BagVerifier()(
         val verificationFailureMessage =
           result.failure
             .map { verifiedFailure =>
-              s"${verifiedFailure.location.uri}: ${verifiedFailure.e.getMessage}"
+              s"${verifiedFailure.verifiableLocation.uri}: ${verifiedFailure.e.getMessage}"
             }
             .mkString("\n")
 

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -151,7 +151,7 @@ class BagVerifier()(
             if (unreferencedFiles.isEmpty)
               Right(())
             else {
-              val message = s"Bag contains files which are not referenced in the manifest: $unreferencedFiles"
+              val message = s"Bag contains files which are not referenced in the manifest: ${unreferencedFiles.mkString(", ")}"
               Left(BagVerifierError(
                 new Throwable(message),
                 userMessage = Some(message)

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -151,10 +151,32 @@ class BagVerifier()(
             if (unreferencedFiles.isEmpty)
               Right(())
             else {
-              val message = s"Bag contains files which are not referenced in the manifest: ${unreferencedFiles.mkString(", ")}"
+
+              // For internal logging, we want a message that contains the full
+              // S3 locations for easy debugging, e.g.:
+              //
+              //    Bag contains 5 files which are not referenced in the manifest:
+              //    bukkit/ingest-id/bag-id/unreferenced1.txt, ...
+              //
+              // For the user-facing message, we want to trim the first part,
+              // because it's an internal detail of the storage service, e.g.:
+              //
+              //    Bag contains 5 files which are not referenced in the manifest:
+              //    unreferenced1.txt, ...
+              //
+              val messagePrefix =
+                if (unreferencedFiles.size == 1) {
+                  "Bag contains a file which is not referenced in the manifest: "
+                } else {
+                  s"Bag contains ${unreferencedFiles.size} files which are not referenced in the manifest: "
+                }
+
+              val userMessage = messagePrefix +
+                unreferencedFiles.map { _.path.stripPrefix(root.path) }.mkString(", ")
+
               Left(BagVerifierError(
-                new Throwable(message),
-                userMessage = Some(message)
+                new Throwable(messagePrefix + unreferencedFiles.mkString(", ")),
+                userMessage = Some(userMessage)
               ))
             }
         } yield result

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
@@ -6,10 +6,16 @@ import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
-import uk.ac.wellcome.platform.archive.bagverifier.services.{BagVerifier, BagVerifierWorker}
+import uk.ac.wellcome.platform.archive.bagverifier.services.{
+  BagVerifier,
+  BagVerifierWorker
+}
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagReader
 import uk.ac.wellcome.platform.archive.common.bagit.services.s3.S3BagReader
-import uk.ac.wellcome.platform.archive.common.fixtures.{MonitoringClientFixture, OperationFixtures}
+import uk.ac.wellcome.platform.archive.common.fixtures.{
+  MonitoringClientFixture,
+  OperationFixtures
+}
 import uk.ac.wellcome.platform.archive.common.storage.services.S3Resolvable
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.json.JsonUtil._

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/fixtures/BagVerifierFixtures.scala
@@ -6,20 +6,15 @@ import uk.ac.wellcome.messaging.fixtures.SQS
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
-import uk.ac.wellcome.platform.archive.bagverifier.services.{
-  BagVerifier,
-  BagVerifierWorker
-}
+import uk.ac.wellcome.platform.archive.bagverifier.services.{BagVerifier, BagVerifierWorker}
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagReader
 import uk.ac.wellcome.platform.archive.common.bagit.services.s3.S3BagReader
-import uk.ac.wellcome.platform.archive.common.fixtures.{
-  MonitoringClientFixture,
-  OperationFixtures
-}
+import uk.ac.wellcome.platform.archive.common.fixtures.{MonitoringClientFixture, OperationFixtures}
 import uk.ac.wellcome.platform.archive.common.storage.services.S3Resolvable
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.common.verify.s3.S3ObjectVerifier
+import uk.ac.wellcome.storage.listing.s3.S3ObjectLocationListing
 
 trait BagVerifierFixtures
     extends AlpakkaSQSWorkerFixtures
@@ -69,6 +64,8 @@ trait BagVerifierFixtures
 
       implicit val _s3Resolvable: S3Resolvable =
         new S3Resolvable()
+
+      implicit val listing: S3ObjectLocationListing = S3ObjectLocationListing()
 
       val verifier = new BagVerifier()
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Verification.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Verification.scala
@@ -22,16 +22,16 @@ object Verification extends Logging {
               .map(verifier.verify)
               .foldLeft[VerificationResult](VerificationSuccess(Nil)) {
 
-                case (VerificationSuccess(sl), s @ VerifiedSuccess(_, _)) =>
+                case (VerificationSuccess(sl), s @ VerifiedSuccess(_, _, _)) =>
                   VerificationSuccess(s :: sl)
 
-                case (VerificationSuccess(sl), f @ VerifiedFailure(_, _)) =>
+                case (VerificationSuccess(sl), f @ VerifiedFailure(_, _, _)) =>
                   VerificationFailure(List(f), sl)
 
-                case (VerificationFailure(fl, sl), s @ VerifiedSuccess(_, _)) =>
+                case (VerificationFailure(fl, sl), s @ VerifiedSuccess(_, _, _)) =>
                   VerificationFailure(fl, s :: sl)
 
-                case (VerificationFailure(fl, sl), f @ VerifiedFailure(_, _)) =>
+                case (VerificationFailure(fl, sl), f @ VerifiedFailure(_, _, _)) =>
                   VerificationFailure(f :: fl, sl)
 
                 case (i @ VerificationIncomplete(_), _) => i

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Verification.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Verification.scala
@@ -28,10 +28,14 @@ object Verification extends Logging {
                 case (VerificationSuccess(sl), f @ VerifiedFailure(_, _, _)) =>
                   VerificationFailure(List(f), sl)
 
-                case (VerificationFailure(fl, sl), s @ VerifiedSuccess(_, _, _)) =>
+                case (
+                    VerificationFailure(fl, sl),
+                    s @ VerifiedSuccess(_, _, _)) =>
                   VerificationFailure(fl, s :: sl)
 
-                case (VerificationFailure(fl, sl), f @ VerifiedFailure(_, _, _)) =>
+                case (
+                    VerificationFailure(fl, sl),
+                    f @ VerifiedFailure(_, _, _)) =>
                   VerificationFailure(f :: fl, sl)
 
                 case (i @ VerificationIncomplete(_), _) => i

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/VerifiedLocation.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/VerifiedLocation.scala
@@ -4,22 +4,19 @@ import uk.ac.wellcome.storage.ObjectLocation
 
 sealed trait VerifiedLocation
 
-case class VerifiedSuccess(
-  verifiableLocation: VerifiableLocation,
-  objectLocation: ObjectLocation,
-  size: Long)
+case class VerifiedSuccess(verifiableLocation: VerifiableLocation,
+                           objectLocation: ObjectLocation,
+                           size: Long)
     extends VerifiedLocation
 
-case class VerifiedFailure(
-  verifiableLocation: VerifiableLocation,
-  objectLocation: Option[ObjectLocation],
-  e: Throwable)
+case class VerifiedFailure(verifiableLocation: VerifiableLocation,
+                           objectLocation: Option[ObjectLocation],
+                           e: Throwable)
     extends VerifiedLocation
 
 case object VerifiedFailure {
-  def apply(
-    verifiableLocation: VerifiableLocation,
-    e: Throwable): VerifiedFailure =
+  def apply(verifiableLocation: VerifiableLocation,
+            e: Throwable): VerifiedFailure =
     VerifiedFailure(
       verifiableLocation = verifiableLocation,
       objectLocation = None,

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/VerifiedLocation.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/VerifiedLocation.scala
@@ -1,8 +1,39 @@
 package uk.ac.wellcome.platform.archive.common.verify
 
+import uk.ac.wellcome.storage.ObjectLocation
+
 sealed trait VerifiedLocation
 
-case class VerifiedSuccess(location: VerifiableLocation, size: Long)
+case class VerifiedSuccess(
+  verifiableLocation: VerifiableLocation,
+  objectLocation: ObjectLocation,
+  size: Long)
     extends VerifiedLocation
-case class VerifiedFailure(location: VerifiableLocation, e: Throwable)
+
+case class VerifiedFailure(
+  verifiableLocation: VerifiableLocation,
+  objectLocation: Option[ObjectLocation],
+  e: Throwable)
     extends VerifiedLocation
+
+case object VerifiedFailure {
+  def apply(
+    verifiableLocation: VerifiableLocation,
+    e: Throwable): VerifiedFailure =
+    VerifiedFailure(
+      verifiableLocation = verifiableLocation,
+      objectLocation = None,
+      e = e
+    )
+
+  def apply(
+    verifiableLocation: VerifiableLocation,
+    objectLocation: ObjectLocation,
+    e: Throwable
+  ): VerifiedFailure =
+    VerifiedFailure(
+      verifiableLocation = verifiableLocation,
+      objectLocation = Some(objectLocation),
+      e = e
+    )
+}

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Verifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/Verifier.scala
@@ -36,7 +36,7 @@ trait Verifier[IS <: InputStream with HasLength] extends Logging {
       }
 
       inputStream <- streamStore.get(objectLocation) match {
-        case Right(stream)              => Right(stream.identifiedT)
+        case Right(stream) => Right(stream.identifiedT)
 
         case Left(_: DoesNotExistError) =>
           Left(
@@ -51,9 +51,7 @@ trait Verifier[IS <: InputStream with HasLength] extends Logging {
     } yield (inputStream, objectLocation)
 
     val result = eitherInputStream match {
-      case Left(e) => VerifiedFailure(
-        verifiableLocation,
-        e = e)
+      case Left(e) => VerifiedFailure(verifiableLocation, e = e)
 
       case Right((inputStream, objectLocation)) =>
         verifiableLocation.length match {

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/VerifierTestCases.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/VerifierTestCases.scala
@@ -50,7 +50,7 @@ trait VerifierTestCases[Namespace, Context]
         result shouldBe a[VerifiedSuccess]
 
         val verifiedSuccess = result.asInstanceOf[VerifiedSuccess]
-        verifiedSuccess.location shouldBe verifiableLocation
+        verifiedSuccess.verifiableLocation shouldBe verifiableLocation
         verifiedSuccess.size shouldBe contentString.getBytes.size
       }
     }
@@ -77,7 +77,7 @@ trait VerifierTestCases[Namespace, Context]
 
         val verifiedFailure = result.asInstanceOf[VerifiedFailure]
 
-        verifiedFailure.location shouldBe verifiableLocation
+        verifiedFailure.verifiableLocation shouldBe verifiableLocation
         verifiedFailure.e shouldBe a[LocationNotFound[_]]
         verifiedFailure.e.getMessage should include(
           "Location not available!"
@@ -108,7 +108,7 @@ trait VerifierTestCases[Namespace, Context]
 
         val verifiedFailure = result.asInstanceOf[VerifiedFailure]
 
-        verifiedFailure.location shouldBe verifiableLocation
+        verifiedFailure.verifiableLocation shouldBe verifiableLocation
         verifiedFailure.e shouldBe a[FailedChecksumNoMatch]
         verifiedFailure.e.getMessage should startWith(
           s"Checksum values do not match! Expected: $checksum"
@@ -147,7 +147,7 @@ trait VerifierTestCases[Namespace, Context]
 
         val verifiedFailure = result.asInstanceOf[VerifiedFailure]
 
-        verifiedFailure.location shouldBe verifiableLocation
+        verifiedFailure.verifiableLocation shouldBe verifiableLocation
         verifiedFailure.e shouldBe a[Throwable]
         verifiedFailure.e.getMessage should startWith(
           "Lengths do not match:"
@@ -185,7 +185,7 @@ trait VerifierTestCases[Namespace, Context]
         result shouldBe a[VerifiedSuccess]
 
         val verifiedSuccess = result.asInstanceOf[VerifiedSuccess]
-        verifiedSuccess.location shouldBe verifiableLocation
+        verifiedSuccess.verifiableLocation shouldBe verifiableLocation
         verifiedSuccess.size shouldBe contentString.getBytes.size
       }
     }
@@ -219,7 +219,7 @@ trait VerifierTestCases[Namespace, Context]
         result shouldBe a[VerifiedSuccess]
 
         val verifiedSuccess = result.asInstanceOf[VerifiedSuccess]
-        verifiedSuccess.location shouldBe verifiableLocation
+        verifiedSuccess.verifiableLocation shouldBe verifiableLocation
         verifiedSuccess.size shouldBe contentString.getBytes.size
       }
     }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/s3/S3ObjectVerifierTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/verify/s3/S3ObjectVerifierTest.scala
@@ -59,7 +59,7 @@ class S3ObjectVerifierTest
 
     val verifiedFailure = result.asInstanceOf[VerifiedFailure]
 
-    verifiedFailure.location shouldBe verifiableLocation
+    verifiedFailure.verifiableLocation shouldBe verifiableLocation
     verifiedFailure.e shouldBe a[LocationNotFound[_]]
     verifiedFailure.e.getMessage should include(
       "Location not available!"
@@ -85,7 +85,7 @@ class S3ObjectVerifierTest
 
     val verifiedFailure = result.asInstanceOf[VerifiedFailure]
 
-    verifiedFailure.location shouldBe verifiableLocation
+    verifiedFailure.verifiableLocation shouldBe verifiableLocation
     verifiedFailure.e shouldBe a[LocationError[_]]
     verifiedFailure.e.getMessage should include(
       "The specified bucket is not valid")
@@ -111,7 +111,7 @@ class S3ObjectVerifierTest
 
       val verifiedFailure = result.asInstanceOf[VerifiedFailure]
 
-      verifiedFailure.location shouldBe verifiableLocation
+      verifiedFailure.verifiableLocation shouldBe verifiableLocation
       verifiedFailure.e shouldBe a[LocationNotFound[_]]
       verifiedFailure.e.getMessage should include(
         "Location not available!"


### PR DESCRIPTION
Closes https://github.com/wellcometrust/platform/issues/3688, and will probably shed light on https://github.com/wellcometrust/platform/issues/3743

If you verify a bag and there are files that the manifest doesn't expect, you get an error:

> Bag contains a file which is not referenced in the manifest: /unreferencedfile.txt
>
> Bag contains 3 files which are not referenced in the manifest: /unreferencedfile_1.txt, /unreferencedfile_2.txt, /unreferencedfile_3.txt

Internally, we log the complete object location.

(My theory for https://github.com/wellcometrust/platform/issues/3743 is that when you create a tar archive with macOS, it's creating some extra files with extended attribute data, and thus breaking the S3 console. Those files aren't referenced in the manifests, so the verifier will catch them now.) 