### PR TITLE
Don't send nulls in the notifier callbacks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,7 @@ lazy val notifier = setupProject(
   project,
   "notifier",
   localDependencies = Seq(common, display),
-  externalDependencies = ExternalDependencies.wiremockDependencies)
+  externalDependencies = ExternalDependencies.wiremockDependencies ++ ExternalDependencies.circeOpticsDependencies)
 
 lazy val ingests_api = setupProject(
   project,

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
@@ -47,6 +47,11 @@ trait IngestGenerators extends BagIdGenerators {
   def createIngestEvent: IngestEvent =
     createIngestEventWith()
 
+  def createIngestEvents(count: Int): Seq[IngestEvent] =
+    (1 to count)
+      .map { _ => createIngestEvent }
+      .sortBy { _.createdDate }
+
   def createIngestEventWith(
     description: String = randomAlphanumeric,
     createdDate: Instant =

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
@@ -49,7 +49,9 @@ trait IngestGenerators extends BagIdGenerators {
 
   def createIngestEvents(count: Int): Seq[IngestEvent] =
     (1 to count)
-      .map { _ => createIngestEvent }
+      .map { _ =>
+        createIngestEvent
+      }
       .sortBy { _.createdDate }
 
   def createIngestEventWith(

--- a/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlService.scala
+++ b/notifier/src/main/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlService.scala
@@ -47,8 +47,11 @@ class CallbackUrlService(contextUrl: URL)(implicit actorSystem: ActorSystem,
                       callbackUri: URI): Future[Try[HttpResponse]] = {
     val request = buildHttpRequest(ingest, callbackUri)
 
-    Http().singleRequest(request)
-      .map { resp => Success(resp) }
+    Http()
+      .singleRequest(request)
+      .map { resp =>
+        Success(resp)
+      }
       .recover { case err => Failure(err) }
   }
 }

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
@@ -52,7 +52,8 @@ class NotifierFeatureTest
 
             val ingest = createIngestWith(
               id = ingestId,
-              callback = Some(createCallbackWith(uri = callbackUri))
+              callback = Some(createCallbackWith(uri = callbackUri)),
+              events = createIngestEvents(count = 2)
             )
 
             sendNotificationToSQS(

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
@@ -2,12 +2,7 @@ package uk.ac.wellcome.platform.archive.notifier
 
 import java.net.URI
 
-import com.github.tomakehurst.wiremock.client.WireMock.{
-  equalToJson,
-  postRequestedFor,
-  urlPathEqualTo,
-  _
-}
+import com.github.tomakehurst.wiremock.client.WireMock._
 import org.apache.http.HttpStatus
 import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.{FunSpec, Inside, Matchers}
@@ -21,7 +16,6 @@ import uk.ac.wellcome.platform.archive.common.ingests.models.{
   IngestCallbackStatusUpdate,
   IngestUpdate
 }
-import uk.ac.wellcome.platform.archive.display._
 import uk.ac.wellcome.platform.archive.notifier.fixtures.{
   LocalWireMockFixture,
   NotifierFixtures
@@ -122,7 +116,6 @@ class NotifierFeatureTest
 
             eventually {
               wireMock.verifyThat(
-                1,
                 postRequestedFor(urlPathEqualTo(callbackUri.getPath))
                   .withRequestBody(equalToJson(expectedJson))
               )
@@ -162,7 +155,8 @@ class NotifierFeatureTest
 
               val ingest = createIngestWith(
                 id = ingestID,
-                callback = Some(createCallbackWith(uri = callbackUri))
+                callback = Some(createCallbackWith(uri = callbackUri)),
+                events = createIngestEvents(count = 2)
               )
 
               sendNotificationToSQS(
@@ -170,38 +164,70 @@ class NotifierFeatureTest
                 CallbackNotification(ingestID, callbackUri, ingest)
               )
 
-              val expectedResponse = ResponseDisplayIngest(
-                context = "http://localhost/context.json",
-                id = ingest.id.underlying,
-                sourceLocation = DisplayLocation(
-                  StandardDisplayProvider,
-                  ingest.sourceLocation.location.namespace,
-                  ingest.sourceLocation.location.path),
-                callback = ingest.callback.map(DisplayCallback(_)),
-                ingestType = DisplayIngestType(ingest.ingestType),
-                space = DisplayStorageSpace(ingest.space.underlying),
-                status = DisplayStatus(ingest.status.toString),
-                bag = RequestDisplayBag(
-                  info = RequestDisplayBagInfo(
-                    externalIdentifier = ingest.externalIdentifier
-                  )
-                ),
-                events = ingest.events.map(
-                  event =>
-                    DisplayIngestEvent(
-                      event.description,
-                      event.createdDate.toString)),
-                createdDate = ingest.createdDate.toString,
-                lastModifiedDate = ingest.lastModifiedDate.map {
-                  _.toString
-                }
-              )
+              val expectedJson =
+                s"""
+                   |{
+                   |  "@context": "http://localhost/context.json",
+                   |  "id": "${ingest.id.toString}",
+                   |  "type": "Ingest",
+                   |  "ingestType": {
+                   |    "id": "${ingest.ingestType.id}",
+                   |    "type": "IngestType"
+                   |  },
+                   |  "space": {
+                   |    "id": "${ingest.space.underlying}",
+                   |    "type": "Space"
+                   |  },
+                   |  "bag": {
+                   |    "type": "Bag",
+                   |    "info": {
+                   |      "type": "BagInfo",
+                   |      "externalIdentifier": "${ingest.externalIdentifier.underlying}"
+                   |    }
+                   |  },
+                   |  "status": {
+                   |    "id": "${ingest.status.toString}",
+                   |    "type": "Status"
+                   |  },
+                   |  "sourceLocation": {
+                   |    "type": "Location",
+                   |    "provider": {
+                   |      "type": "Provider",
+                   |      "id": "aws-s3-standard"
+                   |    },
+                   |    "bucket": "${ingest.sourceLocation.location.namespace}",
+                   |    "path": "${ingest.sourceLocation.location.path}"
+                   |  },
+                   |  "callback": {
+                   |    "type": "Callback",
+                   |    "url": "${ingest.callback.get.uri}",
+                   |    "status": {
+                   |      "id": "${ingest.callback.get.status.toString}",
+                   |      "type": "Status"
+                   |    }
+                   |  },
+                   |  "createdDate": "${ingest.createdDate}",
+                   |  "lastModifiedDate": "${ingest.lastModifiedDate.get}",
+                   |  "events": [
+                   |    {
+                   |      "type": "IngestEvent",
+                   |      "createdDate": "${ingest.events(0).createdDate}",
+                   |      "description": "${ingest.events(0).description}"
+                   |    },
+                   |    {
+                   |      "type": "IngestEvent",
+                   |      "createdDate": "${ingest.events(1).createdDate}",
+                   |      "description": "${ingest.events(1).description}"
+                   |    }
+                   |  ]
+                   |}
+                 """.stripMargin
 
               eventually {
                 wireMock.verifyThat(
                   1,
                   postRequestedFor(urlPathEqualTo(callbackUri.getPath))
-                    .withRequestBody(equalToJson(toJson(expectedResponse).get))
+                    .withRequestBody(equalToJson(expectedJson))
                 )
 
                 val updates = messageSender.getMessages[IngestUpdate]

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlServiceTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlServiceTest.scala
@@ -2,7 +2,12 @@ package uk.ac.wellcome.platform.archive.notifier.services
 
 import java.net.URI
 
-import akka.http.scaladsl.model.{ContentTypes, HttpMethods, HttpRequest, StatusCodes}
+import akka.http.scaladsl.model.{
+  ContentTypes,
+  HttpMethods,
+  HttpRequest,
+  StatusCodes
+}
 import akka.stream.scaladsl.Sink
 import io.circe.optics.JsonPath.root
 import io.circe.parser.parse
@@ -11,7 +16,10 @@ import org.scalatest.{Assertion, EitherValues, FunSpec, Matchers}
 import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
-import uk.ac.wellcome.platform.archive.notifier.fixtures.{LocalWireMockFixture, NotifierFixtures}
+import uk.ac.wellcome.platform.archive.notifier.fixtures.{
+  LocalWireMockFixture,
+  NotifierFixtures
+}
 
 class CallbackUrlServiceTest
     extends FunSpec
@@ -32,8 +40,8 @@ class CallbackUrlServiceTest
 
           val future = service.getHttpResponse(
             ingest = ingest,
-            callbackUri =
-              new URI(s"http://$callbackHost:$callbackPort/callback/${ingest.id}")
+            callbackUri = new URI(
+              s"http://$callbackHost:$callbackPort/callback/${ingest.id}")
           )
 
           whenReady(future) { result =>

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlServiceTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlServiceTest.scala
@@ -71,7 +71,7 @@ class CallbackUrlServiceTest
       val ingest = createIngestWith(
         id = ingestId,
         callback = Some(createCallbackWith(uri = callbackUri)),
-        events = Seq(createIngestEvent, createIngestEvent).sortBy { _.createdDate }
+        events = createIngestEvents(count = 2)
       )
 
       val request = buildRequest(ingest, callbackUri)

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlServiceTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/services/CallbackUrlServiceTest.scala
@@ -2,61 +2,184 @@ package uk.ac.wellcome.platform.archive.notifier.services
 
 import java.net.URI
 
-import akka.http.scaladsl.model.StatusCodes
+import akka.http.scaladsl.model.{ContentTypes, HttpMethods, HttpRequest, StatusCodes}
+import akka.stream.scaladsl.Sink
+import io.circe.optics.JsonPath.root
+import io.circe.parser.parse
 import org.scalatest.concurrent.{IntegrationPatience, ScalaFutures}
-import org.scalatest.{FunSpec, Matchers}
-import uk.ac.wellcome.akka.fixtures.Akka
+import org.scalatest.{Assertion, EitherValues, FunSpec, Matchers}
+import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
-import uk.ac.wellcome.platform.archive.notifier.fixtures.{
-  LocalWireMockFixture,
-  NotifierFixtures
-}
+import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest
+import uk.ac.wellcome.platform.archive.notifier.fixtures.{LocalWireMockFixture, NotifierFixtures}
 
 class CallbackUrlServiceTest
     extends FunSpec
     with Matchers
     with ScalaFutures
+    with EitherValues
     with IntegrationPatience
-    with Akka
     with NotifierFixtures
     with LocalWireMockFixture
-    with IngestGenerators {
+    with IngestGenerators
+    with JsonAssertions {
 
-  it("returns a Success if the request succeeds") {
-    withActorSystem { implicit actorSystem =>
-      withCallbackUrlService { service =>
-        val ingest = createIngest
+  describe("sends the request successfully") {
+    it("returns a Success if the request succeeds") {
+      withActorSystem { implicit actorSystem =>
+        withCallbackUrlService { service =>
+          val ingest = createIngest
 
-        val future = service.getHttpResponse(
-          ingest = ingest,
-          callbackUri =
-            new URI(s"http://$callbackHost:$callbackPort/callback/${ingest.id}")
-        )
+          val future = service.getHttpResponse(
+            ingest = ingest,
+            callbackUri =
+              new URI(s"http://$callbackHost:$callbackPort/callback/${ingest.id}")
+          )
 
-        whenReady(future) { result =>
-          result.isSuccess shouldBe true
-          result.get.status shouldBe StatusCodes.NotFound
+          whenReady(future) { result =>
+            result.isSuccess shouldBe true
+            result.get.status shouldBe StatusCodes.NotFound
+          }
+        }
+      }
+    }
+
+    it("returns a failed future if the HTTP request fails") {
+      withActorSystem { implicit actorSystem =>
+        withCallbackUrlService { service =>
+          val ingest = createIngest
+
+          val future = service.getHttpResponse(
+            ingest = ingest,
+            callbackUri = new URI(s"http://nope.nope/callback/${ingest.id}")
+          )
+
+          whenReady(future) { result =>
+            result.isFailure shouldBe true
+          }
         }
       }
     }
   }
 
-  it("returns a failed future if the HTTP request fails") {
-    withActorSystem { implicit actorSystem =>
-      withCallbackUrlService { service =>
-        val ingest = createIngest
+  describe("builds the correct HTTP request") {
+    it("creates a JSON string") {
+      val ingestId = createIngestID
 
-        val future = service.getHttpResponse(
-          ingest = ingest,
-          callbackUri = new URI(s"http://nope.nope/callback/${ingest.id}")
+      val callbackUri = new URI(s"http://example.org/callback/$ingestId")
+
+      val ingest = createIngestWith(
+        id = ingestId,
+        callback = Some(createCallbackWith(uri = callbackUri)),
+        events = Seq(createIngestEvent, createIngestEvent).sortBy { _.createdDate }
+      )
+
+      val request = buildRequest(ingest, callbackUri)
+
+      assertIsJsonRequest(request, uri = callbackUri) { requestJsonString =>
+        assertJsonStringsAreEqual(
+          requestJsonString,
+          s"""
+             |{
+             |  "@context": "http://localhost/context.json",
+             |  "id": "${ingestId.toString}",
+             |  "type": "Ingest",
+             |  "ingestType": {
+             |    "id": "${ingest.ingestType.id}",
+             |    "type": "IngestType"
+             |  },
+             |  "space": {
+             |    "id": "${ingest.space.underlying}",
+             |    "type": "Space"
+             |  },
+             |  "bag": {
+             |    "type": "Bag",
+             |    "info": {
+             |      "type": "BagInfo",
+             |      "externalIdentifier": "${ingest.externalIdentifier.underlying}"
+             |    }
+             |  },
+             |  "status": {
+             |    "id": "${ingest.status.toString}",
+             |    "type": "Status"
+             |  },
+             |  "sourceLocation": {
+             |    "type": "Location",
+             |    "provider": {
+             |      "type": "Provider",
+             |      "id": "aws-s3-standard"
+             |    },
+             |    "bucket": "${ingest.sourceLocation.location.namespace}",
+             |    "path": "${ingest.sourceLocation.location.path}"
+             |  },
+             |  "callback": {
+             |    "type": "Callback",
+             |    "url": "${ingest.callback.get.uri}",
+             |    "status": {
+             |      "id": "${ingest.callback.get.status.toString}",
+             |      "type": "Status"
+             |    }
+             |  },
+             |  "createdDate": "${ingest.createdDate}",
+             |  "lastModifiedDate": "${ingest.lastModifiedDate.get}",
+             |  "events": [
+             |    {
+             |      "type": "IngestEvent",
+             |      "createdDate": "${ingest.events(0).createdDate}",
+             |      "description": "${ingest.events(0).description}"
+             |    },
+             |    {
+             |      "type": "IngestEvent",
+             |      "createdDate": "${ingest.events(1).createdDate}",
+             |      "description": "${ingest.events(1).description}"
+             |    }
+             |  ]
+             |}
+                 """.stripMargin
         )
-
-        whenReady(future) { result =>
-          result.isFailure shouldBe true
-        }
       }
     }
-  }
 
-  // TODO: Add a test that it sends the correct POST payload.
+    it("omits null values from the JSON") {
+      val callbackUri = new URI(s"http://example.org/callback/$createIngestID")
+
+      val ingest = createIngestWith(
+        events = Seq.empty
+      )
+
+      ingest.lastModifiedDate shouldBe None
+
+      val request = buildRequest(ingest, callbackUri)
+
+      assertIsJsonRequest(request, uri = callbackUri) { requestJsonString =>
+        val json = parse(requestJsonString).right.value
+        root.lastModifiedDate.string.getOption(json) shouldBe None
+      }
+    }
+
+    def buildRequest(ingest: Ingest, callbackUri: URI): HttpRequest =
+      withActorSystem { implicit actorSystem =>
+        withCallbackUrlService { service =>
+          service.buildHttpRequest(
+            ingest = ingest,
+            callbackUri = callbackUri
+          )
+        }
+      }
+
+    def assertIsJsonRequest(request: HttpRequest, uri: URI)(
+      assertJson: String => Assertion): Assertion = {
+      request.method shouldBe HttpMethods.POST
+      request.uri.toString() shouldBe uri.toString
+
+      withMaterializer { implicit materializer =>
+        val future = request.entity.dataBytes.runWith(Sink.seq)
+        whenReady(future) { byteString =>
+          assertJson(byteString.head.utf8String)
+        }
+      }
+
+      request.entity.contentType shouldBe ContentTypes.`application/json`
+    }
+  }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -88,7 +88,7 @@ object ExternalDependencies {
   )
 
   val circeOpticsDependencies = Seq[ModuleID](
-    "io.circe" %% "circe-optics" % versions.circe
+    "io.circe" %% "circe-optics" % versions.circe % "test"
   )
 
   val scalatestDependencies = Seq[ModuleID](

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -68,7 +68,7 @@ object ExternalDependencies {
     val akkaStreamAlpakka = "0.20"
     val commonsCompress = "1.5"
     val commonsIO = "2.6"
-    val aws = "1.11.95"
+    val aws = "1.11.504"
     val circe = "0.9.0"
     val scalatest = "3.0.1"
     val wiremock = "2.18.0"


### PR DESCRIPTION
Spotted while working on https://github.com/wellcometrust/platform/issues/3770, pulled out of #280.

The notifier should now send the same output as the ingests service – no nulls for missing entries! Plus stricter tests for the exact JSON output we expect.

Assumes #282, so that will need to be merged first.