### PR TITLE
Track the ingest version internally

### DIFF
--- a/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
+++ b/bag_auditor/src/main/scala/uk/ac/wellcome/platform/storage/bagauditor/services/BagAuditorWorker.scala
@@ -5,6 +5,11 @@ import com.amazonaws.services.sqs.AmazonSQSAsync
 import io.circe.Decoder
 import uk.ac.wellcome.messaging.sqsworker.alpakka.AlpakkaSQSWorkerConfig
 import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  IngestEvent,
+  IngestID,
+  IngestVersionUpdate
+}
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services._
 import uk.ac.wellcome.platform.archive.common.storage.models.{
@@ -39,7 +44,7 @@ class BagAuditorWorker[IngestDestination, OutgoingDestination](
     for {
       _ <- ingestUpdater.start(ingestId = payload.ingestId)
 
-      auditStep <- bagAuditor.getAuditSummary(
+      stepResult <- bagAuditor.getAuditSummary(
         ingestId = payload.ingestId,
         ingestDate = payload.ingestDate,
         ingestType = payload.ingestType,
@@ -47,9 +52,30 @@ class BagAuditorWorker[IngestDestination, OutgoingDestination](
         storageSpace = payload.storageSpace
       )
 
-      _ <- ingestUpdater.send(payload.ingestId, auditStep)
-      _ <- sendSuccessful(payload)(auditStep)
-    } yield auditStep
+      _ <- sendIngestUpdate(payload.ingestId, stepResult)
+      _ <- sendSuccessful(payload)(stepResult)
+    } yield stepResult
+
+  private def sendIngestUpdate(
+    ingestId: IngestID,
+    stepResult: IngestStepResult[AuditSummary]): Try[Unit] =
+    stepResult match {
+      case IngestStepSucceeded(summary: AuditSuccessSummary, _) =>
+        val update = IngestVersionUpdate(
+          id = ingestId,
+          events = Seq(
+            IngestEvent(
+              s"${ingestUpdater.stepName.capitalize} succeeded - assigned bag version ${summary.version}"
+            )
+          ),
+          version = summary.version
+        )
+
+        ingestUpdater.sendUpdate(update)
+
+      case _ =>
+        ingestUpdater.send(ingestId, stepResult)
+    }
 
   private def sendSuccessful(payload: BagRootLocationPayload)(
     step: IngestStepResult[AuditSummary]): Try[Unit] =

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
@@ -68,16 +68,14 @@ class BagAuditorFeatureTest
                 ingestUpdates should have size 2
 
                 ingestUpdates(0) shouldBe a[IngestEventUpdate]
-                ingestUpdates(0)
-                  .events.map { _.description } shouldBe Seq(
+                ingestUpdates(0).events.map { _.description } shouldBe Seq(
                   "Auditing bag started")
 
                 ingestUpdates(1) shouldBe a[IngestVersionUpdate]
                 ingestUpdates(1)
                   .asInstanceOf[IngestVersionUpdate]
                   .version shouldBe BagVersion(1)
-                ingestUpdates(1)
-                  .events.map { _.description } shouldBe Seq(
+                ingestUpdates(1).events.map { _.description } shouldBe Seq(
                   "Auditing bag succeeded - assigned bag version v1")
             }
           }

--- a/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
+++ b/bag_auditor/src/test/scala/uk/ac/wellcome/platform/storage/bagauditor/BagAuditorFeatureTest.scala
@@ -6,16 +6,15 @@ import org.scalatest.FunSpec
 import org.scalatest.concurrent.Eventually
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
+import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion
+import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion._
 import uk.ac.wellcome.platform.archive.common.generators.{
   ExternalIdentifierGenerators,
   PayloadGenerators,
   StorageSpaceGenerators
 }
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  CreateIngestType,
-  UpdateIngestType
-}
+import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.{
   BagRootLocationPayload,
   EnrichedBagInformationPayload
@@ -64,14 +63,23 @@ class BagAuditorFeatureTest
               .getMessages[EnrichedBagInformationPayload] shouldBe Seq(
               expectedPayload)
 
-            assertTopicReceivesIngestEvents(
-              payload.ingestId,
-              ingests,
-              expectedDescriptions = Seq(
-                "Auditing bag started",
-                "Auditing bag succeeded - Assigned bag version v1"
-              )
-            )
+            assertTopicReceivesIngestUpdates(payload.ingestId, ingests) {
+              ingestUpdates =>
+                ingestUpdates should have size 2
+
+                ingestUpdates(0) shouldBe a[IngestEventUpdate]
+                ingestUpdates(0)
+                  .events.map { _.description } shouldBe Seq(
+                  "Auditing bag started")
+
+                ingestUpdates(1) shouldBe a[IngestVersionUpdate]
+                ingestUpdates(1)
+                  .asInstanceOf[IngestVersionUpdate]
+                  .version shouldBe BagVersion(1)
+                ingestUpdates(1)
+                  .events.map { _.description } shouldBe Seq(
+                  "Auditing bag succeeded - assigned bag version v1")
+            }
           }
       }
     }
