### PR TITLE
Send the version in the notifier callback

### DIFF
--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
@@ -32,6 +32,7 @@ class IngestsApiFeatureTest
     with StorageRandomThings {
 
   val contextUrl = "http://api.wellcomecollection.org/storage/v1/context.json"
+
   describe("GET /ingests/:id") {
     it("returns an ingest when available") {
       val ingest = createIngestWith(
@@ -42,76 +43,74 @@ class IngestsApiFeatureTest
 
       withConfiguredApp(initialIngests = Seq(ingest)) {
         case (_, _, metrics, baseUrl) =>
-          withMaterializer { implicit materializer =>
-            whenGetRequestReady(s"$baseUrl/ingests/${ingest.id}") { result =>
-              result.status shouldBe StatusCodes.OK
+          whenGetRequestReady(s"$baseUrl/ingests/${ingest.id}") { result =>
+            result.status shouldBe StatusCodes.OK
 
-              withStringEntity(result.entity) { jsonString =>
-                assertJsonStringsAreEqual(
-                  jsonString,
-                  s"""
-                     |{
-                     |  "@context": "http://api.wellcomecollection.org/storage/v1/context.json",
-                     |  "id": "${ingest.id.toString}",
-                     |  "type": "Ingest",
-                     |  "ingestType": {
-                     |    "id": "${ingest.ingestType.id}",
-                     |    "type": "IngestType"
-                     |  },
-                     |  "space": {
-                     |    "id": "${ingest.space.underlying}",
-                     |    "type": "Space"
-                     |  },
-                     |  "bag": {
-                     |    "type": "Bag",
-                     |    "info": {
-                     |      "type": "BagInfo",
-                     |      "externalIdentifier": "${ingest.externalIdentifier.underlying}"
-                     |    }
-                     |  },
-                     |  "status": {
-                     |    "id": "${ingest.status.toString}",
-                     |    "type": "Status"
-                     |  },
-                     |  "sourceLocation": {
-                     |    "type": "Location",
-                     |    "provider": {
-                     |      "type": "Provider",
-                     |      "id": "aws-s3-standard"
-                     |    },
-                     |    "bucket": "${ingest.sourceLocation.location.namespace}",
-                     |    "path": "${ingest.sourceLocation.location.path}"
-                     |  },
-                     |  "callback": {
-                     |    "type": "Callback",
-                     |    "url": "${ingest.callback.get.uri}",
-                     |    "status": {
-                     |      "id": "${ingest.callback.get.status.toString}",
-                     |      "type": "Status"
-                     |    }
-                     |  },
-                     |  "createdDate": "${ingest.createdDate}",
-                     |  "events": [
-                     |    {
-                     |      "type": "IngestEvent",
-                     |      "createdDate": "${ingest.events(0).createdDate}",
-                     |      "description": "${ingest.events(0).description}"
-                     |    },
-                     |    {
-                     |      "type": "IngestEvent",
-                     |      "createdDate": "${ingest.events(1).createdDate}",
-                     |      "description": "${ingest.events(1).description}"
-                     |    }
-                     |  ]
-                     |}
-                   """.stripMargin
-                )
-              }
-
-              assertMetricSent(metrics, result = HttpMetricResults.Success)
+            withStringEntity(result.entity) { jsonString =>
+              assertJsonStringsAreEqual(
+                jsonString,
+                s"""
+                   |{
+                   |  "@context": "http://api.wellcomecollection.org/storage/v1/context.json",
+                   |  "id": "${ingest.id.toString}",
+                   |  "type": "Ingest",
+                   |  "ingestType": {
+                   |    "id": "${ingest.ingestType.id}",
+                   |    "type": "IngestType"
+                   |  },
+                   |  "space": {
+                   |    "id": "${ingest.space.underlying}",
+                   |    "type": "Space"
+                   |  },
+                   |  "bag": {
+                   |    "type": "Bag",
+                   |    "info": {
+                   |      "type": "BagInfo",
+                   |      "externalIdentifier": "${ingest.externalIdentifier.underlying}"
+                   |    }
+                   |  },
+                   |  "status": {
+                   |    "id": "${ingest.status.toString}",
+                   |    "type": "Status"
+                   |  },
+                   |  "sourceLocation": {
+                   |    "type": "Location",
+                   |    "provider": {
+                   |      "type": "Provider",
+                   |      "id": "aws-s3-standard"
+                   |    },
+                   |    "bucket": "${ingest.sourceLocation.location.namespace}",
+                   |    "path": "${ingest.sourceLocation.location.path}"
+                   |  },
+                   |  "callback": {
+                   |    "type": "Callback",
+                   |    "url": "${ingest.callback.get.uri}",
+                   |    "status": {
+                   |      "id": "${ingest.callback.get.status.toString}",
+                   |      "type": "Status"
+                   |    }
+                   |  },
+                   |  "createdDate": "${ingest.createdDate}",
+                   |  "events": [
+                   |    {
+                   |      "type": "IngestEvent",
+                   |      "createdDate": "${ingest.events(0).createdDate}",
+                   |      "description": "${ingest.events(0).description}"
+                   |    },
+                   |    {
+                   |      "type": "IngestEvent",
+                   |      "createdDate": "${ingest.events(1).createdDate}",
+                   |      "description": "${ingest.events(1).description}"
+                   |    }
+                   |  ]
+                   |}
+                 """.stripMargin
+              )
             }
+
+            assertMetricSent(metrics, result = HttpMetricResults.Success)
           }
-      }
+        }
     }
 
     it("includes the version, if present") {
@@ -121,14 +120,12 @@ class IngestsApiFeatureTest
 
       withConfiguredApp(initialIngests = Seq(ingest)) {
         case (_, _, _, baseUrl) =>
-          withMaterializer { implicit materializer =>
-            whenGetRequestReady(s"$baseUrl/ingests/${ingest.id}") { result =>
-              result.status shouldBe StatusCodes.OK
+          whenGetRequestReady(s"$baseUrl/ingests/${ingest.id}") { result =>
+            result.status shouldBe StatusCodes.OK
 
-              withStringEntity(result.entity) { jsonString =>
-                val json = parse(jsonString).right.value
-                root.bag.info.version.string.getOption(json) shouldBe Some("v3")
-              }
+            withStringEntity(result.entity) { jsonString =>
+              val json = parse(jsonString).right.value
+              root.bag.info.version.string.getOption(json) shouldBe Some("v3")
             }
           }
       }
@@ -139,48 +136,40 @@ class IngestsApiFeatureTest
 
       withConfiguredApp(initialIngests = Seq(ingest)) {
         case (_, _, metrics, baseUrl) =>
-          withMaterializer { implicit materialiser =>
-            whenGetRequestReady(s"$baseUrl/ingests/${ingest.id}") { result =>
-              result.status shouldBe StatusCodes.OK
-              withStringEntity(result.entity) { jsonString =>
-                val infoJson = parse(jsonString).right.get
-                infoJson.findAllByKey("callback") shouldBe empty
-              }
-
-              assertMetricSent(metrics, result = HttpMetricResults.Success)
+          whenGetRequestReady(s"$baseUrl/ingests/${ingest.id}") { result =>
+            result.status shouldBe StatusCodes.OK
+            withStringEntity(result.entity) { jsonString =>
+              val infoJson = parse(jsonString).right.get
+              infoJson.findAllByKey("callback") shouldBe empty
             }
+
+            assertMetricSent(metrics, result = HttpMetricResults.Success)
           }
       }
     }
 
     it("returns a 404 NotFound if no ingest tracker matches id") {
-      withMaterializer { implicit materializer =>
-        withConfiguredApp() {
-          case (_, _, metrics, baseUrl) =>
-            val id = randomUUID
-            whenGetRequestReady(s"$baseUrl/ingests/$id") { response =>
-              assertIsUserErrorResponse(
-                response,
-                description = s"Ingest $id not found",
-                statusCode = StatusCodes.NotFound,
-                label = "Not Found"
-              )
+      withConfiguredApp() { case (_, _, metrics, baseUrl) =>
+        val id = randomUUID
+        whenGetRequestReady(s"$baseUrl/ingests/$id") { response =>
+          assertIsUserErrorResponse(
+            response,
+            description = s"Ingest $id not found",
+            statusCode = StatusCodes.NotFound,
+            label = "Not Found"
+          )
 
-              assertMetricSent(metrics, result = HttpMetricResults.UserError)
-            }
+          assertMetricSent(metrics, result = HttpMetricResults.UserError)
         }
       }
     }
 
     it("returns a 500 Server Error if reading from DynamoDB fails") {
-      withMaterializer { implicit materializer =>
-        withBrokenApp {
-          case (_, _, metrics, baseUrl) =>
-            whenGetRequestReady(s"$baseUrl/ingests/$randomUUID") { response =>
-              assertIsInternalServerErrorResponse(response)
+      withBrokenApp { case (_, _, metrics, baseUrl) =>
+        whenGetRequestReady(s"$baseUrl/ingests/$randomUUID") { response =>
+          assertIsInternalServerErrorResponse(response)
 
-              assertMetricSent(metrics, result = HttpMetricResults.ServerError)
-            }
+          assertMetricSent(metrics, result = HttpMetricResults.ServerError)
         }
       }
     }
@@ -190,86 +179,84 @@ class IngestsApiFeatureTest
     it("creates an ingest") {
       withConfiguredApp() {
         case (ingestTracker, messageSender, metrics, baseUrl) =>
-          withMaterializer { implicit mat =>
-            val url = s"$baseUrl/ingests"
+          val url = s"$baseUrl/ingests"
 
-            val bucketName = "bucket"
-            val s3key = "key.txt"
-            val spaceName = "somespace"
+          val bucketName = "bucket"
+          val s3key = "key.txt"
+          val spaceName = "somespace"
 
-            val externalIdentifier = createExternalIdentifier
+          val externalIdentifier = createExternalIdentifier
 
-            val entity = createRequestWith(
-              bucket = bucketName,
-              key = s3key,
-              space = spaceName,
-              externalIdentifier = externalIdentifier
-            )
+          val entity = createRequestWith(
+            bucket = bucketName,
+            key = s3key,
+            space = spaceName,
+            externalIdentifier = externalIdentifier
+          )
 
-            val expectedLocationR = s"$baseUrl/(.+)".r
+          val expectedLocationR = s"$baseUrl/(.+)".r
 
-            whenPostRequestReady(url, entity) { response: HttpResponse =>
-              response.status shouldBe StatusCodes.Created
+          whenPostRequestReady(url, entity) { response: HttpResponse =>
+            response.status shouldBe StatusCodes.Created
 
-              val maybeId = response.headers.collectFirst {
-                case HttpHeader("location", expectedLocationR(id)) => id
-              }
+            val maybeId = response.headers.collectFirst {
+              case HttpHeader("location", expectedLocationR(id)) => id
+            }
 
-              maybeId.isEmpty shouldBe false
-              val id = UUID.fromString(maybeId.get)
+            maybeId.isEmpty shouldBe false
+            val id = UUID.fromString(maybeId.get)
 
-              val ingestFuture =
+            val ingestFuture =
+              withMaterializer { implicit materializer =>
                 Unmarshal(response.entity).to[ResponseDisplayIngest]
-
-              whenReady(ingestFuture) { actualIngest =>
-                actualIngest.context shouldBe contextUrl
-                actualIngest.id shouldBe id
-                actualIngest.sourceLocation shouldBe DisplayLocation(
-                  provider = StandardDisplayProvider,
-                  bucket = bucketName,
-                  path = s3key
-                )
-
-                actualIngest.callback.isDefined shouldBe true
-                actualIngest.callback.get.url shouldBe testCallbackUri.toString
-                actualIngest.callback.get.status.get shouldBe DisplayStatus(
-                  "processing")
-
-                actualIngest.ingestType shouldBe CreateDisplayIngestType
-
-                actualIngest.status shouldBe DisplayStatus("accepted")
-
-                actualIngest.space shouldBe DisplayStorageSpace(
-                  spaceName,
-                  "Space")
-
-                actualIngest.bag.info.externalIdentifier shouldBe externalIdentifier.toString
-
-                val expectedIngest = Ingest(
-                  id = IngestID(id),
-                  ingestType = CreateIngestType,
-                  sourceLocation = StorageLocation(
-                    StandardStorageProvider,
-                    ObjectLocation(bucketName, s3key)
-                  ),
-                  space = StorageSpace(spaceName),
-                  callback = Some(Callback(testCallbackUri, Callback.Pending)),
-                  status = Ingest.Accepted,
-                  externalIdentifier = externalIdentifier,
-                  createdDate = Instant.parse(actualIngest.createdDate),
-                  lastModifiedDate = None,
-                  events = Nil
-                )
-
-                assertIngestCreated(expectedIngest)(ingestTracker)
-
-                val expectedPayload = SourceLocationPayload(expectedIngest)
-                messageSender
-                  .getMessages[SourceLocationPayload] shouldBe Seq(
-                  expectedPayload)
-
-                assertMetricSent(metrics, result = HttpMetricResults.Success)
               }
+
+            whenReady(ingestFuture) { actualIngest =>
+              actualIngest.context shouldBe contextUrl
+              actualIngest.id shouldBe id
+              actualIngest.sourceLocation shouldBe DisplayLocation(
+                provider = StandardDisplayProvider,
+                bucket = bucketName,
+                path = s3key
+              )
+
+              actualIngest.callback.isDefined shouldBe true
+              actualIngest.callback.get.url shouldBe testCallbackUri.toString
+              actualIngest.callback.get.status.get shouldBe DisplayStatus(
+                "processing")
+
+              actualIngest.ingestType shouldBe CreateDisplayIngestType
+
+              actualIngest.status shouldBe DisplayStatus("accepted")
+
+              actualIngest.space shouldBe DisplayStorageSpace(spaceName)
+
+              actualIngest.bag.info.externalIdentifier shouldBe externalIdentifier.toString
+
+              val expectedIngest = Ingest(
+                id = IngestID(id),
+                ingestType = CreateIngestType,
+                sourceLocation = StorageLocation(
+                  StandardStorageProvider,
+                  ObjectLocation(bucketName, s3key)
+                ),
+                space = StorageSpace(spaceName),
+                callback = Some(Callback(testCallbackUri, Callback.Pending)),
+                status = Ingest.Accepted,
+                externalIdentifier = externalIdentifier,
+                createdDate = Instant.parse(actualIngest.createdDate),
+                lastModifiedDate = None,
+                events = Nil
+              )
+
+              assertIngestCreated(expectedIngest)(ingestTracker)
+
+              val expectedPayload = SourceLocationPayload(expectedIngest)
+              messageSender
+                .getMessages[SourceLocationPayload] shouldBe Seq(
+                expectedPayload)
+
+              assertMetricSent(metrics, result = HttpMetricResults.Success)
             }
           }
       }
@@ -511,17 +498,14 @@ class IngestsApiFeatureTest
     }
 
     it("returns a 500 Server Error if updating the ingest starter fails") {
-      withMaterializer { implicit materializer =>
-        withBrokenApp {
-          case (_, _, metrics, baseUrl) =>
-            whenPostRequestReady(s"$baseUrl/ingests/$randomUUID", createRequest) {
-              response =>
-                assertIsInternalServerErrorResponse(response)
+      withBrokenApp { case (_, _, metrics, baseUrl) =>
+        whenPostRequestReady(s"$baseUrl/ingests/$randomUUID", createRequest) {
+          response =>
+            assertIsInternalServerErrorResponse(response)
 
-                assertMetricSent(
-                  metrics,
-                  result = HttpMetricResults.ServerError)
-            }
+            assertMetricSent(
+              metrics,
+              result = HttpMetricResults.ServerError)
         }
       }
     }

--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
@@ -14,7 +14,10 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.platform.archive.common.SourceLocationPayload
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagVersion,
+  ExternalIdentifier
+}
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
 import uk.ac.wellcome.platform.archive.common.http.HttpMetricResults
 import uk.ac.wellcome.platform.archive.common.ingests.models._
@@ -110,7 +113,7 @@ class IngestsApiFeatureTest
 
             assertMetricSent(metrics, result = HttpMetricResults.Success)
           }
-        }
+      }
     }
 
     it("includes the version, if present") {
@@ -149,28 +152,30 @@ class IngestsApiFeatureTest
     }
 
     it("returns a 404 NotFound if no ingest tracker matches id") {
-      withConfiguredApp() { case (_, _, metrics, baseUrl) =>
-        val id = randomUUID
-        whenGetRequestReady(s"$baseUrl/ingests/$id") { response =>
-          assertIsUserErrorResponse(
-            response,
-            description = s"Ingest $id not found",
-            statusCode = StatusCodes.NotFound,
-            label = "Not Found"
-          )
+      withConfiguredApp() {
+        case (_, _, metrics, baseUrl) =>
+          val id = randomUUID
+          whenGetRequestReady(s"$baseUrl/ingests/$id") { response =>
+            assertIsUserErrorResponse(
+              response,
+              description = s"Ingest $id not found",
+              statusCode = StatusCodes.NotFound,
+              label = "Not Found"
+            )
 
-          assertMetricSent(metrics, result = HttpMetricResults.UserError)
-        }
+            assertMetricSent(metrics, result = HttpMetricResults.UserError)
+          }
       }
     }
 
     it("returns a 500 Server Error if reading from DynamoDB fails") {
-      withBrokenApp { case (_, _, metrics, baseUrl) =>
-        whenGetRequestReady(s"$baseUrl/ingests/$randomUUID") { response =>
-          assertIsInternalServerErrorResponse(response)
+      withBrokenApp {
+        case (_, _, metrics, baseUrl) =>
+          whenGetRequestReady(s"$baseUrl/ingests/$randomUUID") { response =>
+            assertIsInternalServerErrorResponse(response)
 
-          assertMetricSent(metrics, result = HttpMetricResults.ServerError)
-        }
+            assertMetricSent(metrics, result = HttpMetricResults.ServerError)
+          }
       }
     }
   }
@@ -498,15 +503,14 @@ class IngestsApiFeatureTest
     }
 
     it("returns a 500 Server Error if updating the ingest starter fails") {
-      withBrokenApp { case (_, _, metrics, baseUrl) =>
-        whenPostRequestReady(s"$baseUrl/ingests/$randomUUID", createRequest) {
-          response =>
-            assertIsInternalServerErrorResponse(response)
+      withBrokenApp {
+        case (_, _, metrics, baseUrl) =>
+          whenPostRequestReady(s"$baseUrl/ingests/$randomUUID", createRequest) {
+            response =>
+              assertIsInternalServerErrorResponse(response)
 
-            assertMetricSent(
-              metrics,
-              result = HttpMetricResults.ServerError)
-        }
+              assertMetricSent(metrics, result = HttpMetricResults.ServerError)
+          }
       }
     }
   }

--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
@@ -41,6 +41,7 @@ class IngestsApiFeatureTest
       val ingest = createIngestWith(
         version = None,
         createdDate = Instant.now(),
+        lastModifiedDate = Some(Instant.now()),
         events = Seq(createIngestEvent, createIngestEvent)
       )
 
@@ -94,6 +95,7 @@ class IngestsApiFeatureTest
                    |    }
                    |  },
                    |  "createdDate": "${ingest.createdDate}",
+                   |  "lastModifiedDate": "${ingest.lastModifiedDate.get}",
                    |  "events": [
                    |    {
                    |      "type": "IngestEvent",

--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
@@ -5,12 +5,26 @@ import com.amazonaws.services.sqs.AmazonSQSAsync
 import io.circe.Decoder
 import uk.ac.wellcome.messaging.sqsworker.alpakka.AlpakkaSQSWorkerConfig
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
-import uk.ac.wellcome.platform.archive.common.ingests.models.{IngestEvent, IngestID, IngestVersionUpdate}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  IngestEvent,
+  IngestID,
+  IngestVersionUpdate
+}
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services._
-import uk.ac.wellcome.platform.archive.common.storage.models.{IngestStepResult, IngestStepSucceeded, IngestStepWorker}
-import uk.ac.wellcome.platform.archive.common.{BagRootLocationPayload, EnrichedBagInformationPayload}
-import uk.ac.wellcome.platform.storage.bagauditor.models.{AuditSuccessSummary, AuditSummary}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  IngestStepResult,
+  IngestStepSucceeded,
+  IngestStepWorker
+}
+import uk.ac.wellcome.platform.archive.common.{
+  BagRootLocationPayload,
+  EnrichedBagInformationPayload
+}
+import uk.ac.wellcome.platform.storage.bagauditor.models.{
+  AuditSuccessSummary,
+  AuditSummary
+}
 
 import scala.util.{Success, Try}
 
@@ -42,7 +56,9 @@ class BagAuditorWorker[IngestDestination, OutgoingDestination](
       _ <- sendSuccessful(payload)(stepResult)
     } yield stepResult
 
-  private def sendIngestUpdate(ingestId: IngestID, stepResult: IngestStepResult[AuditSummary]): Try[Unit] =
+  private def sendIngestUpdate(
+    ingestId: IngestID,
+    stepResult: IngestStepResult[AuditSummary]): Try[Unit] =
     stepResult match {
       case IngestStepSucceeded(summary: AuditSuccessSummary, _) =>
         val update = IngestVersionUpdate(

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
@@ -8,10 +8,17 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion._
-import uk.ac.wellcome.platform.archive.common.generators.{ExternalIdentifierGenerators, PayloadGenerators, StorageSpaceGenerators}
+import uk.ac.wellcome.platform.archive.common.generators.{
+  ExternalIdentifierGenerators,
+  PayloadGenerators,
+  StorageSpaceGenerators
+}
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
 import uk.ac.wellcome.platform.archive.common.ingests.models._
-import uk.ac.wellcome.platform.archive.common.{BagRootLocationPayload, EnrichedBagInformationPayload}
+import uk.ac.wellcome.platform.archive.common.{
+  BagRootLocationPayload,
+  EnrichedBagInformationPayload
+}
 import uk.ac.wellcome.platform.storage.bagauditor.fixtures.BagAuditorFixtures
 import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
 
@@ -56,15 +63,20 @@ class BagAuditorFeatureTest
               .getMessages[EnrichedBagInformationPayload] shouldBe Seq(
               expectedPayload)
 
-            assertTopicReceivesIngestUpdates(payload.ingestId, ingests) { ingestUpdates =>
-              ingestUpdates should have size 2
+            assertTopicReceivesIngestUpdates(payload.ingestId, ingests) {
+              ingestUpdates =>
+                ingestUpdates should have size 2
 
-              ingestUpdates(0) shouldBe a[IngestEventUpdate]
-              ingestUpdates(0).events.map { _.description } shouldBe Seq("Auditing bag started")
+                ingestUpdates(0) shouldBe a[IngestEventUpdate]
+                ingestUpdates(0).events.map { _.description } shouldBe Seq(
+                  "Auditing bag started")
 
-              ingestUpdates(1) shouldBe a[IngestVersionUpdate]
-              ingestUpdates(1).asInstanceOf[IngestVersionUpdate].version shouldBe BagVersion(1)
-              ingestUpdates(1).events.map { _.description } shouldBe Seq("Auditing bag succeeded - assigned bag version v1")
+                ingestUpdates(1) shouldBe a[IngestVersionUpdate]
+                ingestUpdates(1)
+                  .asInstanceOf[IngestVersionUpdate]
+                  .version shouldBe BagVersion(1)
+                ingestUpdates(1).events.map { _.description } shouldBe Seq(
+                  "Auditing bag succeeded - assigned bag version v1")
             }
           }
       }
@@ -108,15 +120,20 @@ class BagAuditorFeatureTest
             outgoing
               .getMessages[EnrichedBagInformationPayload] should have size 1
 
-            assertTopicReceivesIngestUpdates(payload1.ingestId, ingests) { ingestUpdates =>
-              ingestUpdates should have size 2
+            assertTopicReceivesIngestUpdates(payload1.ingestId, ingests) {
+              ingestUpdates =>
+                ingestUpdates should have size 2
 
-              ingestUpdates(0) shouldBe a[IngestEventUpdate]
-              ingestUpdates(0).events.map { _.description } shouldBe Seq("Auditing bag started")
+                ingestUpdates(0) shouldBe a[IngestEventUpdate]
+                ingestUpdates(0).events.map { _.description } shouldBe Seq(
+                  "Auditing bag started")
 
-              ingestUpdates(1) shouldBe a[IngestVersionUpdate]
-              ingestUpdates(1).asInstanceOf[IngestVersionUpdate].version shouldBe BagVersion(1)
-              ingestUpdates(1).events.map { _.description } shouldBe Seq("Auditing bag succeeded - assigned bag version v1")
+                ingestUpdates(1) shouldBe a[IngestVersionUpdate]
+                ingestUpdates(1)
+                  .asInstanceOf[IngestVersionUpdate]
+                  .version shouldBe BagVersion(1)
+                ingestUpdates(1).events.map { _.description } shouldBe Seq(
+                  "Auditing bag succeeded - assigned bag version v1")
             }
           }
 
@@ -129,22 +146,31 @@ class BagAuditorFeatureTest
             outgoing
               .getMessages[EnrichedBagInformationPayload] should have size 2
 
-            assertTopicReceivesIngestUpdates(payload1.ingestId, ingests) { ingestUpdates =>
-              ingestUpdates should have size 4
+            assertTopicReceivesIngestUpdates(payload1.ingestId, ingests) {
+              ingestUpdates =>
+                ingestUpdates should have size 4
 
-              ingestUpdates(0) shouldBe a[IngestEventUpdate]
-              ingestUpdates(0).events.map { _.description } shouldBe Seq("Auditing bag started")
+                ingestUpdates(0) shouldBe a[IngestEventUpdate]
+                ingestUpdates(0).events.map { _.description } shouldBe Seq(
+                  "Auditing bag started")
 
-              ingestUpdates(1) shouldBe a[IngestVersionUpdate]
-              ingestUpdates(1).asInstanceOf[IngestVersionUpdate].version shouldBe BagVersion(1)
-              ingestUpdates(1).events.map { _.description } shouldBe Seq("Auditing bag succeeded - assigned bag version v1")
+                ingestUpdates(1) shouldBe a[IngestVersionUpdate]
+                ingestUpdates(1)
+                  .asInstanceOf[IngestVersionUpdate]
+                  .version shouldBe BagVersion(1)
+                ingestUpdates(1).events.map { _.description } shouldBe Seq(
+                  "Auditing bag succeeded - assigned bag version v1")
 
-              ingestUpdates(2) shouldBe a[IngestEventUpdate]
-              ingestUpdates(2).events.map { _.description } shouldBe Seq("Auditing bag started")
+                ingestUpdates(2) shouldBe a[IngestEventUpdate]
+                ingestUpdates(2).events.map { _.description } shouldBe Seq(
+                  "Auditing bag started")
 
-              ingestUpdates(3) shouldBe a[IngestVersionUpdate]
-              ingestUpdates(3).asInstanceOf[IngestVersionUpdate].version shouldBe BagVersion(2)
-              ingestUpdates(3).events.map { _.description } shouldBe Seq("Auditing bag succeeded - assigned bag version v2")
+                ingestUpdates(3) shouldBe a[IngestVersionUpdate]
+                ingestUpdates(3)
+                  .asInstanceOf[IngestVersionUpdate]
+                  .version shouldBe BagVersion(2)
+                ingestUpdates(3).events.map { _.description } shouldBe Seq(
+                  "Auditing bag succeeded - assigned bag version v2")
             }
           }
       }

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
@@ -6,20 +6,12 @@ import org.scalatest.FunSpec
 import org.scalatest.concurrent.Eventually
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
-import uk.ac.wellcome.platform.archive.common.generators.{
-  ExternalIdentifierGenerators,
-  PayloadGenerators,
-  StorageSpaceGenerators
-}
+import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion
+import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion._
+import uk.ac.wellcome.platform.archive.common.generators.{ExternalIdentifierGenerators, PayloadGenerators, StorageSpaceGenerators}
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  CreateIngestType,
-  UpdateIngestType
-}
-import uk.ac.wellcome.platform.archive.common.{
-  BagRootLocationPayload,
-  EnrichedBagInformationPayload
-}
+import uk.ac.wellcome.platform.archive.common.ingests.models._
+import uk.ac.wellcome.platform.archive.common.{BagRootLocationPayload, EnrichedBagInformationPayload}
 import uk.ac.wellcome.platform.storage.bagauditor.fixtures.BagAuditorFixtures
 import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
 
@@ -64,14 +56,16 @@ class BagAuditorFeatureTest
               .getMessages[EnrichedBagInformationPayload] shouldBe Seq(
               expectedPayload)
 
-            assertTopicReceivesIngestEvents(
-              payload.ingestId,
-              ingests,
-              expectedDescriptions = Seq(
-                "Auditing bag started",
-                "Auditing bag succeeded - Assigned bag version v1"
-              )
-            )
+            assertTopicReceivesIngestUpdates(payload.ingestId, ingests) { ingestUpdates =>
+              ingestUpdates should have size 2
+
+              ingestUpdates(0) shouldBe a[IngestEventUpdate]
+              ingestUpdates(0).events.map { _.description } shouldBe Seq("Auditing bag started")
+
+              ingestUpdates(1) shouldBe a[IngestVersionUpdate]
+              ingestUpdates(1).asInstanceOf[IngestVersionUpdate].version shouldBe BagVersion(1)
+              ingestUpdates(1).events.map { _.description } shouldBe Seq("Auditing bag succeeded - assigned bag version v1")
+            }
           }
       }
     }
@@ -114,14 +108,16 @@ class BagAuditorFeatureTest
             outgoing
               .getMessages[EnrichedBagInformationPayload] should have size 1
 
-            assertTopicReceivesIngestEvents(
-              payload1.ingestId,
-              ingests,
-              expectedDescriptions = Seq(
-                "Auditing bag started",
-                "Auditing bag succeeded - Assigned bag version v1"
-              )
-            )
+            assertTopicReceivesIngestUpdates(payload1.ingestId, ingests) { ingestUpdates =>
+              ingestUpdates should have size 2
+
+              ingestUpdates(0) shouldBe a[IngestEventUpdate]
+              ingestUpdates(0).events.map { _.description } shouldBe Seq("Auditing bag started")
+
+              ingestUpdates(1) shouldBe a[IngestVersionUpdate]
+              ingestUpdates(1).asInstanceOf[IngestVersionUpdate].version shouldBe BagVersion(1)
+              ingestUpdates(1).events.map { _.description } shouldBe Seq("Auditing bag succeeded - assigned bag version v1")
+            }
           }
 
           // Now send the payload with "update"
@@ -133,21 +129,25 @@ class BagAuditorFeatureTest
             outgoing
               .getMessages[EnrichedBagInformationPayload] should have size 2
 
-            assertTopicReceivesIngestEvents(
-              payload1.ingestId,
-              ingests,
-              expectedDescriptions = Seq(
-                "Auditing bag started",
-                "Auditing bag succeeded - Assigned bag version v1",
-                "Auditing bag started",
-                "Auditing bag succeeded - Assigned bag version v2"
-              )
-            )
+            assertTopicReceivesIngestUpdates(payload1.ingestId, ingests) { ingestUpdates =>
+              ingestUpdates should have size 4
+
+              ingestUpdates(0) shouldBe a[IngestEventUpdate]
+              ingestUpdates(0).events.map { _.description } shouldBe Seq("Auditing bag started")
+
+              ingestUpdates(1) shouldBe a[IngestVersionUpdate]
+              ingestUpdates(1).asInstanceOf[IngestVersionUpdate].version shouldBe BagVersion(1)
+              ingestUpdates(1).events.map { _.description } shouldBe Seq("Auditing bag succeeded - assigned bag version v1")
+
+              ingestUpdates(2) shouldBe a[IngestEventUpdate]
+              ingestUpdates(2).events.map { _.description } shouldBe Seq("Auditing bag started")
+
+              ingestUpdates(3) shouldBe a[IngestVersionUpdate]
+              ingestUpdates(3).asInstanceOf[IngestVersionUpdate].version shouldBe BagVersion(2)
+              ingestUpdates(3).events.map { _.description } shouldBe Seq("Auditing bag succeeded - assigned bag version v2")
+            }
           }
       }
     }
   }
-
-  // TODO: When we pass an ingest type in the bag auditor payload, check it sends
-  // an appropriate user-facing message in the ingests app.
 }

