### PR TITLE
Improve the verifier message for dangling fetch entries

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagMatcher.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagMatcher.scala
@@ -52,21 +52,22 @@ object BagMatcher {
           fetchEntries = existing.fetchEntries :+ fetchEntry))
     }
 
-    val matchedLocations = paths.map { case (path, pathInfo) =>
-      (pathInfo.bagFiles.distinct, pathInfo.fetchEntries.distinct) match {
-        case (Seq(bagFile), Seq()) =>
-          Right(MatchedLocation(bagFile = bagFile, fetchEntry = None))
-        case (Seq(bagFile), Seq(fetchEntry)) =>
-          Right(
-            MatchedLocation(bagFile = bagFile, fetchEntry = Some(fetchEntry)))
+    val matchedLocations = paths.map {
+      case (path, pathInfo) =>
+        (pathInfo.bagFiles.distinct, pathInfo.fetchEntries.distinct) match {
+          case (Seq(bagFile), Seq()) =>
+            Right(MatchedLocation(bagFile = bagFile, fetchEntry = None))
+          case (Seq(bagFile), Seq(fetchEntry)) =>
+            Right(
+              MatchedLocation(bagFile = bagFile, fetchEntry = Some(fetchEntry)))
 
-        case (Seq(), fetchEntriesForPath) if fetchEntriesForPath.nonEmpty =>
-          Left(
-            s"Fetch entry refers to a path that isn't in the bag manifest: $path")
+          case (Seq(), fetchEntriesForPath) if fetchEntriesForPath.nonEmpty =>
+            Left(
+              s"Fetch entry refers to a path that isn't in the bag manifest: $path")
 
-        case _ =>
-          Left(s"Multiple, ambiguous entries for the same path: $pathInfo")
-      }
+          case _ =>
+            Left(s"Multiple, ambiguous entries for the same path: $pathInfo")
+        }
     }
 
     val successes = matchedLocations.collect { case Right(t) => t }.toSeq

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagMatcher.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagMatcher.scala
@@ -52,7 +52,7 @@ object BagMatcher {
           fetchEntries = existing.fetchEntries :+ fetchEntry))
     }
 
-    val matchedLocations = paths.values.map { pathInfo =>
+    val matchedLocations = paths.map { case (path, pathInfo) =>
       (pathInfo.bagFiles.distinct, pathInfo.fetchEntries.distinct) match {
         case (Seq(bagFile), Seq()) =>
           Right(MatchedLocation(bagFile = bagFile, fetchEntry = None))
@@ -60,16 +60,9 @@ object BagMatcher {
           Right(
             MatchedLocation(bagFile = bagFile, fetchEntry = Some(fetchEntry)))
 
-        case (Seq(), fetchEntriesForPath) =>
-          val uriString = fetchEntriesForPath.map { _.uri }.mkString(", ")
-          val message =
-            if (fetchEntriesForPath.size == 1) {
-              s"Fetch entry refers to a path that isn't in the bag manifest: $uriString"
-            } else {
-              s"Multiple fetch entries refer to a path that isn't in the bag manifest: $uriString"
-            }
-
-          Left(message)
+        case (Seq(), fetchEntriesForPath) if fetchEntriesForPath.nonEmpty =>
+          Left(
+            s"Fetch entry refers to a path that isn't in the bag manifest: $path")
 
         case _ =>
           Left(s"Multiple, ambiguous entries for the same path: $pathInfo")

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagMatcher.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagMatcher.scala
@@ -59,12 +59,18 @@ object BagMatcher {
         case (Seq(bagFile), Seq(fetchEntry)) =>
           Right(
             MatchedLocation(bagFile = bagFile, fetchEntry = Some(fetchEntry)))
-        case (Seq(), Seq(fetchEntry)) =>
-          Left(
-            s"Fetch entry refers to a path that isn't in the bag: $fetchEntry")
+
         case (Seq(), fetchEntriesForPath) =>
-          Left(
-            s"Multiple fetch entries refers to a path that isn't in the bag: $fetchEntriesForPath")
+          val uriString = fetchEntriesForPath.map { _.uri }.mkString(", ")
+          val message =
+            if (fetchEntriesForPath.size == 1) {
+              s"Fetch entry refers to a path that isn't in the bag manifest: $uriString"
+            } else {
+              s"Multiple fetch entries refer to a path that isn't in the bag manifest: $uriString"
+            }
+
+          Left(message)
+
         case _ =>
           Left(s"Multiple, ambiguous entries for the same path: $pathInfo")
       }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagMatcherTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagMatcherTest.scala
@@ -112,7 +112,7 @@ class BagMatcherTest
       )
 
       result.left.value.head.getMessage shouldBe
-        s"Fetch entry refers to a path that isn't in the bag manifest: ${fetchEntries.head.uri}"
+        s"Fetch entry refers to a path that isn't in the bag manifest: ${fetchEntries.head.path}"
     }
 
     it("there are multiple fetch entries for files that aren't in the bag") {
@@ -125,8 +125,7 @@ class BagMatcherTest
       )
 
       result.left.value.head.getMessage shouldBe
-        "Multiple fetch entries refer to a path that isn't in the bag manifest: " +
-          fetchEntries.map { _.uri }.mkString(", ")
+        s"Fetch entry refers to a path that isn't in the bag manifest: $bagPath"
     }
 
     it("has multiple, differing fetch entries for the same file") {

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagMatcherTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagMatcherTest.scala
@@ -117,7 +117,9 @@ class BagMatcherTest
 
     it("there are multiple fetch entries for files that aren't in the bag") {
       val bagPath = BagPath(randomAlphanumeric)
-      val fetchEntries = (1 to 3).map { _ => createFetchEntryWith(path = bagPath) }
+      val fetchEntries = (1 to 3).map { _ =>
+        createFetchEntryWith(path = bagPath)
+      }
 
       val result = BagMatcher.correlateFetchEntryToBagFile(
         bagFiles = Seq.empty,

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagVerifiableTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagVerifiableTest.scala
@@ -202,8 +202,8 @@ class BagVerifiableTest
 
       val result = bagVerifiable.create(bag)
       result shouldBe a[Left[_, _]]
-      result.left.get.msg should startWith(
-        "Multiple fetch entries refers to a path that isn't in the bag")
+      result.left.get.msg shouldBe
+        "Fetch entry refers to a path that isn't in the bag manifest: example.txt"
     }
 
     it("has multiple references to the same file with different checksums") {

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
@@ -347,7 +347,7 @@ class StorageManifestServiceTest
       assertIsError(bag = bag) { msg =>
         msg should startWith("Unable to resolve fetch entries:")
         msg should include(
-          s"Fetch entry refers to a path that isn't in the bag: ${fetchEntries.head}")
+          s"Fetch entry refers to a path that isn't in the bag manifest: ${fetchEntries.head.path}")
       }
     }
 


### PR DESCRIPTION
Previously:

> Fetch entry refers to a path that isn't in the bag: BagFetchEntry(s3://wellcomecollection-storage-archive/digitised/b12956156/v1/data/objects/RAMC_262_10_0008.jp2,None,data/objects/RAMC_262_10_0008.jp2)

Now:

> Fetch entry refers to a path that isn't in the bag manifest: data/objects/RAMC_262_10_0008.jp2

This confused at least one person (see [discussion in #intranda](https://wellcome.slack.com/archives/C6LLC2V8Q/p1564407567008800)), so make the message clearer about the fact that it’s the bag *manifest* where the file is missing, not the bag itself.