@@ -114,14 +122,21 @@ class BagAuditorFeatureTest
             outgoing
               .getMessages[EnrichedBagInformationPayload] should have size 1
 
-            assertTopicReceivesIngestEvents(
-              payload1.ingestId,
-              ingests,
-              expectedDescriptions = Seq(
-                "Auditing bag started",
-                "Auditing bag succeeded - Assigned bag version v1"
-              )
-            )
+            assertTopicReceivesIngestUpdates(payload1.ingestId, ingests) {
+              ingestUpdates =>
+                ingestUpdates should have size 2
+
+                ingestUpdates(0) shouldBe a[IngestEventUpdate]
+                ingestUpdates(0).events.map { _.description } shouldBe Seq(
+                  "Auditing bag started")
+
+                ingestUpdates(1) shouldBe a[IngestVersionUpdate]
+                ingestUpdates(1)
+                  .asInstanceOf[IngestVersionUpdate]
+                  .version shouldBe BagVersion(1)
+                ingestUpdates(1).events.map { _.description } shouldBe Seq(
+                  "Auditing bag succeeded - assigned bag version v1")
+            }
           }
 
           // Now send the payload with "update"
@@ -133,21 +148,34 @@ class BagAuditorFeatureTest
             outgoing
               .getMessages[EnrichedBagInformationPayload] should have size 2
 
-            assertTopicReceivesIngestEvents(
-              payload1.ingestId,
-              ingests,
-              expectedDescriptions = Seq(
-                "Auditing bag started",
-                "Auditing bag succeeded - Assigned bag version v1",
-                "Auditing bag started",
-                "Auditing bag succeeded - Assigned bag version v2"
-              )
-            )
+            assertTopicReceivesIngestUpdates(payload1.ingestId, ingests) {
+              ingestUpdates =>
+                ingestUpdates should have size 4
+
+                ingestUpdates(0) shouldBe a[IngestEventUpdate]
+                ingestUpdates(0).events.map { _.description } shouldBe Seq(
+                  "Auditing bag started")
+
+                ingestUpdates(1) shouldBe a[IngestVersionUpdate]
+                ingestUpdates(1)
+                  .asInstanceOf[IngestVersionUpdate]
+                  .version shouldBe BagVersion(1)
+                ingestUpdates(1).events.map { _.description } shouldBe Seq(
+                  "Auditing bag succeeded - assigned bag version v1")
+
+                ingestUpdates(2) shouldBe a[IngestEventUpdate]
+                ingestUpdates(2).events.map { _.description } shouldBe Seq(
+                  "Auditing bag started")
+
+                ingestUpdates(3) shouldBe a[IngestVersionUpdate]
+                ingestUpdates(3)
+                  .asInstanceOf[IngestVersionUpdate]
+                  .version shouldBe BagVersion(2)
+                ingestUpdates(3).events.map { _.description } shouldBe Seq(
+                  "Auditing bag succeeded - assigned bag version v2")
+            }
           }
       }
     }
   }