--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,7 @@ lazy val notifier = setupProject(
   project,
   "notifier",
   localDependencies = Seq(common, display),
-  externalDependencies = ExternalDependencies.wiremockDependencies)
+  externalDependencies = ExternalDependencies.wiremockDependencies ++ ExternalDependencies.circeOpticsDependencies)
 
 lazy val ingests_api = setupProject(
   project,

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/Ingest.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/Ingest.scala
@@ -2,7 +2,10 @@ package uk.ac.wellcome.platform.archive.common.ingests.models
 
 import java.time.Instant
 
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagVersion,
+  ExternalIdentifier
+}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 
 case class Ingest(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/Ingest.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/Ingest.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.archive.common.ingests.models
 
 import java.time.Instant
 
-import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
+import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 
 case class Ingest(
@@ -13,9 +13,10 @@ case class Ingest(
   callback: Option[Callback],
   status: Ingest.Status,
   externalIdentifier: ExternalIdentifier,
+  version: Option[BagVersion] = None,
   createdDate: Instant,
   lastModifiedDate: Option[Instant] = None,
-  events: Seq[IngestEvent] = Seq.empty
+  events: Seq[IngestEvent] = Seq.empty,
 )
 
 case object Ingest {

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/IngestUpdate.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/IngestUpdate.scala
@@ -1,24 +1,8 @@
 package uk.ac.wellcome.platform.archive.common.ingests.models
 
-import uk.ac.wellcome.platform.archive.common.bagit.models.error.ArchiveError
-
 sealed trait IngestUpdate {
   val id: IngestID
   val events: Seq[IngestEvent]
-}
-
-object IngestUpdate {
-
-  def failed[T](id: IngestID, error: ArchiveError[T]) =
-    IngestStatusUpdate(
-      id = id,
-      status = Ingest.Failed,
-      events = List(IngestEvent(error.toString))
-    )
-
-  def event(id: IngestID, description: String) =
-    IngestEventUpdate(id, Seq(IngestEvent(description)))
-
 }
 
 case class IngestEventUpdate(id: IngestID, events: Seq[IngestEvent])

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/IngestUpdate.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/IngestUpdate.scala
@@ -1,5 +1,7 @@
 package uk.ac.wellcome.platform.archive.common.ingests.models
 
+import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion
+
 sealed trait IngestUpdate {
   val id: IngestID
   val events: Seq[IngestEvent]
@@ -8,9 +10,15 @@ sealed trait IngestUpdate {
 case class IngestEventUpdate(id: IngestID, events: Seq[IngestEvent])
     extends IngestUpdate
 
+case class IngestVersionUpdate(
+  id: IngestID,
+  events: Seq[IngestEvent],
+  version: BagVersion
+) extends IngestUpdate
+
 case class IngestStatusUpdate(id: IngestID,
                               status: Ingest.Status,
-                              events: Seq[IngestEvent] = List.empty)
+                              events: Seq[IngestEvent] = Seq.empty)
     extends IngestUpdate
 
 case class IngestCallbackStatusUpdate(
@@ -26,6 +34,6 @@ case object IngestCallbackStatusUpdate {
     IngestCallbackStatusUpdate(
       id = id,
       callbackStatus = callbackStatus,
-      events = List(IngestEvent(description))
+      events = Seq(IngestEvent(description))
     )
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdater.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdater.scala
@@ -36,26 +36,36 @@ class IngestUpdater[Destination](stepName: String,
         )
 
       case IngestStepSucceeded(_, maybeMessage) =>
-        IngestUpdate.event(
+        IngestEventUpdate(
           id = ingestId,
-          description = eventDescription(
-            s"${stepName.capitalize} succeeded",
-            maybeMessage
+          events = Seq(
+            IngestEvent(
+              eventDescription(
+                s"${stepName.capitalize} succeeded",
+                maybeMessage
+              )
+            )
           )
         )
 
       case IngestStepStarted(_) =>
-        IngestUpdate.event(
+        IngestEventUpdate(
           id = ingestId,
-          description = s"${stepName.capitalize} started"
+          events = Seq(
+            IngestEvent(s"${stepName.capitalize} started")
+          )
         )
 
       case IngestShouldRetry(_, _, maybeMessage) =>
-        IngestUpdate.event(
+        IngestEventUpdate(
           id = ingestId,
-          description = eventDescription(
-            s"${stepName.capitalize} retrying",
-            maybeMessage
+          events = Seq(
+            IngestEvent(
+              eventDescription(
+                s"${stepName.capitalize} retrying",
+                maybeMessage
+              )
+            )
           )
         )
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdater.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdater.scala
@@ -8,7 +8,7 @@ import uk.ac.wellcome.platform.archive.common.storage.models._
 
 import scala.util.Try
 
-class IngestUpdater[Destination](stepName: String,
+class IngestUpdater[Destination](val stepName: String,
                                  messageSender: MessageSender[Destination])
     extends Logging {
 
@@ -81,8 +81,11 @@ class IngestUpdater[Destination](stepName: String,
         )
     }
 
-    messageSender.sendT[IngestUpdate](update)
+    sendUpdate(update)
   }
+
+  def sendUpdate(update: IngestUpdate): Try[Unit] =
+    messageSender.sendT[IngestUpdate](update)
 
   def sendEvent(ingestId: IngestID, messages: Seq[String]): Try[Unit] = {
     debug(s"Sending an ingest event for ID=$ingestId messages=$messages")

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
@@ -3,11 +3,13 @@ package uk.ac.wellcome.platform.archive.common.generators
 import java.net.URI
 import java.time.Instant
 
-import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
+import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest.Status
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.ObjectLocation
+
+import scala.util.Random
 
 trait IngestGenerators extends BagIdGenerators {
 
@@ -22,6 +24,13 @@ trait IngestGenerators extends BagIdGenerators {
   val testCallbackUri =
     new URI("http://www.wellcomecollection.org/callback/ok")
 
+  private def maybeVersion: Option[BagVersion] =
+    if (Random.nextBoolean()) {
+      Some(BagVersion(Random.nextInt))
+    } else {
+      None
+    }
+
   def createIngestWith(id: IngestID = createIngestID,
                        ingestType: IngestType = CreateIngestType,
                        sourceLocation: StorageLocation = storageLocation,
@@ -30,6 +39,7 @@ trait IngestGenerators extends BagIdGenerators {
                        status: Status = Ingest.Accepted,
                        externalIdentifier: ExternalIdentifier =
                          createExternalIdentifier,
+                       version: Option[BagVersion] = maybeVersion,
                        createdDate: Instant = randomInstant,
                        events: Seq[IngestEvent] = Seq.empty): Ingest =
     Ingest(
@@ -40,6 +50,7 @@ trait IngestGenerators extends BagIdGenerators {
       space = space,
       status = status,
       externalIdentifier = externalIdentifier,
+      version = version,
       createdDate = createdDate,
       events = events
     )
@@ -66,6 +77,17 @@ trait IngestGenerators extends BagIdGenerators {
       id = id,
       status = status,
       events = events
+    )
+
+  def createIngestVersionUpdateWith(
+    id: IngestID = createIngestID,
+    events: Seq[IngestEvent] = Seq(createIngestEvent),
+    version: BagVersion = BagVersion(Random.nextInt)
+  ): IngestVersionUpdate =
+    IngestVersionUpdate(
+      id = id,
+      events = events,
+      version = version
     )
 
   def createIngestCallbackStatusUpdateWith(

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
@@ -34,6 +34,13 @@ trait IngestGenerators extends BagIdGenerators {
       None
     }
 
+  private def maybeModifiedDate: Option[Instant] =
+    if (Random.nextBoolean()) {
+      Some(randomInstant)
+    } else {
+      None
+    }
+
   def createIngestWith(id: IngestID = createIngestID,
                        ingestType: IngestType = CreateIngestType,
                        sourceLocation: StorageLocation = storageLocation,
@@ -44,6 +51,7 @@ trait IngestGenerators extends BagIdGenerators {
                          createExternalIdentifier,
                        version: Option[BagVersion] = maybeVersion,
                        createdDate: Instant = randomInstant,
+                       lastModifiedDate: Option[Instant] = maybeModifiedDate,
                        events: Seq[IngestEvent] = Seq.empty): Ingest =
     Ingest(
       id = id,
@@ -55,6 +63,7 @@ trait IngestGenerators extends BagIdGenerators {
       externalIdentifier = externalIdentifier,
       version = version,
       createdDate = createdDate,
+      lastModifiedDate = lastModifiedDate,
       events = events
     )
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
@@ -3,7 +3,10 @@ package uk.ac.wellcome.platform.archive.common.generators
 import java.net.URI
 import java.time.Instant
 
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagVersion,
+  ExternalIdentifier
+}
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest.Status
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
@@ -71,7 +71,7 @@ trait IngestGenerators extends BagIdGenerators {
     IngestEvent(randomAlphanumeric)
 
   def createIngestEventUpdateWith(id: IngestID,
-                                  events: List[IngestEvent] = List(
+                                  events: Seq[IngestEvent] = Seq(
                                     createIngestEvent)): IngestEventUpdate =
     IngestEventUpdate(
       id = id,

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/fixtures/IngestUpdateAssertions.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/fixtures/IngestUpdateAssertions.scala
@@ -4,6 +4,7 @@ import grizzled.slf4j.Logging
 import org.scalatest.{Assertion, Inside, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
+import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion._
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 
 import scala.util.Try
@@ -64,7 +65,7 @@ trait IngestUpdateAssertions extends Inside with Logging with Matchers {
 
       val (success, _) = ingestUpdates
         .map { ingestUpdate =>
-          println(s"Received IngestUpdate: $ingestUpdate")
+          debug(s"Received IngestUpdate: $ingestUpdate")
           Try(inside(ingestUpdate) {
             case IngestEventUpdate(id, events) =>
               id shouldBe ingestId

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/fixtures/TimeTestFixture.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/fixtures/TimeTestFixture.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.ingest.fixtures
+package uk.ac.wellcome.platform.archive.common.ingests.fixtures
 
 import java.time.{Duration, Instant}
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestStatesTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestStatesTest.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 
 sealed trait IngestUpdateTestCases[UpdateType <: IngestUpdate]
-  extends FunSpec
+    extends FunSpec
     with Matchers
     with IngestGenerators
     with TryValues {
@@ -29,7 +29,7 @@ sealed trait IngestUpdateTestCases[UpdateType <: IngestUpdate]
       updatedIngest.events shouldBe Seq(event)
     }
 
-      it("adds multiple events") {
+    it("adds multiple events") {
       val ingest = createIngestWith(events = List.empty)
 
       val events =
@@ -43,7 +43,7 @@ sealed trait IngestUpdateTestCases[UpdateType <: IngestUpdate]
       updatedIngest.events shouldBe events
     }
 
-      it("preserves the existing events") {
+    it("preserves the existing events") {
       val existingEvents = List(createIngestEvent, createIngestEvent)
       val ingest = createIngestWith(events = existingEvents)
 
@@ -60,9 +60,10 @@ sealed trait IngestUpdateTestCases[UpdateType <: IngestUpdate]
 }
 
 class IngestEventUpdateTest
-  extends IngestUpdateTestCases[IngestEventUpdate]
+    extends IngestUpdateTestCases[IngestEventUpdate]
     with TableDrivenPropertyChecks {
-  override def createUpdateWith(id: IngestID, events: Seq[IngestEvent]): IngestEventUpdate =
+  override def createUpdateWith(id: IngestID,
+                                events: Seq[IngestEvent]): IngestEventUpdate =
     createIngestEventUpdateWith(id = id, events = events)
 
   val eventStatusUpdates = Table(
@@ -88,9 +89,10 @@ class IngestEventUpdateTest
 }
 
 class IngestStatusUpdateTest
-  extends IngestUpdateTestCases[IngestStatusUpdate]
+    extends IngestUpdateTestCases[IngestStatusUpdate]
     with TableDrivenPropertyChecks {
-  override def createUpdateWith(id: IngestID, events: Seq[IngestEvent]): IngestStatusUpdate =
+  override def createUpdateWith(id: IngestID,
+                                events: Seq[IngestEvent]): IngestStatusUpdate =
     createIngestStatusUpdateWith(id = id, events = events)
 
   describe("updating the status") {
@@ -153,9 +155,11 @@ class IngestStatusUpdateTest
 }
 
 class IngestCallbackStatusUpdateTest
-  extends IngestUpdateTestCases[IngestCallbackStatusUpdate]
+    extends IngestUpdateTestCases[IngestCallbackStatusUpdate]
     with TableDrivenPropertyChecks {
-  override def createUpdateWith(id: IngestID, events: Seq[IngestEvent]): IngestCallbackStatusUpdate =
+  override def createUpdateWith(
+    id: IngestID,
+    events: Seq[IngestEvent]): IngestCallbackStatusUpdate =
     createIngestCallbackStatusUpdateWith(id = id, events = events)
 
   describe("updating the callback status") {
@@ -171,8 +175,8 @@ class IngestCallbackStatusUpdateTest
     it("updates the status of a callback") {
       forAll(allowedCallbackStatusUpdates) {
         case (
-          initialStatus: Callback.CallbackStatus,
-          updatedStatus: Callback.CallbackStatus) =>
+            initialStatus: Callback.CallbackStatus,
+            updatedStatus: Callback.CallbackStatus) =>
           val ingest = createIngestWith(
             callback = Some(
               Callback(
@@ -203,8 +207,8 @@ class IngestCallbackStatusUpdateTest
     it("does not allow the callback status to go backwards") {
       forAll(disallowedCallbackStatusUpdates) {
         case (
-          initialStatus: Callback.CallbackStatus,
-          updatedStatus: Callback.CallbackStatus) =>
+            initialStatus: Callback.CallbackStatus,
+            updatedStatus: Callback.CallbackStatus) =>
           val ingest = createIngestWith(
             callback = Some(
               Callback(
@@ -240,8 +244,9 @@ class IngestCallbackStatusUpdateTest
 }
 
 class IngestVersionUpdateTest
-  extends IngestUpdateTestCases[IngestVersionUpdate] {
-  override def createUpdateWith(id: IngestID, events: Seq[IngestEvent]): IngestVersionUpdate =
+    extends IngestUpdateTestCases[IngestVersionUpdate] {
+  override def createUpdateWith(id: IngestID,
+                                events: Seq[IngestEvent]): IngestVersionUpdate =
     createIngestVersionUpdateWith(id = id, events = events)
 
   describe("updating the version") {

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestStatesTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestStatesTest.scala
@@ -6,21 +6,21 @@ import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{FunSpec, Matchers, TryValues}
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
-import uk.ac.wellcome.platform.archive.common.ingests.models.{Callback, Ingest}
+import uk.ac.wellcome.platform.archive.common.ingests.models._
 
-class IngestStatesTest
-    extends FunSpec
+sealed trait IngestUpdateTestCases[UpdateType <: IngestUpdate]
+  extends FunSpec
     with Matchers
     with IngestGenerators
-    with TryValues
-    with TableDrivenPropertyChecks {
+    with TryValues {
+  def createUpdateWith(id: IngestID, events: Seq[IngestEvent]): UpdateType
 
-  describe("handling an IngestEventUpdate") {
-    it("adds an event to an ingest") {
+  describe("updating the events") {
+    it("adds an event") {
       val ingest = createIngestWith(events = List.empty)
 
       val event = createIngestEvent
-      val update = createIngestEventUpdateWith(
+      val update = createUpdateWith(
         id = ingest.id,
         events = List(event)
       )
@@ -29,12 +29,12 @@ class IngestStatesTest
       updatedIngest.events shouldBe Seq(event)
     }
 
-    it("adds multiple events to an ingest") {
+      it("adds multiple events") {
       val ingest = createIngestWith(events = List.empty)
 
       val events =
         List(createIngestEvent, createIngestEvent, createIngestEvent)
-      val update = createIngestEventUpdateWith(
+      val update = createUpdateWith(
         id = ingest.id,
         events = events
       )
@@ -43,12 +43,12 @@ class IngestStatesTest
       updatedIngest.events shouldBe events
     }
 
-    it("preserves the existing events on an ingest") {
+      it("preserves the existing events") {
       val existingEvents = List(createIngestEvent, createIngestEvent)
       val ingest = createIngestWith(events = existingEvents)
 
       val newEvents = List(createIngestEvent, createIngestEvent)
-      val update = createIngestEventUpdateWith(
+      val update = createUpdateWith(
         id = ingest.id,
         events = newEvents
       )
@@ -56,360 +56,234 @@ class IngestStatesTest
       val updatedIngest = IngestStates.applyUpdate(ingest, update).success.value
       updatedIngest.events shouldBe existingEvents ++ newEvents
     }
+  }
+}
 
-    val eventStatusUpdates = Table(
-      ("initial", "expected"),
+class IngestEventUpdateTest
+  extends IngestUpdateTestCases[IngestEventUpdate]
+    with TableDrivenPropertyChecks {
+  override def createUpdateWith(id: IngestID, events: Seq[IngestEvent]): IngestEventUpdate =
+    createIngestEventUpdateWith(id = id, events = events)
+
+  val eventStatusUpdates = Table(
+    ("initial", "expected"),
+    (Ingest.Accepted, Ingest.Processing),
+    (Ingest.Processing, Ingest.Processing),
+    (Ingest.Completed, Ingest.Completed),
+    (Ingest.Failed, Ingest.Failed),
+  )
+
+  it("updates the status to Processing when it sees the first event update") {
+    forAll(eventStatusUpdates) {
+      case (initialStatus: Ingest.Status, expectedStatus: Ingest.Status) =>
+        val ingest = createIngestWith(status = initialStatus)
+
+        val update = createIngestEventUpdate
+
+        val updatedIngest =
+          IngestStates.applyUpdate(ingest, update).success.value
+        updatedIngest.status shouldBe expectedStatus
+    }
+  }
+}
+
+class IngestStatusUpdateTest
+  extends IngestUpdateTestCases[IngestStatusUpdate]
+    with TableDrivenPropertyChecks {
+  override def createUpdateWith(id: IngestID, events: Seq[IngestEvent]): IngestStatusUpdate =
+    createIngestStatusUpdateWith(id = id, events = events)
+
+  describe("updating the status") {
+    val allowedStatusUpdates = Table(
+      ("initial", "update"),
+      (Ingest.Accepted, Ingest.Accepted),
       (Ingest.Accepted, Ingest.Processing),
-      (Ingest.Processing, Ingest.Processing),
+      (Ingest.Accepted, Ingest.Completed),
+      (Ingest.Accepted, Ingest.Failed),
+      (Ingest.Processing, Ingest.Completed),
+      (Ingest.Processing, Ingest.Failed),
       (Ingest.Completed, Ingest.Completed),
       (Ingest.Failed, Ingest.Failed),
     )
 
-    it("updates the status to Processing when it sees the first event update") {
-      forAll(eventStatusUpdates) {
-        case (initialStatus: Ingest.Status, expectedStatus: Ingest.Status) =>
+    it("updates the status of an ingest") {
+      forAll(allowedStatusUpdates) {
+        case (initialStatus: Ingest.Status, updatedStatus: Ingest.Status) =>
           val ingest = createIngestWith(status = initialStatus)
 
-          val update = createIngestEventUpdate
+          val update = createIngestStatusUpdateWith(
+            id = ingest.id,
+            status = updatedStatus
+          )
 
           val updatedIngest =
             IngestStates.applyUpdate(ingest, update).success.value
-          updatedIngest.status shouldBe expectedStatus
+          updatedIngest.status shouldBe updatedStatus
+      }
+    }
+
+    val disallowedStatusUpdates = Table(
+      ("initial", "update"),
+      (Ingest.Failed, Ingest.Completed),
+      (Ingest.Failed, Ingest.Processing),
+      (Ingest.Failed, Ingest.Accepted),
+      (Ingest.Completed, Ingest.Failed),
+      (Ingest.Completed, Ingest.Processing),
+      (Ingest.Completed, Ingest.Accepted),
+      (Ingest.Processing, Ingest.Accepted),
+    )
+
+    it("does not allow the status to go backwards") {
+      forAll(disallowedStatusUpdates) {
+        case (initialStatus: Ingest.Status, updatedStatus: Ingest.Status) =>
+          val ingest = createIngestWith(status = initialStatus)
+
+          val update = createIngestStatusUpdateWith(
+            id = ingest.id,
+            status = updatedStatus
+          )
+
+          IngestStates
+            .applyUpdate(ingest, update)
+            .failure
+            .exception shouldBe a[IngestStatusGoingBackwardsException]
       }
     }
   }
+}
 
-  describe("handling an IngestStatusUpdate") {
-    describe("updating the events") {
-      it("adds an event to an ingest") {
-        val ingest = createIngestWith(events = List.empty)
+class IngestCallbackStatusUpdateTest
+  extends IngestUpdateTestCases[IngestCallbackStatusUpdate]
+    with TableDrivenPropertyChecks {
+  override def createUpdateWith(id: IngestID, events: Seq[IngestEvent]): IngestCallbackStatusUpdate =
+    createIngestCallbackStatusUpdateWith(id = id, events = events)
 
-        val event = createIngestEvent
-        val update = createIngestStatusUpdateWith(
-          id = ingest.id,
-          events = List(event)
-        )
+  describe("updating the callback status") {
+    val allowedCallbackStatusUpdates = Table(
+      ("initial", "update"),
+      (Callback.Pending, Callback.Pending),
+      (Callback.Pending, Callback.Succeeded),
+      (Callback.Pending, Callback.Failed),
+      (Callback.Succeeded, Callback.Succeeded),
+      (Callback.Failed, Callback.Failed),
+    )
 
-        val updatedIngest =
-          IngestStates.applyUpdate(ingest, update).success.value
-        updatedIngest.events shouldBe Seq(event)
-      }
+    it("updates the status of a callback") {
+      forAll(allowedCallbackStatusUpdates) {
+        case (
+          initialStatus: Callback.CallbackStatus,
+          updatedStatus: Callback.CallbackStatus) =>
+          val ingest = createIngestWith(
+            callback = Some(
+              Callback(
+                uri = new URI("https://example.org/callback"),
+                status = initialStatus
+              ))
+          )
 
-      it("adds multiple events to an ingest") {
-        val ingest = createIngestWith(events = List.empty)
+          val update = createIngestCallbackStatusUpdateWith(
+            id = ingest.id,
+            callbackStatus = updatedStatus
+          )
 
-        val events =
-          List(createIngestEvent, createIngestEvent, createIngestEvent)
-        val update = createIngestStatusUpdateWith(
-          id = ingest.id,
-          events = events
-        )
-
-        val updatedIngest =
-          IngestStates.applyUpdate(ingest, update).success.value
-        updatedIngest.events shouldBe events
-      }
-
-      it("preserves the existing events on an ingest") {
-        val existingEvents = List(createIngestEvent, createIngestEvent)
-        val ingest = createIngestWith(events = existingEvents)
-
-        val newEvents = List(createIngestEvent, createIngestEvent)
-        val update = createIngestStatusUpdateWith(
-          id = ingest.id,
-          events = newEvents
-        )
-
-        val updatedIngest =
-          IngestStates.applyUpdate(ingest, update).success.value
-        updatedIngest.events shouldBe existingEvents ++ newEvents
+          val updatedIngest =
+            IngestStates.applyUpdate(ingest, update).success.value
+          updatedIngest.callback.get.status shouldBe updatedStatus
       }
     }
 
-    describe("updating the status") {
-      val allowedStatusUpdates = Table(
-        ("initial", "update"),
-        (Ingest.Accepted, Ingest.Accepted),
-        (Ingest.Accepted, Ingest.Processing),
-        (Ingest.Accepted, Ingest.Completed),
-        (Ingest.Accepted, Ingest.Failed),
-        (Ingest.Processing, Ingest.Completed),
-        (Ingest.Processing, Ingest.Failed),
-        (Ingest.Completed, Ingest.Completed),
-        (Ingest.Failed, Ingest.Failed),
+    val disallowedCallbackStatusUpdates = Table(
+      ("initial", "update"),
+      (Callback.Succeeded, Callback.Pending),
+      (Callback.Succeeded, Callback.Failed),
+      (Callback.Failed, Callback.Pending),
+      (Callback.Failed, Callback.Succeeded),
+    )
+
+    it("does not allow the callback status to go backwards") {
+      forAll(disallowedCallbackStatusUpdates) {
+        case (
+          initialStatus: Callback.CallbackStatus,
+          updatedStatus: Callback.CallbackStatus) =>
+          val ingest = createIngestWith(
+            callback = Some(
+              Callback(
+                uri = new URI("https://example.org/callback"),
+                status = initialStatus
+              ))
+          )
+
+          val update = createIngestCallbackStatusUpdateWith(
+            id = ingest.id,
+            callbackStatus = updatedStatus
+          )
+
+          val err = IngestStates.applyUpdate(ingest, update).failure.exception
+
+          err shouldBe a[CallbackStatusGoingBackwardsException]
+      }
+    }
+
+    it("errors if the ingest does not have a callback") {
+      val ingest = createIngestWith(
+        callback = None
+      )
+      val update = createIngestCallbackStatusUpdateWith(
+        id = ingest.id
       )
 
-      it("updates the status of an ingest") {
-        forAll(allowedStatusUpdates) {
-          case (initialStatus: Ingest.Status, updatedStatus: Ingest.Status) =>
-            val ingest = createIngestWith(status = initialStatus)
+      val err = IngestStates.applyUpdate(ingest, update).failure.exception
 
-            val update = createIngestStatusUpdateWith(
-              id = ingest.id,
-              status = updatedStatus
-            )
-
-            val updatedIngest =
-              IngestStates.applyUpdate(ingest, update).success.value
-            updatedIngest.status shouldBe updatedStatus
-        }
-      }
-
-      val disallowedStatusUpdates = Table(
-        ("initial", "update"),
-        (Ingest.Failed, Ingest.Completed),
-        (Ingest.Failed, Ingest.Processing),
-        (Ingest.Failed, Ingest.Accepted),
-        (Ingest.Completed, Ingest.Failed),
-        (Ingest.Completed, Ingest.Processing),
-        (Ingest.Completed, Ingest.Accepted),
-        (Ingest.Processing, Ingest.Accepted),
-      )
-
-      it("does not allow the status to go backwards") {
-        forAll(disallowedStatusUpdates) {
-          case (initialStatus: Ingest.Status, updatedStatus: Ingest.Status) =>
-            val ingest = createIngestWith(status = initialStatus)
-
-            val update = createIngestStatusUpdateWith(
-              id = ingest.id,
-              status = updatedStatus
-            )
-
-            IngestStates
-              .applyUpdate(ingest, update)
-              .failure
-              .exception shouldBe a[IngestStatusGoingBackwardsException]
-        }
-      }
+      err shouldBe a[NoCallbackException]
     }
   }
+}
 
-  describe("handling a CallbackStatusUpdate") {
-    describe("updating the events") {
-      it("adds an event to an ingest") {
-        val ingest = createIngestWith(events = List.empty)
+class IngestVersionUpdateTest
+  extends IngestUpdateTestCases[IngestVersionUpdate] {
+  override def createUpdateWith(id: IngestID, events: Seq[IngestEvent]): IngestVersionUpdate =
+    createIngestVersionUpdateWith(id = id, events = events)
 
-        val event = createIngestEvent
-        val update = createIngestCallbackStatusUpdateWith(
-          id = ingest.id,
-          events = List(event)
-        )
-
-        val updatedIngest =
-          IngestStates.applyUpdate(ingest, update).success.value
-        updatedIngest.events shouldBe Seq(event)
-      }
-
-      it("adds multiple events to an ingest") {
-        val ingest = createIngestWith(events = List.empty)
-
-        val events =
-          List(createIngestEvent, createIngestEvent, createIngestEvent)
-        val update = createIngestCallbackStatusUpdateWith(
-          id = ingest.id,
-          events = events
-        )
-
-        val updatedIngest =
-          IngestStates.applyUpdate(ingest, update).success.value
-        updatedIngest.events shouldBe events
-      }
-
-      it("preserves the existing events on an ingest") {
-        val existingEvents = List(createIngestEvent, createIngestEvent)
-        val ingest = createIngestWith(events = existingEvents)
-
-        val newEvents = List(createIngestEvent, createIngestEvent)
-        val update = createIngestCallbackStatusUpdateWith(
-          id = ingest.id,
-          events = newEvents
-        )
-
-        val updatedIngest =
-          IngestStates.applyUpdate(ingest, update).success.value
-        updatedIngest.events shouldBe existingEvents ++ newEvents
-      }
-    }
-
-    describe("updating the callback status") {
-      val allowedCallbackStatusUpdates = Table(
-        ("initial", "update"),
-        (Callback.Pending, Callback.Pending),
-        (Callback.Pending, Callback.Succeeded),
-        (Callback.Pending, Callback.Failed),
-        (Callback.Succeeded, Callback.Succeeded),
-        (Callback.Failed, Callback.Failed),
+  describe("updating the version") {
+    it("sets the version if there isn't one already") {
+      val ingest = createIngestWith(
+        version = None
+      )
+      val update = createIngestVersionUpdateWith(
+        id = ingest.id,
+        version = BagVersion(1)
       )
 
-      it("updates the status of a callback") {
-        forAll(allowedCallbackStatusUpdates) {
-          case (
-              initialStatus: Callback.CallbackStatus,
-              updatedStatus: Callback.CallbackStatus) =>
-            val ingest = createIngestWith(
-              callback = Some(
-                Callback(
-                  uri = new URI("https://example.org/callback"),
-                  status = initialStatus
-                ))
-            )
+      val updatedIngest =
+        IngestStates.applyUpdate(ingest, update).success.value
+      updatedIngest.version shouldBe Some(BagVersion(1))
+    }
 
-            val update = createIngestCallbackStatusUpdateWith(
-              id = ingest.id,
-              callbackStatus = updatedStatus
-            )
-
-            val updatedIngest =
-              IngestStates.applyUpdate(ingest, update).success.value
-            updatedIngest.callback.get.status shouldBe updatedStatus
-        }
-      }
-
-      val disallowedCallbackStatusUpdates = Table(
-        ("initial", "update"),
-        (Callback.Succeeded, Callback.Pending),
-        (Callback.Succeeded, Callback.Failed),
-        (Callback.Failed, Callback.Pending),
-        (Callback.Failed, Callback.Succeeded),
+    it("does nothing if the version is already set") {
+      val ingest = createIngestWith(
+        version = Some(BagVersion(1))
+      )
+      val update = createIngestVersionUpdateWith(
+        id = ingest.id,
+        version = BagVersion(1)
       )
 
-      it("does not allow the callback status to go backwards") {
-        forAll(disallowedCallbackStatusUpdates) {
-          case (
-              initialStatus: Callback.CallbackStatus,
-              updatedStatus: Callback.CallbackStatus) =>
-            val ingest = createIngestWith(
-              callback = Some(
-                Callback(
-                  uri = new URI("https://example.org/callback"),
-                  status = initialStatus
-                ))
-            )
-
-            val update = createIngestCallbackStatusUpdateWith(
-              id = ingest.id,
-              callbackStatus = updatedStatus
-            )
-
-            val err = IngestStates.applyUpdate(ingest, update).failure.exception
-
-            err shouldBe a[CallbackStatusGoingBackwardsException]
-        }
-      }
-
-      it("errors if the ingest does not have a callback") {
-        val ingest = createIngestWith(
-          callback = None
-        )
-        val update = createIngestCallbackStatusUpdateWith(
-          id = ingest.id
-        )
-
-        val err = IngestStates.applyUpdate(ingest, update).failure.exception
-
-        err shouldBe a[NoCallbackException]
-      }
-    }
-  }
-
-  describe("handling an IngestVersionUpdate") {
-    describe("updating the events") {
-      it("adds an event to an ingest") {
-        val ingest = createIngestWith(
-          version = None,
-          events = List.empty
-        )
-
-        val event = createIngestEvent
-        val update = createIngestVersionUpdateWith(
-          id = ingest.id,
-          events = List(event)
-        )
-
-        val updatedIngest =
-          IngestStates.applyUpdate(ingest, update).success.value
-        updatedIngest.events shouldBe Seq(event)
-      }
-
-      it("adds multiple events to an ingest") {
-        val ingest = createIngestWith(
-          version = None,
-          events = List.empty
-        )
-
-        val events =
-          List(createIngestEvent, createIngestEvent, createIngestEvent)
-        val update = createIngestVersionUpdateWith(
-          id = ingest.id,
-          events = events
-        )
-
-        val updatedIngest =
-          IngestStates.applyUpdate(ingest, update).success.value
-        updatedIngest.events shouldBe events
-      }
-
-      it("preserves the existing events on an ingest") {
-        val existingEvents = List(createIngestEvent, createIngestEvent)
-        val ingest = createIngestWith(
-          version = None,
-          events = existingEvents
-        )
-
-        val newEvents = List(createIngestEvent, createIngestEvent)
-        val update = createIngestVersionUpdateWith(
-          id = ingest.id,
-          events = newEvents
-        )
-
-        val updatedIngest =
-          IngestStates.applyUpdate(ingest, update).success.value
-        updatedIngest.events shouldBe existingEvents ++ newEvents
-      }
+      val updatedIngest =
+        IngestStates.applyUpdate(ingest, update).success.value
+      updatedIngest.version shouldBe Some(BagVersion(1))
     }
 
-    describe("updating the version") {
-      it("sets the version if there isn't one already") {
-        val ingest = createIngestWith(
-          version = None
-        )
-        val update = createIngestVersionUpdateWith(
-          id = ingest.id,
-          version = BagVersion(1)
-        )
+    it("errors if the existing version is different") {
+      val ingest = createIngestWith(
+        version = Some(BagVersion(1))
+      )
+      val update = createIngestVersionUpdateWith(
+        id = ingest.id,
+        version = BagVersion(2)
+      )
 
-        val updatedIngest =
-          IngestStates.applyUpdate(ingest, update).success.value
-        updatedIngest.version shouldBe Some(BagVersion(1))
-      }
-
-      it("does nothing if the version is already set") {
-        val ingest = createIngestWith(
-          version = Some(BagVersion(1))
-        )
-        val update = createIngestVersionUpdateWith(
-          id = ingest.id,
-          version = BagVersion(1)
-        )
-
-        val updatedIngest =
-          IngestStates.applyUpdate(ingest, update).success.value
-        updatedIngest.version shouldBe Some(BagVersion(1))
-      }
-
-      it("errors if the existing version is different") {
-        val ingest = createIngestWith(
-          version = Some(BagVersion(1))
-        )
-        val update = createIngestVersionUpdateWith(
-          id = ingest.id,
-          version = BagVersion(2)
-        )
-
-        val err = IngestStates.applyUpdate(ingest, update).failure.exception
-        err shouldBe a[MismatchedVersionUpdateException]
-      }
+      val err = IngestStates.applyUpdate(ingest, update).failure.exception
+      err shouldBe a[MismatchedVersionUpdateException]
     }
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdateTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdateTest.scala
@@ -15,9 +15,12 @@ sealed trait IngestUpdateTestCases[UpdateType <: IngestUpdate]
     with TryValues {
   def createUpdateWith(id: IngestID, events: Seq[IngestEvent]): UpdateType
 
+  def createInitialIngestWith(events: Seq[IngestEvent]): Ingest =
+    createIngestWith(events = events)
+
   describe("updating the events") {
     it("adds an event") {
-      val ingest = createIngestWith(events = List.empty)
+      val ingest = createInitialIngestWith(events = List.empty)
 
       val event = createIngestEvent
       val update = createUpdateWith(
@@ -30,7 +33,7 @@ sealed trait IngestUpdateTestCases[UpdateType <: IngestUpdate]
     }
 
     it("adds multiple events") {
-      val ingest = createIngestWith(events = List.empty)
+      val ingest = createInitialIngestWith(events = List.empty)
 
       val events =
         List(createIngestEvent, createIngestEvent, createIngestEvent)
@@ -45,7 +48,7 @@ sealed trait IngestUpdateTestCases[UpdateType <: IngestUpdate]
 
     it("preserves the existing events") {
       val existingEvents = List(createIngestEvent, createIngestEvent)
-      val ingest = createIngestWith(events = existingEvents)
+      val ingest = createInitialIngestWith(events = existingEvents)
 
       val newEvents = List(createIngestEvent, createIngestEvent)
       val update = createUpdateWith(
@@ -248,6 +251,12 @@ class IngestVersionUpdateTest
   override def createUpdateWith(id: IngestID,
                                 events: Seq[IngestEvent]): IngestVersionUpdate =
     createIngestVersionUpdateWith(id = id, events = events)
+
+  override def createInitialIngestWith(events: Seq[IngestEvent]): Ingest =
+    createIngestWith(
+      events = events,
+      version = None
+    )
 
   describe("updating the version") {
     it("sets the version if there isn't one already") {

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
@@ -14,7 +14,7 @@ import uk.ac.wellcome.platform.archive.common.generators.{
   BagGenerators,
   StorageSpaceGenerators
 }
-import uk.ac.wellcome.platform.archive.common.ingest.fixtures.TimeTestFixture
+import uk.ac.wellcome.platform.archive.common.ingests.fixtures.TimeTestFixture
 import uk.ac.wellcome.platform.archive.common.ingests.models.{
   InfrequentAccessStorageProvider,
   StorageLocation

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayBag.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayBag.scala
@@ -6,3 +6,8 @@ case class RequestDisplayBag(
   info: RequestDisplayBagInfo,
   @JsonKey("type") ontologyType: String = "Bag"
 )
+
+case class ResponseDisplayBag(
+  info: ResponseDisplayBagInfo,
+  @JsonKey("type") ontologyType: String = "Bag"
+)

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayBagInfo.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayBagInfo.scala
@@ -7,3 +7,9 @@ case class RequestDisplayBagInfo(
   externalIdentifier: ExternalIdentifier,
   @JsonKey("type") ontologyType: String = "BagInfo"
 )
+
+case class ResponseDisplayBagInfo(
+  externalIdentifier: String,
+  version: Option[String],
+  @JsonKey("type") ontologyType: String = "BagInfo"
+)

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayIngest.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayIngest.scala
@@ -39,7 +39,7 @@ case class ResponseDisplayIngest(@JsonKey("@context") context: String,
                                  ingestType: DisplayIngestType,
                                  space: DisplayStorageSpace,
                                  status: DisplayStatus,
-                                 bag: RequestDisplayBag,
+                                 bag: ResponseDisplayBag,
                                  events: Seq[DisplayIngestEvent] = Seq.empty,
                                  createdDate: String,
                                  lastModifiedDate: Option[String],
@@ -56,9 +56,10 @@ object ResponseDisplayIngest {
       callback = ingest.callback.map { DisplayCallback(_) },
       space = DisplayStorageSpace(ingest.space.toString),
       ingestType = DisplayIngestType(ingest.ingestType),
-      bag = RequestDisplayBag(
-        info = RequestDisplayBagInfo(
-          externalIdentifier = ingest.externalIdentifier
+      bag = ResponseDisplayBag(
+        info = ResponseDisplayBagInfo(
+          externalIdentifier = ingest.externalIdentifier.toString,
+          version = ingest.version.map { _.toString }
         )
       ),
       status = DisplayStatus(ingest.status),

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayIngestTest.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayIngestTest.scala
@@ -68,7 +68,7 @@ class DisplayIngestTest
       )
       displayIngest.space shouldBe DisplayStorageSpace(spaceId)
       displayIngest.status shouldBe DisplayStatus("processing")
-      displayIngest.bag.info.externalIdentifier shouldBe externalIdentifier
+      displayIngest.bag.info.externalIdentifier shouldBe externalIdentifier.toString
       displayIngest.createdDate shouldBe createdDate
       displayIngest.lastModifiedDate.get shouldBe modifiedDate
       displayIngest.events shouldBe List(
@@ -187,10 +187,8 @@ class DisplayIngestTest
       ingestType = ingestType,
       bag = RequestDisplayBag(
         info = RequestDisplayBagInfo(
-          externalIdentifier = createExternalIdentifier,
-          ontologyType = "BagInfo"
-        ),
-        ontologyType = "Bag"
+          externalIdentifier = createExternalIdentifier
+        )
       ),
       space = space
     )

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayIngestTest.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayIngestTest.scala
@@ -8,7 +8,7 @@ import uk.ac.wellcome.platform.archive.common.generators.{
   BagIdGenerators,
   IngestGenerators
 }
-import uk.ac.wellcome.platform.archive.common.ingest.fixtures.TimeTestFixture
+import uk.ac.wellcome.platform.archive.common.ingests.fixtures.TimeTestFixture
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.ObjectLocation

--- a/ingests_common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/tracker/IngestTracker.scala
+++ b/ingests_common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/tracker/IngestTracker.scala
@@ -2,12 +2,7 @@ package uk.ac.wellcome.platform.archive.common.ingests.tracker
 
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagId
 import uk.ac.wellcome.platform.archive.common.ingests.models._
-import uk.ac.wellcome.platform.archive.common.ingests.services.{
-  CallbackStatusGoingBackwardsException,
-  IngestStates,
-  IngestStatusGoingBackwardsException,
-  NoCallbackException
-}
+import uk.ac.wellcome.platform.archive.common.ingests.services._
 import uk.ac.wellcome.storage._
 import uk.ac.wellcome.storage.store.VersionedStore
 
@@ -55,6 +50,9 @@ trait IngestTracker {
 
       case Failure(_: NoCallbackException) =>
         Left(NoCallbackOnIngest())
+
+      case Failure(err: MismatchedVersionUpdateException) =>
+        Left(IngestBadVersionUpdate(err.existing, err.update))
 
       case Success(Left(err)) => Left(IngestTrackerStoreError(err))
 

--- a/ingests_common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/tracker/IngestTrackerError.scala
+++ b/ingests_common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/tracker/IngestTrackerError.scala
@@ -2,7 +2,12 @@ package uk.ac.wellcome.platform.archive.common.ingests.tracker
 
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion
 import uk.ac.wellcome.platform.archive.common.ingests.models.{Callback, Ingest}
-import uk.ac.wellcome.storage.{NotFoundError, StorageError, UpdateNoSourceError, VersionAlreadyExistsError}
+import uk.ac.wellcome.storage.{
+  NotFoundError,
+  StorageError,
+  UpdateNoSourceError,
+  VersionAlreadyExistsError
+}
 
 sealed trait IngestTrackerError
 
@@ -27,7 +32,7 @@ case class IngestCallbackStatusGoingBackwards(stored: Callback.CallbackStatus,
 
 case class NoCallbackOnIngest() extends IngestTrackerError
 
-case class IngestBadVersionUpdate(existing: BagVersion,
-                                  update: BagVersion) extends IngestTrackerError
+case class IngestBadVersionUpdate(existing: BagVersion, update: BagVersion)
+    extends IngestTrackerError
 
 case class IngestTrackerUpdateError(err: Throwable) extends IngestTrackerError

--- a/ingests_common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/tracker/IngestTrackerError.scala
+++ b/ingests_common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/tracker/IngestTrackerError.scala
@@ -1,11 +1,8 @@
 package uk.ac.wellcome.platform.archive.common.ingests.tracker
+
+import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion
 import uk.ac.wellcome.platform.archive.common.ingests.models.{Callback, Ingest}
-import uk.ac.wellcome.storage.{
-  NotFoundError,
-  StorageError,
-  UpdateNoSourceError,
-  VersionAlreadyExistsError
-}
+import uk.ac.wellcome.storage.{NotFoundError, StorageError, UpdateNoSourceError, VersionAlreadyExistsError}
 
 sealed trait IngestTrackerError
 
@@ -29,5 +26,8 @@ case class IngestCallbackStatusGoingBackwards(stored: Callback.CallbackStatus,
     extends IngestTrackerError
 
 case class NoCallbackOnIngest() extends IngestTrackerError
+
+case class IngestBadVersionUpdate(existing: BagVersion,
+                                  update: BagVersion) extends IngestTrackerError
 
 case class IngestTrackerUpdateError(err: Throwable) extends IngestTrackerError

--- a/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/tracker/fixtures/IngestTrackerFixtures.scala
+++ b/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/tracker/fixtures/IngestTrackerFixtures.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.archive.common.ingests.tracker.fixtures
 
 import org.scalatest.EitherValues
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.archive.common.ingest.fixtures.TimeTestFixture
+import uk.ac.wellcome.platform.archive.common.ingests.fixtures.TimeTestFixture
 import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestID}
 import uk.ac.wellcome.platform.archive.common.ingests.tracker.memory.MemoryIngestTracker
 import uk.ac.wellcome.storage.Version

--- a/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlService.scala
+++ b/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlService.scala
@@ -18,7 +18,8 @@ class CallbackUrlService(contextUrl: URL)(implicit actorSystem: ActorSystem)
     extends Logging {
   implicit val printer: Printer = Printer.noSpaces.copy(dropNullValues = true)
 
-  def getHttpResponse(ingest: Ingest, callbackUri: URI): Future[HttpResponse] = {
+  def getHttpResponse(ingest: Ingest,
+                      callbackUri: URI): Future[HttpResponse] = {
     val jsonString =
       ResponseDisplayIngest(
         ingest = ingest,

--- a/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlService.scala
+++ b/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlService.scala
@@ -18,8 +18,8 @@ class CallbackUrlService(contextUrl: URL)(implicit actorSystem: ActorSystem)
     extends Logging {
   implicit val printer: Printer = Printer.noSpaces.copy(dropNullValues = true)
 
-  def getHttpResponse(ingest: Ingest,
-                      callbackUri: URI): Future[HttpResponse] = {
+  def buildHttpRequest(ingest: Ingest,
+                        callbackUri: URI): HttpRequest = {
     val jsonString =
       ResponseDisplayIngest(
         ingest = ingest,
@@ -33,12 +33,16 @@ class CallbackUrlService(contextUrl: URL)(implicit actorSystem: ActorSystem)
 
     debug(s"POST to $callbackUri request:$entity")
 
-    val request = HttpRequest(
+    HttpRequest(
       method = HttpMethods.POST,
       uri = callbackUri.toString,
       entity = entity
     )
-
-    Http().singleRequest(request)
   }
+
+  def getHttpResponse(ingest: Ingest,
+                      callbackUri: URI): Future[HttpResponse] =
+    Http().singleRequest(
+      buildHttpRequest(ingest, callbackUri)
+    )
 }

--- a/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlService.scala
+++ b/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlService.scala
@@ -16,16 +16,14 @@ import scala.concurrent.Future
 
 class CallbackUrlService(contextUrl: URL)(implicit actorSystem: ActorSystem)
     extends Logging {
-  def buildHttpRequest(ingest: Ingest,
-                        callbackUri: URI): HttpRequest = {
+  def buildHttpRequest(ingest: Ingest, callbackUri: URI): HttpRequest = {
     val json = ResponseDisplayIngest(
       ingest = ingest,
       contextUrl = contextUrl
     ).asJson
 
     val jsonString =
-      Printer
-        .noSpaces
+      Printer.noSpaces
         .copy(dropNullValues = true)
         .pretty(json)
 
@@ -43,8 +41,7 @@ class CallbackUrlService(contextUrl: URL)(implicit actorSystem: ActorSystem)
     )
   }
 
-  def getHttpResponse(ingest: Ingest,
-                      callbackUri: URI): Future[HttpResponse] =
+  def getHttpResponse(ingest: Ingest, callbackUri: URI): Future[HttpResponse] =
     Http().singleRequest(
       buildHttpRequest(ingest, callbackUri)
     )

--- a/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlService.scala
+++ b/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlService.scala
@@ -16,15 +16,18 @@ import scala.concurrent.Future
 
 class CallbackUrlService(contextUrl: URL)(implicit actorSystem: ActorSystem)
     extends Logging {
-  implicit val printer: Printer = Printer.noSpaces.copy(dropNullValues = true)
-
   def buildHttpRequest(ingest: Ingest,
                         callbackUri: URI): HttpRequest = {
+    val json = ResponseDisplayIngest(
+      ingest = ingest,
+      contextUrl = contextUrl
+    ).asJson
+
     val jsonString =
-      ResponseDisplayIngest(
-        ingest = ingest,
-        contextUrl = contextUrl
-      ).asJson.noSpaces
+      Printer
+        .noSpaces
+        .copy(dropNullValues = true)
+        .pretty(json)
 
     val entity = HttpEntity(
       contentType = ContentTypes.`application/json`,

--- a/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/services/NotifierWorker.scala
+++ b/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/services/NotifierWorker.scala
@@ -5,24 +5,14 @@ import com.amazonaws.services.sqs.AmazonSQSAsync
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.MessageSender
-import uk.ac.wellcome.messaging.sqsworker.alpakka.{
-  AlpakkaSQSWorker,
-  AlpakkaSQSWorkerConfig
-}
-import uk.ac.wellcome.messaging.worker.models.{
-  DeterministicFailure,
-  Result,
-  Successful
-}
+import uk.ac.wellcome.messaging.sqsworker.alpakka.{AlpakkaSQSWorker, AlpakkaSQSWorkerConfig}
+import uk.ac.wellcome.messaging.worker.models.{DeterministicFailure, Result, Successful}
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  CallbackNotification,
-  IngestCallbackStatusUpdate,
-  IngestUpdate
-}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{CallbackNotification, IngestCallbackStatusUpdate, IngestUpdate}
 import uk.ac.wellcome.typesafe.Runnable
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
 
 class NotifierWorker[Destination](
   alpakkaSQSWorkerConfig: AlpakkaSQSWorkerConfig,
@@ -47,6 +37,9 @@ class NotifierWorker[Destination](
         ingest = callbackNotification.payload,
         callbackUri = callbackNotification.callbackUri
       )
+        .map { response => Success(response) }
+        .recover { case err => Failure(err) }
+
       ingestUpdate = PrepareNotificationService.prepare(
         id = callbackNotification.ingestId,
         httpResponse = httpResponse

--- a/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/services/NotifierWorker.scala
+++ b/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/services/NotifierWorker.scala
@@ -5,10 +5,21 @@ import com.amazonaws.services.sqs.AmazonSQSAsync
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.MessageSender
-import uk.ac.wellcome.messaging.sqsworker.alpakka.{AlpakkaSQSWorker, AlpakkaSQSWorkerConfig}
-import uk.ac.wellcome.messaging.worker.models.{DeterministicFailure, Result, Successful}
+import uk.ac.wellcome.messaging.sqsworker.alpakka.{
+  AlpakkaSQSWorker,
+  AlpakkaSQSWorkerConfig
+}
+import uk.ac.wellcome.messaging.worker.models.{
+  DeterministicFailure,
+  Result,
+  Successful
+}
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
-import uk.ac.wellcome.platform.archive.common.ingests.models.{CallbackNotification, IngestCallbackStatusUpdate, IngestUpdate}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  CallbackNotification,
+  IngestCallbackStatusUpdate,
+  IngestUpdate
+}
 import uk.ac.wellcome.typesafe.Runnable
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -33,11 +44,14 @@ class NotifierWorker[Destination](
   def processMessage(callbackNotification: CallbackNotification)
     : Future[Result[IngestCallbackStatusUpdate]] = {
     val future = for {
-      httpResponse <- callbackUrlService.getHttpResponse(
-        ingest = callbackNotification.payload,
-        callbackUri = callbackNotification.callbackUri
-      )
-        .map { response => Success(response) }
+      httpResponse <- callbackUrlService
+        .getHttpResponse(
+          ingest = callbackNotification.payload,
+          callbackUri = callbackNotification.callbackUri
+        )
+        .map { response =>
+          Success(response)
+        }
         .recover { case err => Failure(err) }
 
       ingestUpdate = PrepareNotificationService.prepare(

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
@@ -1,13 +1,9 @@
 package uk.ac.wellcome.platform.archive.notifier
 
 import java.net.URI
+import java.time.Instant
 
-import com.github.tomakehurst.wiremock.client.WireMock.{
-  equalToJson,
-  postRequestedFor,
-  urlPathEqualTo,
-  _
-}
+import com.github.tomakehurst.wiremock.client.WireMock.{equalToJson, postRequestedFor, urlPathEqualTo, _}
 import org.apache.http.HttpStatus
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.{FunSpec, Inside, Matchers}
@@ -15,17 +11,9 @@ import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
 import uk.ac.wellcome.platform.archive.common.ingest.fixtures.TimeTestFixture
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  Callback,
-  CallbackNotification,
-  IngestCallbackStatusUpdate,
-  IngestUpdate
-}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{Callback, CallbackNotification, IngestCallbackStatusUpdate, IngestUpdate}
 import uk.ac.wellcome.platform.archive.display._
-import uk.ac.wellcome.platform.archive.notifier.fixtures.{
-  LocalWireMockFixture,
-  NotifierFixtures
-}
+import uk.ac.wellcome.platform.archive.notifier.fixtures.{LocalWireMockFixture, NotifierFixtures}
 
 class NotifierFeatureTest
     extends FunSpec
@@ -53,7 +41,7 @@ class NotifierFeatureTest
             val ingest = createIngestWith(
               id = ingestId,
               callback = Some(createCallbackWith(uri = callbackUri)),
-              lastModifiedDate = None
+              lastModifiedDate = Some(Instant.now)
             )
 
             sendNotificationToSQS(
@@ -132,6 +120,7 @@ class NotifierFeatureTest
               val ingest = createIngestWith(
                 id = ingestID,
                 version = None,
+                lastModifiedDate = None,
                 callback = Some(createCallbackWith(uri = callbackUri)),
                 events = Seq(createIngestEvent, createIngestEvent)
               )
@@ -141,13 +130,10 @@ class NotifierFeatureTest
                 CallbackNotification(ingestID, callbackUri, ingest)
               )
 
-              // TODO: This test is failing because lastModifiedDate is
-              // a null.  We shouldn't be sending nulls in callbacks!
-              // Compare to the ingests API, and add a test for it.
               val expectedJson =
                 s"""
                    |{
-                   |  "@context": "http://api.wellcomecollection.org/storage/v1/context.json",
+                   |  "@context": "http://localhost/context.json",
                    |  "id": "${ingest.id.toString}",
                    |  "type": "Ingest",
                    |  "ingestType": {

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
@@ -10,7 +10,7 @@ import org.scalatest.{FunSpec, Inside, Matchers}
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
-import uk.ac.wellcome.platform.archive.common.ingest.fixtures.TimeTestFixture
+import uk.ac.wellcome.platform.archive.common.ingests.fixtures.TimeTestFixture
 import uk.ac.wellcome.platform.archive.common.ingests.models.{Callback, CallbackNotification, IngestCallbackStatusUpdate, IngestUpdate}
 import uk.ac.wellcome.platform.archive.display._
 import uk.ac.wellcome.platform.archive.notifier.fixtures.{LocalWireMockFixture, NotifierFixtures}

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
@@ -52,7 +52,8 @@ class NotifierFeatureTest
 
             val ingest = createIngestWith(
               id = ingestId,
-              callback = Some(createCallbackWith(uri = callbackUri))
+              callback = Some(createCallbackWith(uri = callbackUri)),
+              lastModifiedDate = None
             )
 
             sendNotificationToSQS(

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
@@ -3,7 +3,12 @@ package uk.ac.wellcome.platform.archive.notifier
 import java.net.URI
 import java.time.Instant
 
-import com.github.tomakehurst.wiremock.client.WireMock.{equalToJson, postRequestedFor, urlPathEqualTo, _}
+import com.github.tomakehurst.wiremock.client.WireMock.{
+  equalToJson,
+  postRequestedFor,
+  urlPathEqualTo,
+  _
+}
 import org.apache.http.HttpStatus
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.{FunSpec, Inside, Matchers}
@@ -11,9 +16,17 @@ import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.TimeTestFixture
-import uk.ac.wellcome.platform.archive.common.ingests.models.{Callback, CallbackNotification, IngestCallbackStatusUpdate, IngestUpdate}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  Callback,
+  CallbackNotification,
+  IngestCallbackStatusUpdate,
+  IngestUpdate
+}
 import uk.ac.wellcome.platform.archive.display._
-import uk.ac.wellcome.platform.archive.notifier.fixtures.{LocalWireMockFixture, NotifierFixtures}
+import uk.ac.wellcome.platform.archive.notifier.fixtures.{
+  LocalWireMockFixture,
+  NotifierFixtures
+}
 
 class NotifierFeatureTest
     extends FunSpec

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
@@ -22,7 +22,10 @@ import uk.ac.wellcome.platform.archive.common.ingests.models.{
   IngestUpdate
 }
 import uk.ac.wellcome.platform.archive.display._
-import uk.ac.wellcome.platform.archive.notifier.fixtures.{LocalWireMockFixture, NotifierFixtures}
+import uk.ac.wellcome.platform.archive.notifier.fixtures.{
+  LocalWireMockFixture,
+  NotifierFixtures
+}
 
 class NotifierFeatureTest
     extends FunSpec

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/fixtures/NotifierFixtures.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/fixtures/NotifierFixtures.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.platform.archive.notifier.fixtures
 
 import java.net.URL
 
-import akka.actor.ActorSystem
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
@@ -25,13 +24,13 @@ trait NotifierFixtures
     with AlpakkaSQSWorkerFixtures
     with MonitoringClientFixture {
 
-  def withCallbackUrlService[R](testWith: TestWith[CallbackUrlService, R])(
-    implicit actorSystem: ActorSystem): R = {
-    val callbackUrlService = new CallbackUrlService(
-      contextUrl = new URL("http://localhost/context.json")
-    )
-    testWith(callbackUrlService)
-  }
+  def withCallbackUrlService[R](testWith: TestWith[CallbackUrlService, R]): R =
+    withActorSystem { implicit actorSystem =>
+      val callbackUrlService = new CallbackUrlService(
+        contextUrl = new URL("http://localhost/context.json")
+      )
+      testWith(callbackUrlService)
+    }
 
   private def withApp[R](queue: Queue, messageSender: MemoryMessageSender)(
     testWith: TestWith[NotifierWorker[String], R]): R =

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlServiceTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlServiceTest.scala
@@ -2,59 +2,164 @@ package uk.ac.wellcome.platform.archive.notifier.services
 
 import java.net.URI
 
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.{ContentTypes, HttpMethods, HttpRequest, StatusCodes}
+import akka.stream.StreamTcpException
+import akka.stream.scaladsl.Sink
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
-import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.akka.fixtures.Akka
+import org.scalatest.{Assertion, FunSpec, Matchers}
+import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
-import uk.ac.wellcome.platform.archive.notifier.fixtures.{
-  LocalWireMockFixture,
-  NotifierFixtures
-}
+import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
+import uk.ac.wellcome.platform.archive.notifier.fixtures.{LocalWireMockFixture, NotifierFixtures}
 
 class CallbackUrlServiceTest
     extends FunSpec
     with Matchers
     with ScalaFutures
     with IntegrationPatience
-    with Akka
     with NotifierFixtures
     with LocalWireMockFixture
-    with IngestGenerators {
+    with IngestGenerators
+    with JsonAssertions {
 
-  it("returns a Success if the request succeeds") {
-    withActorSystem { implicit actorSystem =>
-      withCallbackUrlService { service =>
-        val ingest = createIngest
+  describe("sends the HTTP requests") {
+    it("returns a Success if the request succeeds") {
+      withActorSystem { implicit actorSystem =>
+        withCallbackUrlService { service =>
+          val ingest = createIngest
 
-        val future = service.getHttpResponse(
-          ingest = ingest,
-          callbackUri =
-            new URI(s"http://$callbackHost:$callbackPort/callback/${ingest.id}")
-        )
+          val future = service.getHttpResponse(
+            ingest = ingest,
+            callbackUri =
+              new URI(s"http://$callbackHost:$callbackPort/callback/${ingest.id}")
+          )
 
-        whenReady(future) { result =>
-          result.status shouldBe StatusCodes.NotFound
+          whenReady(future) { result =>
+            result.status shouldBe StatusCodes.NotFound
+          }
+        }
+      }
+    }
+
+    it("returns a failed future if the HTTP request fails") {
+      withActorSystem { implicit actorSystem =>
+        withCallbackUrlService { service =>
+          val ingest = createIngest
+
+          val future = service.getHttpResponse(
+            ingest = ingest,
+            callbackUri = new URI(s"http://nope.nope/callback/${ingest.id}")
+          )
+
+          whenReady(future.failed) { result =>
+            result shouldBe a[StreamTcpException]
+          }
         }
       }
     }
   }
 
-  it("returns a failed future if the HTTP request fails") {
-    withActorSystem { implicit actorSystem =>
+  describe("builds the correct HTTP request") {
+    it("creates a JSON string") {
+      val ingestId = createIngestID
+
+      val callbackUri = new URI(s"http://example.org/callback/$ingestId")
+
+      val ingest = createIngestWith(
+        id = ingestId,
+        version = None,
+        callback = Some(createCallbackWith(uri = callbackUri)),
+        events = Seq(createIngestEvent, createIngestEvent)
+      )
+
+      val request = buildRequest(ingest, callbackUri)
+
+      assertIsJsonRequest(
+        request = request,
+        uri = callbackUri,
+        jsonString =
+          s"""
+             |{
+             |  "@context": "http://localhost/context.json",
+             |  "id": "${ingestId.toString}",
+             |  "type": "Ingest",
+             |  "ingestType": {
+             |    "id": "${ingest.ingestType.id}",
+             |    "type": "IngestType"
+             |  },
+             |  "space": {
+             |    "id": "${ingest.space.underlying}",
+             |    "type": "Space"
+             |  },
+             |  "bag": {
+             |    "type": "Bag",
+             |    "info": {
+             |      "type": "BagInfo",
+             |      "externalIdentifier": "${ingest.externalIdentifier.underlying}"
+             |    }
+             |  },
+             |  "status": {
+             |    "id": "${ingest.status.toString}",
+             |    "type": "Status"
+             |  },
+             |  "sourceLocation": {
+             |    "type": "Location",
+             |    "provider": {
+             |      "type": "Provider",
+             |      "id": "aws-s3-standard"
+             |    },
+             |    "bucket": "${ingest.sourceLocation.location.namespace}",
+             |    "path": "${ingest.sourceLocation.location.path}"
+             |  },
+             |  "callback": {
+             |    "type": "Callback",
+             |    "url": "${ingest.callback.get.uri}",
+             |    "status": {
+             |      "id": "${ingest.callback.get.status.toString}",
+             |      "type": "Status"
+             |    }
+             |  },
+             |  "createdDate": "${ingest.createdDate}",
+             |  "events": [
+             |    {
+             |      "type": "IngestEvent",
+             |      "createdDate": "${ingest.events(0).createdDate}",
+             |      "description": "${ingest.events(0).description}"
+             |    },
+             |    {
+             |      "type": "IngestEvent",
+             |      "createdDate": "${ingest.events(1).createdDate}",
+             |      "description": "${ingest.events(1).description}"
+             |    }
+             |  ]
+             |}
+                 """.stripMargin
+      )
+    }
+
+    def buildRequest(ingest: Ingest, callbackUri: URI): HttpRequest =
       withCallbackUrlService { service =>
-        val ingest = createIngest
-
-        val future = service.getHttpResponse(
+        service.buildHttpRequest(
           ingest = ingest,
-          callbackUri = new URI(s"http://nope.nope/callback/${ingest.id}")
+          callbackUri = callbackUri
         )
+      }
 
-        whenReady(future.failed) { result =>
-          println(result)
-          true shouldBe false
+    def assertIsJsonRequest(request: HttpRequest, uri: URI, jsonString: String): Assertion = {
+      request.method shouldBe HttpMethods.POST
+      request.uri.toString() shouldBe uri.toString
+
+      withMaterializer { implicit materializer =>
+        val future = request.entity.dataBytes.runWith(Sink.seq)
+        whenReady(future) { byteString =>
+          assertJsonStringsAreEqual(
+            byteString.head.utf8String,
+            jsonString
+          )
         }
       }
+
+      request.entity.contentType shouldBe ContentTypes.`application/json`
     }
   }
 }

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlServiceTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlServiceTest.scala
@@ -34,8 +34,7 @@ class CallbackUrlServiceTest
         )
 
         whenReady(future) { result =>
-          result.isSuccess shouldBe true
-          result.get.status shouldBe StatusCodes.NotFound
+          result.status shouldBe StatusCodes.NotFound
         }
       }
     }
@@ -51,12 +50,11 @@ class CallbackUrlServiceTest
           callbackUri = new URI(s"http://nope.nope/callback/${ingest.id}")
         )
 
-        whenReady(future) { result =>
-          result.isFailure shouldBe true
+        whenReady(future.failed) { result =>
+          println(result)
+          true shouldBe false
         }
       }
     }
   }
-
-  // TODO: Add a test that it sends the correct POST payload.
 }

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlServiceTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlServiceTest.scala
@@ -3,7 +3,12 @@ package uk.ac.wellcome.platform.archive.notifier.services
 import java.net.URI
 import java.time.Instant
 
-import akka.http.scaladsl.model.{ContentTypes, HttpMethods, HttpRequest, StatusCodes}
+import akka.http.scaladsl.model.{
+  ContentTypes,
+  HttpMethods,
+  HttpRequest,
+  StatusCodes
+}
 import akka.stream.StreamTcpException
 import akka.stream.scaladsl.Sink
 import io.circe.optics.JsonPath.root
@@ -14,7 +19,10 @@ import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
-import uk.ac.wellcome.platform.archive.notifier.fixtures.{LocalWireMockFixture, NotifierFixtures}
+import uk.ac.wellcome.platform.archive.notifier.fixtures.{
+  LocalWireMockFixture,
+  NotifierFixtures
+}
 
 class CallbackUrlServiceTest
     extends FunSpec
@@ -35,8 +43,8 @@ class CallbackUrlServiceTest
 
           val future = service.getHttpResponse(
             ingest = ingest,
-            callbackUri =
-              new URI(s"http://$callbackHost:$callbackPort/callback/${ingest.id}")
+            callbackUri = new URI(
+              s"http://$callbackHost:$callbackPort/callback/${ingest.id}")
           )
 
           whenReady(future) { result =>
@@ -182,7 +190,8 @@ class CallbackUrlServiceTest
         )
       }
 
-    def assertIsJsonRequest(request: HttpRequest, uri: URI)(assertJson: String => Assertion): Assertion = {
+    def assertIsJsonRequest(request: HttpRequest, uri: URI)(
+      assertJson: String => Assertion): Assertion = {
       request.method shouldBe HttpMethods.POST
       request.uri.toString() shouldBe uri.toString
 

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/PrepareNotificationServiceTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/PrepareNotificationServiceTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
-import uk.ac.wellcome.platform.archive.common.ingest.fixtures.TimeTestFixture
+import uk.ac.wellcome.platform.archive.common.ingests.fixtures.TimeTestFixture
 import uk.ac.wellcome.platform.archive.common.ingests.models.{
   Callback,
   IngestID

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -88,7 +88,7 @@ object ExternalDependencies {
   )
 
   val circeOpticsDependencies = Seq[ModuleID](
-    "io.circe" %% "circe-optics" % versions.circe
+    "io.circe" %% "circe-optics" % versions.circe % "test"
   )
 
   val scalatestDependencies = Seq[ModuleID](


### PR DESCRIPTION
* When the auditor assigns a version, it sends an IngestVersionUpdate to the ingests monitor, which attaches it to the ingest. This version gets shown in the ingests API and the notifier. Fixes https://github.com/wellcometrust/platform/issues/3770

* The IngestStatesTest has been split into one test for each type of update, with the event-updating test cases a single shared set.

* The notifier tests now assert on explicit JSON output, which fixes a couple of cases where we were sending null in the output

* Don't make `lastModifiedDate` an explicit field on an `Ingest`; derive it from the list of IngestEvents when we need to display it. We were never setting it previously, now it’s marginally more useful. This fell out of refactoring to catch nulls. Closes https://github.com/wellcometrust/platform/issues/3773