### PR TITLE
Set the last modified date on an ingest

### DIFF
--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
@@ -36,7 +36,9 @@ class IngestsApiFeatureTest
     it("returns a ingest tracker when available") {
       val ingest = createIngestWith(
         createdDate = Instant.now(),
-        events = Seq(createIngestEvent, createIngestEvent).sortBy { _.createdDate }
+        events = Seq(createIngestEvent, createIngestEvent).sortBy {
+          _.createdDate
+        }
       )
 
       withConfiguredApp(initialIngests = Seq(ingest)) {

--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
@@ -36,7 +36,7 @@ class IngestsApiFeatureTest
     it("returns a ingest tracker when available") {
       val ingest = createIngestWith(
         createdDate = Instant.now(),
-        events = Seq(createIngestEvent, createIngestEvent)
+        events = Seq(createIngestEvent, createIngestEvent).sortBy { _.createdDate }
       )
 
       withConfiguredApp(initialIngests = Seq(ingest)) {
@@ -90,6 +90,7 @@ class IngestsApiFeatureTest
                      |    }
                      |  },
                      |  "createdDate": "${ingest.createdDate}",
+                     |  "lastModifiedDate": "${ingest.lastModifiedDate.get}",
                      |  "events": [
                      |    {
                      |      "type": "IngestEvent",

--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
@@ -236,7 +236,6 @@ class IngestsApiFeatureTest
                   status = Ingest.Accepted,
                   externalIdentifier = externalIdentifier,
                   createdDate = Instant.parse(actualIngest.createdDate),
-                  lastModifiedDate = None,
                   events = Nil
                 )
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/Ingest.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/Ingest.scala
@@ -14,9 +14,17 @@ case class Ingest(
   status: Ingest.Status,
   externalIdentifier: ExternalIdentifier,
   createdDate: Instant,
-  lastModifiedDate: Option[Instant] = None,
   events: Seq[IngestEvent] = Seq.empty
-)
+) {
+  def lastModifiedDate: Option[Instant] =
+    if (events.isEmpty) {
+      None
+    } else {
+      Some(
+        events.map { _.createdDate }.max
+      )
+    }
+}
 
 case object Ingest {
   sealed trait Status

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
@@ -49,7 +49,8 @@ trait IngestGenerators extends BagIdGenerators {
 
   def createIngestEventWith(
     description: String = randomAlphanumeric,
-    createdDate: Instant = Instant.now().plusSeconds(randomInt(from = 0, to = 30))
+    createdDate: Instant =
+      Instant.now().plusSeconds(randomInt(from = 0, to = 30))
   ): IngestEvent =
     IngestEvent(
       description = description,

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
@@ -49,7 +49,7 @@ trait IngestGenerators extends BagIdGenerators {
 
   def createIngestEventWith(
     description: String = randomAlphanumeric,
-    createdDate: Instant = randomInstant
+    createdDate: Instant = Instant.now().plusSeconds(randomInt(from = 0, to = 30))
   ): IngestEvent =
     IngestEvent(
       description = description,

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
@@ -45,7 +45,16 @@ trait IngestGenerators extends BagIdGenerators {
     )
 
   def createIngestEvent: IngestEvent =
-    IngestEvent(randomAlphanumeric)
+    createIngestEventWith()
+
+  def createIngestEventWith(
+    description: String = randomAlphanumeric,
+    createdDate: Instant = randomInstant
+  ): IngestEvent =
+    IngestEvent(
+      description = description,
+      createdDate = createdDate
+    )
 
   def createIngestEventUpdateWith(id: IngestID,
                                   events: List[IngestEvent] = List(

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/fixtures/TimeTestFixture.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/fixtures/TimeTestFixture.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.ingest.fixtures
+package uk.ac.wellcome.platform.archive.common.ingests.fixtures
 
 import java.time.{Duration, Instant}
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/models/IngestTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/models/IngestTest.scala
@@ -1,0 +1,28 @@
+package uk.ac.wellcome.platform.archive.common.ingests.models
+
+import java.time.Instant
+
+import org.scalatest.{FunSpec, Matchers}
+import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
+
+class IngestTest extends FunSpec with Matchers with IngestGenerators {
+  describe("sets the last modified date correctly") {
+    it("if there are no events, last modified date is None") {
+      val ingest = createIngestWith(events = Seq.empty)
+
+      ingest.lastModifiedDate shouldBe None
+    }
+
+    it("if there are events, last modified date is the latest") {
+      val events = Seq(1, 5, 3, 4, 2).map { t =>
+        createIngestEventWith(
+          createdDate = Instant.ofEpochSecond(t)
+        )
+      }
+
+      val ingest = createIngestWith(events = events)
+
+      ingest.lastModifiedDate shouldBe Some(Instant.ofEpochSecond(5))
+    }
+  }
+}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
@@ -14,7 +14,7 @@ import uk.ac.wellcome.platform.archive.common.generators.{
   BagGenerators,
   StorageSpaceGenerators
 }
-import uk.ac.wellcome.platform.archive.common.ingest.fixtures.TimeTestFixture
+import uk.ac.wellcome.platform.archive.common.ingests.fixtures.TimeTestFixture
 import uk.ac.wellcome.platform.archive.common.ingests.models.{
   InfrequentAccessStorageProvider,
   StorageLocation

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayIngestTest.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayIngestTest.scala
@@ -8,7 +8,7 @@ import uk.ac.wellcome.platform.archive.common.generators.{
   BagIdGenerators,
   IngestGenerators
 }
-import uk.ac.wellcome.platform.archive.common.ingest.fixtures.TimeTestFixture
+import uk.ac.wellcome.platform.archive.common.ingests.fixtures.TimeTestFixture
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.ObjectLocation

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayIngestTest.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayIngestTest.scala
@@ -26,7 +26,6 @@ class DisplayIngestTest
   private val callbackUrl = "http://www.example.com/callback"
   private val spaceId = "space-id"
   private val createdDate = "2018-10-10T09:38:55.321Z"
-  private val modifiedDate = "2018-10-10T09:38:55.322Z"
   private val eventDate = "2018-10-10T09:38:55.323Z"
   private val eventDescription = "Event description"
   private val contextUrl = new URL(
@@ -48,7 +47,6 @@ class DisplayIngestTest
         status = Ingest.Processing,
         externalIdentifier = externalIdentifier,
         createdDate = Instant.parse(createdDate),
-        lastModifiedDate = Some(Instant.parse(modifiedDate)),
         events = List(IngestEvent(eventDescription, Instant.parse(eventDate)))
       )
 
@@ -70,7 +68,7 @@ class DisplayIngestTest
       displayIngest.status shouldBe DisplayStatus("processing")
       displayIngest.bag.info.externalIdentifier shouldBe externalIdentifier
       displayIngest.createdDate shouldBe createdDate
-      displayIngest.lastModifiedDate.get shouldBe modifiedDate
+      displayIngest.lastModifiedDate.get shouldBe eventDate
       displayIngest.events shouldBe List(
         DisplayIngestEvent(eventDescription, eventDate)
       )
@@ -150,7 +148,6 @@ class DisplayIngestTest
       ingest.status shouldBe Ingest.Accepted
       ingest.externalIdentifier shouldBe externalIdentifier
       assertRecent(ingest.createdDate)
-      ingest.lastModifiedDate shouldBe None
       ingest.events shouldBe empty
     }
 

--- a/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/tracker/fixtures/IngestTrackerFixtures.scala
+++ b/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/tracker/fixtures/IngestTrackerFixtures.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.archive.common.ingests.tracker.fixtures
 
 import org.scalatest.EitherValues
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.archive.common.ingest.fixtures.TimeTestFixture
+import uk.ac.wellcome.platform.archive.common.ingests.fixtures.TimeTestFixture
 import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestID}
 import uk.ac.wellcome.platform.archive.common.ingests.tracker.memory.MemoryIngestTracker
 import uk.ac.wellcome.storage.Version

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
@@ -14,7 +14,7 @@ import org.scalatest.{FunSpec, Inside, Matchers}
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
-import uk.ac.wellcome.platform.archive.common.ingest.fixtures.TimeTestFixture
+import uk.ac.wellcome.platform.archive.common.ingests.fixtures.TimeTestFixture
 import uk.ac.wellcome.platform.archive.common.ingests.models.{
   Callback,
   CallbackNotification,

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/PrepareNotificationServiceTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/PrepareNotificationServiceTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.{Assertion, FunSpec, Matchers}
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
-import uk.ac.wellcome.platform.archive.common.ingest.fixtures.TimeTestFixture
+import uk.ac.wellcome.platform.archive.common.ingests.fixtures.TimeTestFixture
 import uk.ac.wellcome.platform.archive.common.ingests.models.{
   Callback,
   IngestID


### PR DESCRIPTION
Closes https://github.com/wellcometrust/platform/issues/3773. Spun out as a separate piece from #280.

Rather than setting the last modified date explicitly, we compute it from the latest IngestEvent date.