-
-  // TODO: When we pass an ingest type in the bag auditor payload, check it sends
-  // an appropriate user-facing message in the ingests app.
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/Ingest.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/Ingest.scala
@@ -2,7 +2,10 @@ package uk.ac.wellcome.platform.archive.common.ingests.models
 
 import java.time.Instant
 
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagVersion,
+  ExternalIdentifier
+}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 
 case class Ingest(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/Ingest.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/Ingest.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.archive.common.ingests.models
 
 import java.time.Instant
 
-import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
+import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 
 case class Ingest(
@@ -13,6 +13,7 @@ case class Ingest(
   callback: Option[Callback],
   status: Ingest.Status,
   externalIdentifier: ExternalIdentifier,
+  version: Option[BagVersion] = None,
   createdDate: Instant,
   events: Seq[IngestEvent] = Seq.empty
 ) {

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/IngestUpdate.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/IngestUpdate.scala
@@ -1,5 +1,7 @@
 package uk.ac.wellcome.platform.archive.common.ingests.models
 
+import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion
+
 sealed trait IngestUpdate {
   val id: IngestID
   val events: Seq[IngestEvent]
@@ -10,7 +12,7 @@ case class IngestEventUpdate(id: IngestID, events: Seq[IngestEvent])
 
 case class IngestStatusUpdate(id: IngestID,
                               status: Ingest.Status,
-                              events: Seq[IngestEvent] = List.empty)
+                              events: Seq[IngestEvent] = Seq.empty)
     extends IngestUpdate
 
 case class IngestCallbackStatusUpdate(
@@ -29,3 +31,9 @@ case object IngestCallbackStatusUpdate {
       events = List(IngestEvent(description))
     )
 }
+
+case class IngestVersionUpdate(
+  id: IngestID,
+  events: Seq[IngestEvent],
+  version: BagVersion
+) extends IngestUpdate

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/IngestUpdate.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/IngestUpdate.scala
@@ -1,24 +1,8 @@
 package uk.ac.wellcome.platform.archive.common.ingests.models
 
-import uk.ac.wellcome.platform.archive.common.bagit.models.error.ArchiveError
-
 sealed trait IngestUpdate {
   val id: IngestID
   val events: Seq[IngestEvent]
-}
-
-object IngestUpdate {
-
-  def failed[T](id: IngestID, error: ArchiveError[T]) =
-    IngestStatusUpdate(
-      id = id,
-      status = Ingest.Failed,
-      events = List(IngestEvent(error.toString))
-    )
-
-  def event(id: IngestID, description: String) =
-    IngestEventUpdate(id, Seq(IngestEvent(description)))
-
 }
 
 case class IngestEventUpdate(id: IngestID, events: Seq[IngestEvent])

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestStates.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestStates.scala
@@ -12,8 +12,8 @@ class IngestStatusGoingBackwardsException(val existing: Ingest.Status,
 
 class MismatchedVersionUpdateException(val existing: BagVersion,
                                        val update: BagVersion)
-  extends RuntimeException(
-    s"Received bag version update $update, but ingest already has version $existing")
+    extends RuntimeException(
+      s"Received bag version update $update, but ingest already has version $existing")
 
 class CallbackStatusGoingBackwardsException(
   val existing: Callback.CallbackStatus,

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdater.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdater.scala
@@ -36,26 +36,38 @@ class IngestUpdater[Destination](stepName: String,
         )
 
       case IngestStepSucceeded(_, maybeMessage) =>
-        IngestUpdate.event(
+        IngestEventUpdate(
           id = ingestId,
-          description = eventDescription(
-            s"${stepName.capitalize} succeeded",
-            maybeMessage
+          events = Seq(
+            IngestEvent(
+              description = eventDescription(
+                s"${stepName.capitalize} succeeded",
+                maybeMessage
+              )
+            )
           )
         )
 
       case IngestStepStarted(_) =>
-        IngestUpdate.event(
+        IngestEventUpdate(
           id = ingestId,
-          description = s"${stepName.capitalize} started"
+          events = Seq(
+            IngestEvent(
+              description = s"${stepName.capitalize} started"
+            )
+          )
         )
 
       case IngestShouldRetry(_, _, maybeMessage) =>
-        IngestUpdate.event(
+        IngestEventUpdate(
           id = ingestId,
-          description = eventDescription(
-            s"${stepName.capitalize} retrying",
-            maybeMessage
+          events = Seq(
+            IngestEvent(
+              description = eventDescription(
+                s"${stepName.capitalize} retrying",
+                maybeMessage
+              )
+            )
           )
         )
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdater.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestUpdater.scala
@@ -8,7 +8,7 @@ import uk.ac.wellcome.platform.archive.common.storage.models._
 
 import scala.util.Try
 
-class IngestUpdater[Destination](stepName: String,
+class IngestUpdater[Destination](val stepName: String,
                                  messageSender: MessageSender[Destination])
     extends Logging {
 
@@ -83,8 +83,11 @@ class IngestUpdater[Destination](stepName: String,
         )
     }
 
-    messageSender.sendT[IngestUpdate](update)
+    sendUpdate(update)
   }
+
+  def sendUpdate(update: IngestUpdate): Try[Unit] =
+    messageSender.sendT[IngestUpdate](update)
 
   def sendEvent(ingestId: IngestID, messages: Seq[String]): Try[Unit] = {
     debug(s"Sending an ingest event for ID=$ingestId messages=$messages")

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
@@ -3,11 +3,13 @@ package uk.ac.wellcome.platform.archive.common.generators
 import java.net.URI
 import java.time.Instant
 
-import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
+import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest.Status
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.ObjectLocation
+
+import scala.util.Random
 
 trait IngestGenerators extends BagIdGenerators {
 
@@ -22,6 +24,13 @@ trait IngestGenerators extends BagIdGenerators {
   val testCallbackUri =
     new URI("http://www.wellcomecollection.org/callback/ok")
 
+  private def maybeVersion: Option[BagVersion] =
+    if (Random.nextBoolean()) {
+      Some(BagVersion(Random.nextInt))
+    } else {
+      None
+    }
+
   def createIngestWith(id: IngestID = createIngestID,
                        ingestType: IngestType = CreateIngestType,
                        sourceLocation: StorageLocation = storageLocation,
@@ -30,6 +39,7 @@ trait IngestGenerators extends BagIdGenerators {
                        status: Status = Ingest.Accepted,
                        externalIdentifier: ExternalIdentifier =
                          createExternalIdentifier,
+                       version: Option[BagVersion] = maybeVersion,
                        createdDate: Instant = randomInstant,
                        events: Seq[IngestEvent] = Seq.empty): Ingest =
     Ingest(
@@ -40,6 +50,7 @@ trait IngestGenerators extends BagIdGenerators {
       space = space,
       status = status,
       externalIdentifier = externalIdentifier,
+      version = version,
       createdDate = createdDate,
       events = events
     )
@@ -94,6 +105,18 @@ trait IngestGenerators extends BagIdGenerators {
 
   def createIngestStatusUpdate: IngestStatusUpdate =
     createIngestStatusUpdateWith()
+
+  def createIngestVersionUpdateWith(
+    id: IngestID = createIngestID,
+    events: Seq[IngestEvent] = Seq(createIngestEvent),
+    version: BagVersion = BagVersion(Random.nextInt)
+  ): IngestVersionUpdate =
+    IngestVersionUpdate(
+      id = id,
+      events = events,
+      version = version
+    )
+
 
   def createCallback(): Callback = createCallbackWith()
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
@@ -58,7 +58,7 @@ trait IngestGenerators extends BagIdGenerators {
     )
 
   def createIngestEventUpdateWith(id: IngestID,
-                                  events: List[IngestEvent] = List(
+                                  events: Seq[IngestEvent] = List(
                                     createIngestEvent)): IngestEventUpdate =
     IngestEventUpdate(
       id = id,

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
@@ -3,7 +3,10 @@ package uk.ac.wellcome.platform.archive.common.generators
 import java.net.URI
 import java.time.Instant
 
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagVersion,
+  ExternalIdentifier
+}
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest.Status
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
@@ -116,7 +119,6 @@ trait IngestGenerators extends BagIdGenerators {
       events = events,
       version = version
     )
-
 
   def createCallback(): Callback = createCallbackWith()
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/fixtures/IngestUpdateAssertions.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/fixtures/IngestUpdateAssertions.scala
@@ -30,7 +30,7 @@ trait IngestUpdateAssertions extends Inside with Logging with Matchers {
         .partition(_.isSuccess)
 
       if (success.size != 1) {
-        println(s"Failures: $failures")
+        debug(s"Failures: $failures")
       }
 
       success should have size 1
@@ -65,7 +65,7 @@ trait IngestUpdateAssertions extends Inside with Logging with Matchers {
 
       val (success, _) = ingestUpdates
         .map { ingestUpdate =>
-          println(s"Received IngestUpdate: $ingestUpdate")
+          debug(s"Received IngestUpdate: $ingestUpdate")
           Try(inside(ingestUpdate) {
             case IngestEventUpdate(id, events) =>
               id shouldBe ingestId

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/fixtures/IngestUpdateAssertions.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/fixtures/IngestUpdateAssertions.scala
@@ -4,6 +4,7 @@ import grizzled.slf4j.Logging
 import org.scalatest.{Assertion, Inside, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
+import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion._
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 
 import scala.util.Try

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestStatesTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestStatesTest.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 
 sealed trait IngestUpdateTestCases[UpdateType <: IngestUpdate]
-  extends FunSpec
+    extends FunSpec
     with Matchers
     with IngestGenerators
     with TryValues {
@@ -63,7 +63,7 @@ sealed trait IngestUpdateTestCases[UpdateType <: IngestUpdate]
 }
 
 class IngestEventUpdateTest
-  extends IngestUpdateTestCases[IngestEventUpdate]
+    extends IngestUpdateTestCases[IngestEventUpdate]
     with TableDrivenPropertyChecks {
   override def createUpdateWith(id: IngestID,
                                 events: Seq[IngestEvent]): IngestEventUpdate =
@@ -92,7 +92,7 @@ class IngestEventUpdateTest
 }
 
 class IngestStatusUpdateTest
-  extends IngestUpdateTestCases[IngestStatusUpdate]
+    extends IngestUpdateTestCases[IngestStatusUpdate]
     with TableDrivenPropertyChecks {
   override def createUpdateWith(id: IngestID,
                                 events: Seq[IngestEvent]): IngestStatusUpdate =
@@ -158,11 +158,11 @@ class IngestStatusUpdateTest
 }
 
 class IngestCallbackStatusUpdateTest
-  extends IngestUpdateTestCases[IngestCallbackStatusUpdate]
+    extends IngestUpdateTestCases[IngestCallbackStatusUpdate]
     with TableDrivenPropertyChecks {
   override def createUpdateWith(
-                                 id: IngestID,
-                                 events: Seq[IngestEvent]): IngestCallbackStatusUpdate =
+    id: IngestID,
+    events: Seq[IngestEvent]): IngestCallbackStatusUpdate =
     createIngestCallbackStatusUpdateWith(id = id, events = events)
 
   describe("updating the callback status") {
@@ -178,8 +178,8 @@ class IngestCallbackStatusUpdateTest
     it("updates the status of a callback") {
       forAll(allowedCallbackStatusUpdates) {
         case (
-          initialStatus: Callback.CallbackStatus,
-          updatedStatus: Callback.CallbackStatus) =>
+            initialStatus: Callback.CallbackStatus,
+            updatedStatus: Callback.CallbackStatus) =>
           val ingest = createIngestWith(
             callback = Some(
               Callback(
@@ -210,8 +210,8 @@ class IngestCallbackStatusUpdateTest
     it("does not allow the callback status to go backwards") {
       forAll(disallowedCallbackStatusUpdates) {
         case (
-          initialStatus: Callback.CallbackStatus,
-          updatedStatus: Callback.CallbackStatus) =>
+            initialStatus: Callback.CallbackStatus,
+            updatedStatus: Callback.CallbackStatus) =>
           val ingest = createIngestWith(
             callback = Some(
               Callback(
@@ -247,7 +247,7 @@ class IngestCallbackStatusUpdateTest
 }
 
 class IngestVersionUpdateTest
-  extends IngestUpdateTestCases[IngestVersionUpdate] {
+    extends IngestUpdateTestCases[IngestVersionUpdate] {
   override def createUpdateWith(id: IngestID,
                                 events: Seq[IngestEvent]): IngestVersionUpdate =
     createIngestVersionUpdateWith(id = id, events = events)

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestStatesTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/services/IngestStatesTest.scala
@@ -5,21 +5,24 @@ import java.net.URI
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.{FunSpec, Matchers, TryValues}
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
-import uk.ac.wellcome.platform.archive.common.ingests.models.{Callback, Ingest}
+import uk.ac.wellcome.platform.archive.common.ingests.models._
 
-class IngestStatesTest
-    extends FunSpec
+sealed trait IngestUpdateTestCases[UpdateType <: IngestUpdate]
+  extends FunSpec
     with Matchers
     with IngestGenerators
-    with TryValues
-    with TableDrivenPropertyChecks {
+    with TryValues {
+  def createUpdateWith(id: IngestID, events: Seq[IngestEvent]): UpdateType
 
-  describe("handling an IngestEventUpdate") {
-    it("adds an event to an ingest") {
-      val ingest = createIngestWith(events = List.empty)
+  def createInitialIngestWith(events: Seq[IngestEvent]): Ingest =
+    createIngestWith(events = events)
+
+  describe("updating the events") {
+    it("adds an event") {
+      val ingest = createInitialIngestWith(events = List.empty)
 
       val event = createIngestEvent
-      val update = createIngestEventUpdateWith(
+      val update = createUpdateWith(
         id = ingest.id,
         events = List(event)
       )
@@ -28,12 +31,12 @@ class IngestStatesTest
       updatedIngest.events shouldBe Seq(event)
     }
 
-    it("adds multiple events to an ingest") {
-      val ingest = createIngestWith(events = List.empty)
+    it("adds multiple events") {
+      val ingest = createInitialIngestWith(events = List.empty)
 
       val events =
         List(createIngestEvent, createIngestEvent, createIngestEvent)
-      val update = createIngestEventUpdateWith(
+      val update = createUpdateWith(
         id = ingest.id,
         events = events
       )
@@ -42,12 +45,12 @@ class IngestStatesTest
       updatedIngest.events shouldBe events
     }
 
-    it("preserves the existing events on an ingest") {
+    it("preserves the existing events") {
       val existingEvents = List(createIngestEvent, createIngestEvent)
-      val ingest = createIngestWith(events = existingEvents)
+      val ingest = createInitialIngestWith(events = existingEvents)
 
       val newEvents = List(createIngestEvent, createIngestEvent)
-      val update = createIngestEventUpdateWith(
+      val update = createUpdateWith(
         id = ingest.id,
         events = newEvents
       )
@@ -55,260 +58,189 @@ class IngestStatesTest
       val updatedIngest = IngestStates.applyUpdate(ingest, update).success.value
       updatedIngest.events shouldBe existingEvents ++ newEvents
     }
+  }
+}
 
-    val eventStatusUpdates = Table(
-      ("initial", "expected"),
+class IngestEventUpdateTest
+  extends IngestUpdateTestCases[IngestEventUpdate]
+    with TableDrivenPropertyChecks {
+  override def createUpdateWith(id: IngestID,
+                                events: Seq[IngestEvent]): IngestEventUpdate =
+    createIngestEventUpdateWith(id = id, events = events)
+
+  val eventStatusUpdates = Table(
+    ("initial", "expected"),
+    (Ingest.Accepted, Ingest.Processing),
+    (Ingest.Processing, Ingest.Processing),
+    (Ingest.Completed, Ingest.Completed),
+    (Ingest.Failed, Ingest.Failed),
+  )
+
+  it("updates the status to Processing when it sees the first event update") {
+    forAll(eventStatusUpdates) {
+      case (initialStatus: Ingest.Status, expectedStatus: Ingest.Status) =>
+        val ingest = createIngestWith(status = initialStatus)
+
+        val update = createIngestEventUpdate
+
+        val updatedIngest =
+          IngestStates.applyUpdate(ingest, update).success.value
+        updatedIngest.status shouldBe expectedStatus
+    }
+  }
+}
+
+class IngestStatusUpdateTest
+  extends IngestUpdateTestCases[IngestStatusUpdate]
+    with TableDrivenPropertyChecks {
+  override def createUpdateWith(id: IngestID,
+                                events: Seq[IngestEvent]): IngestStatusUpdate =
+    createIngestStatusUpdateWith(id = id, events = events)
+
+  describe("updating the status") {
+    val allowedStatusUpdates = Table(
+      ("initial", "update"),
+      (Ingest.Accepted, Ingest.Accepted),
       (Ingest.Accepted, Ingest.Processing),
-      (Ingest.Processing, Ingest.Processing),
+      (Ingest.Accepted, Ingest.Completed),
+      (Ingest.Accepted, Ingest.Failed),
+      (Ingest.Processing, Ingest.Completed),
+      (Ingest.Processing, Ingest.Failed),
       (Ingest.Completed, Ingest.Completed),
       (Ingest.Failed, Ingest.Failed),
     )
 
-    it("updates the status to Processing when it sees the first event update") {
-      forAll(eventStatusUpdates) {
-        case (initialStatus: Ingest.Status, expectedStatus: Ingest.Status) =>
+    it("updates the status of an ingest") {
+      forAll(allowedStatusUpdates) {
+        case (initialStatus: Ingest.Status, updatedStatus: Ingest.Status) =>
           val ingest = createIngestWith(status = initialStatus)
 
-          val update = createIngestEventUpdate
+          val update = createIngestStatusUpdateWith(
+            id = ingest.id,
+            status = updatedStatus
+          )
 
           val updatedIngest =
             IngestStates.applyUpdate(ingest, update).success.value
-          updatedIngest.status shouldBe expectedStatus
+          updatedIngest.status shouldBe updatedStatus
+      }
+    }
+
+    val disallowedStatusUpdates = Table(
+      ("initial", "update"),
+      (Ingest.Failed, Ingest.Completed),
+      (Ingest.Failed, Ingest.Processing),
+      (Ingest.Failed, Ingest.Accepted),
+      (Ingest.Completed, Ingest.Failed),
+      (Ingest.Completed, Ingest.Processing),
+      (Ingest.Completed, Ingest.Accepted),
+      (Ingest.Processing, Ingest.Accepted),
+    )
+
+    it("does not allow the status to go backwards") {
+      forAll(disallowedStatusUpdates) {
+        case (initialStatus: Ingest.Status, updatedStatus: Ingest.Status) =>
+          val ingest = createIngestWith(status = initialStatus)
+
+          val update = createIngestStatusUpdateWith(
+            id = ingest.id,
+            status = updatedStatus
+          )
+
+          IngestStates
+            .applyUpdate(ingest, update)
+            .failure
+            .exception shouldBe a[IngestStatusGoingBackwardsException]
       }
     }
   }
+}
 
-  describe("handling an IngestStatusUpdate") {
-    describe("updating the events") {
-      it("adds an event to an ingest") {
-        val ingest = createIngestWith(events = List.empty)
+class IngestCallbackStatusUpdateTest
+  extends IngestUpdateTestCases[IngestCallbackStatusUpdate]
+    with TableDrivenPropertyChecks {
+  override def createUpdateWith(
+                                 id: IngestID,
+                                 events: Seq[IngestEvent]): IngestCallbackStatusUpdate =
+    createIngestCallbackStatusUpdateWith(id = id, events = events)
 
-        val event = createIngestEvent
-        val update = createIngestStatusUpdateWith(
-          id = ingest.id,
-          events = List(event)
-        )
+  describe("updating the callback status") {
+    val allowedCallbackStatusUpdates = Table(
+      ("initial", "update"),
+      (Callback.Pending, Callback.Pending),
+      (Callback.Pending, Callback.Succeeded),
+      (Callback.Pending, Callback.Failed),
+      (Callback.Succeeded, Callback.Succeeded),
+      (Callback.Failed, Callback.Failed),
+    )
 
-        val updatedIngest =
-          IngestStates.applyUpdate(ingest, update).success.value
-        updatedIngest.events shouldBe Seq(event)
-      }
+    it("updates the status of a callback") {
+      forAll(allowedCallbackStatusUpdates) {
+        case (
+          initialStatus: Callback.CallbackStatus,
+          updatedStatus: Callback.CallbackStatus) =>
+          val ingest = createIngestWith(
+            callback = Some(
+              Callback(
+                uri = new URI("https://example.org/callback"),
+                status = initialStatus
+              ))
+          )
 
-      it("adds multiple events to an ingest") {
-        val ingest = createIngestWith(events = List.empty)
+          val update = createIngestCallbackStatusUpdateWith(
+            id = ingest.id,
+            callbackStatus = updatedStatus
+          )
 
-        val events =
-          List(createIngestEvent, createIngestEvent, createIngestEvent)
-        val update = createIngestStatusUpdateWith(
-          id = ingest.id,
-          events = events
-        )
-
-        val updatedIngest =
-          IngestStates.applyUpdate(ingest, update).success.value
-        updatedIngest.events shouldBe events
-      }
-
-      it("preserves the existing events on an ingest") {
-        val existingEvents = List(createIngestEvent, createIngestEvent)
-        val ingest = createIngestWith(events = existingEvents)
-
-        val newEvents = List(createIngestEvent, createIngestEvent)
-        val update = createIngestStatusUpdateWith(
-          id = ingest.id,
-          events = newEvents
-        )
-
-        val updatedIngest =
-          IngestStates.applyUpdate(ingest, update).success.value
-        updatedIngest.events shouldBe existingEvents ++ newEvents
+          val updatedIngest =
+            IngestStates.applyUpdate(ingest, update).success.value
+          updatedIngest.callback.get.status shouldBe updatedStatus
       }
     }
 
-    describe("updating the status") {
-      val allowedStatusUpdates = Table(
-        ("initial", "update"),
-        (Ingest.Accepted, Ingest.Accepted),
-        (Ingest.Accepted, Ingest.Processing),
-        (Ingest.Accepted, Ingest.Completed),
-        (Ingest.Accepted, Ingest.Failed),
-        (Ingest.Processing, Ingest.Completed),
-        (Ingest.Processing, Ingest.Failed),
-        (Ingest.Completed, Ingest.Completed),
-        (Ingest.Failed, Ingest.Failed),
-      )
+    val disallowedCallbackStatusUpdates = Table(
+      ("initial", "update"),
+      (Callback.Succeeded, Callback.Pending),
+      (Callback.Succeeded, Callback.Failed),
+      (Callback.Failed, Callback.Pending),
+      (Callback.Failed, Callback.Succeeded),
+    )
 
-      it("updates the status of an ingest") {
-        forAll(allowedStatusUpdates) {
-          case (initialStatus: Ingest.Status, updatedStatus: Ingest.Status) =>
-            val ingest = createIngestWith(status = initialStatus)
+    it("does not allow the callback status to go backwards") {
+      forAll(disallowedCallbackStatusUpdates) {
+        case (
+          initialStatus: Callback.CallbackStatus,
+          updatedStatus: Callback.CallbackStatus) =>
+          val ingest = createIngestWith(
+            callback = Some(
+              Callback(
+                uri = new URI("https://example.org/callback"),
+                status = initialStatus
+              ))
+          )
 
-            val update = createIngestStatusUpdateWith(
-              id = ingest.id,
-              status = updatedStatus
-            )
+          val update = createIngestCallbackStatusUpdateWith(
+            id = ingest.id,
+            callbackStatus = updatedStatus
+          )
 
-            val updatedIngest =
-              IngestStates.applyUpdate(ingest, update).success.value
-            updatedIngest.status shouldBe updatedStatus
-        }
-      }
+          val err = IngestStates.applyUpdate(ingest, update).failure.exception
 
-      val disallowedStatusUpdates = Table(
-        ("initial", "update"),
-        (Ingest.Failed, Ingest.Completed),
-        (Ingest.Failed, Ingest.Processing),
-        (Ingest.Failed, Ingest.Accepted),
-        (Ingest.Completed, Ingest.Failed),
-        (Ingest.Completed, Ingest.Processing),
-        (Ingest.Completed, Ingest.Accepted),
-        (Ingest.Processing, Ingest.Accepted),
-      )
-
-      it("does not allow the status to go backwards") {
-        forAll(disallowedStatusUpdates) {
-          case (initialStatus: Ingest.Status, updatedStatus: Ingest.Status) =>
-            val ingest = createIngestWith(status = initialStatus)
-
-            val update = createIngestStatusUpdateWith(
-              id = ingest.id,
-              status = updatedStatus
-            )
-
-            IngestStates
-              .applyUpdate(ingest, update)
-              .failure
-              .exception shouldBe a[IngestStatusGoingBackwardsException]
-        }
-      }
-    }
-  }
-
-  describe("handling a CallbackStatusUpdate") {
-    describe("updating the events") {
-      it("adds an event to an ingest") {
-        val ingest = createIngestWith(events = List.empty)
-
-        val event = createIngestEvent
-        val update = createIngestCallbackStatusUpdateWith(
-          id = ingest.id,
-          events = List(event)
-        )
-
-        val updatedIngest =
-          IngestStates.applyUpdate(ingest, update).success.value
-        updatedIngest.events shouldBe Seq(event)
-      }
-
-      it("adds multiple events to an ingest") {
-        val ingest = createIngestWith(events = List.empty)
-
-        val events =
-          List(createIngestEvent, createIngestEvent, createIngestEvent)
-        val update = createIngestCallbackStatusUpdateWith(
-          id = ingest.id,
-          events = events
-        )
-
-        val updatedIngest =
-          IngestStates.applyUpdate(ingest, update).success.value
-        updatedIngest.events shouldBe events
-      }
-
-      it("preserves the existing events on an ingest") {
-        val existingEvents = List(createIngestEvent, createIngestEvent)
-        val ingest = createIngestWith(events = existingEvents)
-
-        val newEvents = List(createIngestEvent, createIngestEvent)
-        val update = createIngestCallbackStatusUpdateWith(
-          id = ingest.id,
-          events = newEvents
-        )
-
-        val updatedIngest =
-          IngestStates.applyUpdate(ingest, update).success.value
-        updatedIngest.events shouldBe existingEvents ++ newEvents
+          err shouldBe a[CallbackStatusGoingBackwardsException]
       }
     }
 
-    describe("updating the callback status") {
-      val allowedCallbackStatusUpdates = Table(
-        ("initial", "update"),
-        (Callback.Pending, Callback.Pending),
-        (Callback.Pending, Callback.Succeeded),
-        (Callback.Pending, Callback.Failed),
-        (Callback.Succeeded, Callback.Succeeded),
-        (Callback.Failed, Callback.Failed),
+    it("errors if the ingest does not have a callback") {
+      val ingest = createIngestWith(
+        callback = None
+      )
+      val update = createIngestCallbackStatusUpdateWith(
+        id = ingest.id
       )
 
-      it("updates the status of a callback") {
-        forAll(allowedCallbackStatusUpdates) {
-          case (
-              initialStatus: Callback.CallbackStatus,
-              updatedStatus: Callback.CallbackStatus) =>
-            val ingest = createIngestWith(
-              callback = Some(
-                Callback(
-                  uri = new URI("https://example.org/callback"),
-                  status = initialStatus
-                ))
-            )
+      val err = IngestStates.applyUpdate(ingest, update).failure.exception
 
-            val update = createIngestCallbackStatusUpdateWith(
-              id = ingest.id,
-              callbackStatus = updatedStatus
-            )
-
-            val updatedIngest =
-              IngestStates.applyUpdate(ingest, update).success.value
-            updatedIngest.callback.get.status shouldBe updatedStatus
-        }
-      }
-
-      val disallowedCallbackStatusUpdates = Table(
-        ("initial", "update"),
-        (Callback.Succeeded, Callback.Pending),
-        (Callback.Succeeded, Callback.Failed),
-        (Callback.Failed, Callback.Pending),
-        (Callback.Failed, Callback.Succeeded),
-      )
-
-      it("does not allow the callback status to go backwards") {
-        forAll(disallowedCallbackStatusUpdates) {
-          case (
-              initialStatus: Callback.CallbackStatus,
-              updatedStatus: Callback.CallbackStatus) =>
-            val ingest = createIngestWith(
-              callback = Some(
-                Callback(
-                  uri = new URI("https://example.org/callback"),
-                  status = initialStatus
-                ))
-            )
-
-            val update = createIngestCallbackStatusUpdateWith(
-              id = ingest.id,
-              callbackStatus = updatedStatus
-            )
-
-            val err = IngestStates.applyUpdate(ingest, update).failure.exception
-
-            err shouldBe a[CallbackStatusGoingBackwardsException]
-        }
-      }
-
-      it("errors if the ingest does not have a callback") {
-        val ingest = createIngestWith(
-          callback = None
-        )
-        val update = createIngestCallbackStatusUpdateWith(
-          id = ingest.id
-        )
-
-        val err = IngestStates.applyUpdate(ingest, update).failure.exception
-
-        err shouldBe a[NoCallbackException]
-      }
+      err shouldBe a[NoCallbackException]
     }
   }
 }


### PR DESCRIPTION
First part of https://github.com/wellcometrust/platform/issues/3770, spun out of #280.

This adds `version` to the internal `Ingest` model, and a new update type `IngestVersionUpdate` that passes the version from the bag auditor to the ingests monitor.