### PR TITLE
Send a version in callback requests

### DIFF
--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
@@ -44,75 +44,73 @@ class IngestsApiFeatureTest
 
       withConfiguredApp(initialIngests = Seq(ingest)) {
         case (_, _, metrics, baseUrl) =>
-          withMaterializer { implicit materializer =>
-            whenGetRequestReady(s"$baseUrl/ingests/${ingest.id}") { result =>
-              result.status shouldBe StatusCodes.OK
+          whenGetRequestReady(s"$baseUrl/ingests/${ingest.id}") { result =>
+            result.status shouldBe StatusCodes.OK
 
-              withStringEntity(result.entity) { jsonString =>
-                assertJsonStringsAreEqual(
-                  jsonString,
-                  s"""
-                     |{
-                     |  "@context": "http://api.wellcomecollection.org/storage/v1/context.json",
-                     |  "id": "${ingest.id.toString}",
-                     |  "type": "Ingest",
-                     |  "ingestType": {
-                     |    "id": "${ingest.ingestType.id}",
-                     |    "type": "IngestType"
-                     |  },
-                     |  "space": {
-                     |    "id": "${ingest.space.underlying}",
-                     |    "type": "Space"
-                     |  },
-                     |  "bag": {
-                     |    "type": "Bag",
-                     |    "info": {
-                     |      "type": "BagInfo",
-                     |      "externalIdentifier": "${ingest.externalIdentifier.underlying}"
-                     |    }
-                     |  },
-                     |  "status": {
-                     |    "id": "${ingest.status.toString}",
-                     |    "type": "Status"
-                     |  },
-                     |  "sourceLocation": {
-                     |    "type": "Location",
-                     |    "provider": {
-                     |      "type": "Provider",
-                     |      "id": "aws-s3-standard"
-                     |    },
-                     |    "bucket": "${ingest.sourceLocation.location.namespace}",
-                     |    "path": "${ingest.sourceLocation.location.path}"
-                     |  },
-                     |  "callback": {
-                     |    "type": "Callback",
-                     |    "url": "${ingest.callback.get.uri}",
-                     |    "status": {
-                     |      "id": "${ingest.callback.get.status.toString}",
-                     |      "type": "Status"
-                     |    }
-                     |  },
-                     |  "createdDate": "${ingest.createdDate}",
-                     |  "lastModifiedDate": "${ingest.lastModifiedDate.get}",
-                     |  "events": [
-                     |    {
-                     |      "type": "IngestEvent",
-                     |      "createdDate": "${ingest.events(0).createdDate}",
-                     |      "description": "${ingest.events(0).description}"
-                     |    },
-                     |    {
-                     |      "type": "IngestEvent",
-                     |      "createdDate": "${ingest.events(1).createdDate}",
-                     |      "description": "${ingest.events(1).description}"
-                     |    }
-                     |  ]
-                     |}
-                   """.stripMargin
-                )
-              }
-
-              assertMetricSent(metrics, result = HttpMetricResults.Success)
+            withStringEntity(result.entity) { jsonString =>
+              assertJsonStringsAreEqual(
+                jsonString,
+                s"""
+                   |{
+                   |  "@context": "http://api.wellcomecollection.org/storage/v1/context.json",
+                   |  "id": "${ingest.id.toString}",
+                   |  "type": "Ingest",
+                   |  "ingestType": {
+                   |    "id": "${ingest.ingestType.id}",
+                   |    "type": "IngestType"
+                   |  },
+                   |  "space": {
+                   |    "id": "${ingest.space.underlying}",
+                   |    "type": "Space"
+                   |  },
+                   |  "bag": {
+                   |    "type": "Bag",
+                   |    "info": {
+                   |      "type": "BagInfo",
+                   |      "externalIdentifier": "${ingest.externalIdentifier.underlying}"
+                   |    }
+                   |  },
+                   |  "status": {
+                   |    "id": "${ingest.status.toString}",
+                   |    "type": "Status"
+                   |  },
+                   |  "sourceLocation": {
+                   |    "type": "Location",
+                   |    "provider": {
+                   |      "type": "Provider",
+                   |      "id": "aws-s3-standard"
+                   |    },
+                   |    "bucket": "${ingest.sourceLocation.location.namespace}",
+                   |    "path": "${ingest.sourceLocation.location.path}"
+                   |  },
+                   |  "callback": {
+                   |    "type": "Callback",
+                   |    "url": "${ingest.callback.get.uri}",
+                   |    "status": {
+                   |      "id": "${ingest.callback.get.status.toString}",
+                   |      "type": "Status"
+                   |    }
+                   |  },
+                   |  "createdDate": "${ingest.createdDate}",
+                   |  "lastModifiedDate": "${ingest.lastModifiedDate.get}",
+                   |  "events": [
+                   |    {
+                   |      "type": "IngestEvent",
+                   |      "createdDate": "${ingest.events(0).createdDate}",
+                   |      "description": "${ingest.events(0).description}"
+                   |    },
+                   |    {
+                   |      "type": "IngestEvent",
+                   |      "createdDate": "${ingest.events(1).createdDate}",
+                   |      "description": "${ingest.events(1).description}"
+                   |    }
+                   |  ]
+                   |}
+                   |""".stripMargin
+              )
             }
+
+            assertMetricSent(metrics, result = HttpMetricResults.Success)
           }
       }
     }
@@ -124,12 +122,10 @@ class IngestsApiFeatureTest
 
       withConfiguredApp(initialIngests = Seq(ingest)) {
         case (_, _, _, baseUrl) =>
-          withMaterializer { implicit materializer =>
-            whenGetRequestReady(s"$baseUrl/ingests/${ingest.id}") { result =>
-              withStringEntity(result.entity) { jsonString =>
-                val json = parse(jsonString).right.value
-                root.bag.info.version.string.getOption(json) shouldBe Some("v3")
-              }
+          whenGetRequestReady(s"$baseUrl/ingests/${ingest.id}") { result =>
+            withStringEntity(result.entity) { jsonString =>
+              val json = parse(jsonString).right.value
+              root.bag.info.version.string.getOption(json) shouldBe Some("v3")
             }
           }
       }
@@ -139,49 +135,41 @@ class IngestsApiFeatureTest
       val ingest = createIngestWith(callback = None)
 
       withConfiguredApp(initialIngests = Seq(ingest)) {
-        case (ingestTracker, _, metrics, baseUrl) =>
-          withMaterializer { implicit materialiser =>
-            whenGetRequestReady(s"$baseUrl/ingests/${ingest.id}") { result =>
-              result.status shouldBe StatusCodes.OK
-              withStringEntity(result.entity) { jsonString =>
-                val infoJson = parse(jsonString).right.get
-                infoJson.findAllByKey("callback") shouldBe empty
-              }
-
-              assertMetricSent(metrics, result = HttpMetricResults.Success)
+        case (_, _, metrics, baseUrl) =>
+          whenGetRequestReady(s"$baseUrl/ingests/${ingest.id}") { result =>
+            result.status shouldBe StatusCodes.OK
+            withStringEntity(result.entity) { jsonString =>
+              val infoJson = parse(jsonString).right.get
+              infoJson.findAllByKey("callback") shouldBe empty
             }
+
+            assertMetricSent(metrics, result = HttpMetricResults.Success)
           }
       }
     }
 
     it("returns a 404 NotFound if no ingest tracker matches id") {
-      withMaterializer { implicit materializer =>
-        withConfiguredApp() {
-          case (_, _, metrics, baseUrl) =>
-            val id = randomUUID
-            whenGetRequestReady(s"$baseUrl/ingests/$id") { response =>
-              assertIsUserErrorResponse(
-                response,
-                description = s"Ingest $id not found",
-                statusCode = StatusCodes.NotFound,
-                label = "Not Found"
-              )
+      withConfiguredApp() { case (_, _, metrics, baseUrl) =>
+        val id = randomUUID
+        whenGetRequestReady(s"$baseUrl/ingests/$id") { response =>
+          assertIsUserErrorResponse(
+            response,
+            description = s"Ingest $id not found",
+            statusCode = StatusCodes.NotFound,
+            label = "Not Found"
+          )
 
-              assertMetricSent(metrics, result = HttpMetricResults.UserError)
-            }
+          assertMetricSent(metrics, result = HttpMetricResults.UserError)
         }
       }
     }
 
     it("returns a 500 Server Error if reading from DynamoDB fails") {
-      withMaterializer { implicit materializer =>
-        withBrokenApp {
-          case (_, _, metrics, baseUrl) =>
-            whenGetRequestReady(s"$baseUrl/ingests/$randomUUID") { response =>
-              assertIsInternalServerErrorResponse(response)
+      withBrokenApp { case (_, _, metrics, baseUrl) =>
+        whenGetRequestReady(s"$baseUrl/ingests/$randomUUID") { response =>
+          assertIsInternalServerErrorResponse(response)
 
-              assertMetricSent(metrics, result = HttpMetricResults.ServerError)
-            }
+          assertMetricSent(metrics, result = HttpMetricResults.ServerError)
         }
       }
     }
@@ -191,135 +179,131 @@ class IngestsApiFeatureTest
     it("creates an ingest") {
       withConfiguredApp() {
         case (ingestTracker, messageSender, metrics, baseUrl) =>
-          withMaterializer { implicit mat =>
-            val url = s"$baseUrl/ingests"
+          val url = s"$baseUrl/ingests"
 
-            val bucketName = "bucket"
-            val s3key = "key.txt"
-            val spaceName = "somespace"
+          val bucketName = "bucket"
+          val s3key = "key.txt"
+          val spaceName = "somespace"
 
-            val externalIdentifier = createExternalIdentifier
+          val externalIdentifier = createExternalIdentifier
 
-            val entity = createRequestWith(
-              bucket = bucketName,
-              key = s3key,
-              space = spaceName,
-              externalIdentifier = externalIdentifier
-            )
+          val entity = createRequestWith(
+            bucket = bucketName,
+            key = s3key,
+            space = spaceName,
+            externalIdentifier = externalIdentifier
+          )
 
-            val expectedLocationR = s"$baseUrl/(.+)".r
+          val expectedLocationR = s"$baseUrl/(.+)".r
 
-            whenPostRequestReady(url, entity) { response: HttpResponse =>
-              response.status shouldBe StatusCodes.Created
+          whenPostRequestReady(url, entity) { response: HttpResponse =>
+            response.status shouldBe StatusCodes.Created
 
-              val maybeId = response.headers.collectFirst {
-                case HttpHeader("location", expectedLocationR(id)) => id
-              }
+            val maybeId = response.headers.collectFirst {
+              case HttpHeader("location", expectedLocationR(id)) => id
+            }
 
-              maybeId.isEmpty shouldBe false
-              val id = UUID.fromString(maybeId.get)
+            maybeId.isEmpty shouldBe false
+            val id = UUID.fromString(maybeId.get)
 
-              val ingestFuture =
+            val ingestFuture =
+              withMaterializer { implicit materializer =>
                 Unmarshal(response.entity).to[ResponseDisplayIngest]
-
-              whenReady(ingestFuture) { actualIngest =>
-                actualIngest.context shouldBe contextUrl
-                actualIngest.id shouldBe id
-                actualIngest.sourceLocation shouldBe DisplayLocation(
-                  provider = StandardDisplayProvider,
-                  bucket = bucketName,
-                  path = s3key
-                )
-
-                actualIngest.callback.isDefined shouldBe true
-                actualIngest.callback.get.url shouldBe testCallbackUri.toString
-                actualIngest.callback.get.status.get shouldBe DisplayStatus(
-                  "processing")
-
-                actualIngest.ingestType shouldBe CreateDisplayIngestType
-
-                actualIngest.status shouldBe DisplayStatus("accepted")
-
-                actualIngest.space shouldBe DisplayStorageSpace(
-                  spaceName,
-                  "Space")
-
-                actualIngest.bag.info.externalIdentifier shouldBe externalIdentifier
-
-                val expectedIngest = Ingest(
-                  id = IngestID(id),
-                  ingestType = CreateIngestType,
-                  sourceLocation = StorageLocation(
-                    StandardStorageProvider,
-                    ObjectLocation(bucketName, s3key)
-                  ),
-                  space = StorageSpace(spaceName),
-                  callback = Some(Callback(testCallbackUri, Callback.Pending)),
-                  status = Ingest.Accepted,
-                  externalIdentifier = externalIdentifier,
-                  createdDate = Instant.parse(actualIngest.createdDate),
-                  events = Nil
-                )
-
-                assertIngestCreated(expectedIngest)(ingestTracker)
-
-                val expectedPayload = SourceLocationPayload(expectedIngest)
-                messageSender
-                  .getMessages[SourceLocationPayload] shouldBe Seq(
-                  expectedPayload)
-
-                assertMetricSent(metrics, result = HttpMetricResults.Success)
               }
+
+            whenReady(ingestFuture) { actualIngest =>
+              actualIngest.context shouldBe contextUrl
+              actualIngest.id shouldBe id
+              actualIngest.sourceLocation shouldBe DisplayLocation(
+                provider = StandardDisplayProvider,
+                bucket = bucketName,
+                path = s3key
+              )
+
+              actualIngest.callback.isDefined shouldBe true
+              actualIngest.callback.get.url shouldBe testCallbackUri.toString
+              actualIngest.callback.get.status.get shouldBe DisplayStatus(
+                "processing")
+
+              actualIngest.ingestType shouldBe CreateDisplayIngestType
+
+              actualIngest.status shouldBe DisplayStatus("accepted")
+
+              actualIngest.space shouldBe DisplayStorageSpace(spaceName)
+
+              actualIngest.bag.info.externalIdentifier shouldBe externalIdentifier
+
+              val expectedIngest = Ingest(
+                id = IngestID(id),
+                ingestType = CreateIngestType,
+                sourceLocation = StorageLocation(
+                  StandardStorageProvider,
+                  ObjectLocation(bucketName, s3key)
+                ),
+                space = StorageSpace(spaceName),
+                callback = Some(Callback(testCallbackUri, Callback.Pending)),
+                status = Ingest.Accepted,
+                externalIdentifier = externalIdentifier,
+                createdDate = Instant.parse(actualIngest.createdDate),
+                events = Nil
+              )
+
+              assertIngestCreated(expectedIngest)(ingestTracker)
+
+              val expectedPayload = SourceLocationPayload(expectedIngest)
+              messageSender
+                .getMessages[SourceLocationPayload] shouldBe Seq(
+                expectedPayload)
+
+              assertMetricSent(metrics, result = HttpMetricResults.Success)
             }
           }
       }
     }
 
     it("allows requesting an ingestType 'create'") {
-      withConfiguredApp() {
-        case (_, messageSender, metrics, baseUrl) =>
-          val url = s"$baseUrl/ingests"
+      withConfiguredApp() { case (_, messageSender, metrics, baseUrl) =>
+        val url = s"$baseUrl/ingests"
 
-          val entity = createRequestWith(
-            ingestType = "create"
-          )
+        val entity = createRequestWith(
+          ingestType = "create"
+        )
 
-          whenPostRequestReady(url, entity) { response: HttpResponse =>
-            response.status shouldBe StatusCodes.Created
+        whenPostRequestReady(url, entity) { response: HttpResponse =>
+          response.status shouldBe StatusCodes.Created
 
-            val actualIngest = getT[ResponseDisplayIngest](response.entity)
-            actualIngest.ingestType.id shouldBe "create"
+          val actualIngest = getT[ResponseDisplayIngest](response.entity)
+          actualIngest.ingestType.id shouldBe "create"
 
-            val payload =
-              messageSender.getMessages[SourceLocationPayload].head
-            payload.context.ingestType shouldBe CreateIngestType
+          val payload =
+            messageSender.getMessages[SourceLocationPayload].head
+          payload.context.ingestType shouldBe CreateIngestType
 
-            assertMetricSent(metrics, result = HttpMetricResults.Success)
-          }
+          assertMetricSent(metrics, result = HttpMetricResults.Success)
+        }
       }
     }
 
     it("allows requesting an ingestType 'update'") {
-      withConfiguredApp() {
-        case (_, messageSender, metrics, baseUrl) =>
-          val url = s"$baseUrl/ingests"
+      withConfiguredApp() { case (_, messageSender, metrics, baseUrl) =>
+        val url = s"$baseUrl/ingests"
 
-          val entity = createRequestWith(
-            ingestType = "update"
-          )
+        val entity = createRequestWith(
+          ingestType = "update"
+        )
 
-          whenPostRequestReady(url, entity) { response: HttpResponse =>
-            response.status shouldBe StatusCodes.Created
+        whenPostRequestReady(url, entity) { response: HttpResponse =>
+          response.status shouldBe StatusCodes.Created
 
-            val actualIngest = getT[ResponseDisplayIngest](response.entity)
+          val actualIngest = getT[ResponseDisplayIngest](response.entity)
 
-            actualIngest.ingestType.id shouldBe "update"
+          actualIngest.ingestType.id shouldBe "update"
 
-            val payload = messageSender.getMessages[SourceLocationPayload].head
-            payload.context.ingestType shouldBe UpdateIngestType
+          val payload = messageSender.getMessages[SourceLocationPayload].head
+          payload.context.ingestType shouldBe UpdateIngestType
 
-            assertMetricSent(metrics, result = HttpMetricResults.Success)
-          }
+          assertMetricSent(metrics, result = HttpMetricResults.Success)
+        }
       }
     }
 
@@ -511,17 +495,14 @@ class IngestsApiFeatureTest
     }
 
     it("returns a 500 Server Error if updating the ingest starter fails") {
-      withMaterializer { implicit materializer =>
-        withBrokenApp {
-          case (_, _, metrics, baseUrl) =>
-            whenPostRequestReady(s"$baseUrl/ingests/$randomUUID", createRequest) {
-              response =>
-                assertIsInternalServerErrorResponse(response)
+      withBrokenApp { case (_, _, metrics, baseUrl) =>
+        whenPostRequestReady(s"$baseUrl/ingests/$randomUUID", createRequest) {
+          response =>
+            assertIsInternalServerErrorResponse(response)
 
-                assertMetricSent(
-                  metrics,
-                  result = HttpMetricResults.ServerError)
-            }
+            assertMetricSent(
+              metrics,
+              result = HttpMetricResults.ServerError)
         }
       }
     }

--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
@@ -14,7 +14,10 @@ import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.platform.archive.common.SourceLocationPayload
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagVersion,
+  ExternalIdentifier
+}
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
 import uk.ac.wellcome.platform.archive.common.http.HttpMetricResults
 import uk.ac.wellcome.platform.archive.common.ingests.models._
@@ -149,28 +152,30 @@ class IngestsApiFeatureTest
     }
 
     it("returns a 404 NotFound if no ingest tracker matches id") {
-      withConfiguredApp() { case (_, _, metrics, baseUrl) =>
-        val id = randomUUID
-        whenGetRequestReady(s"$baseUrl/ingests/$id") { response =>
-          assertIsUserErrorResponse(
-            response,
-            description = s"Ingest $id not found",
-            statusCode = StatusCodes.NotFound,
-            label = "Not Found"
-          )
+      withConfiguredApp() {
+        case (_, _, metrics, baseUrl) =>
+          val id = randomUUID
+          whenGetRequestReady(s"$baseUrl/ingests/$id") { response =>
+            assertIsUserErrorResponse(
+              response,
+              description = s"Ingest $id not found",
+              statusCode = StatusCodes.NotFound,
+              label = "Not Found"
+            )
 
-          assertMetricSent(metrics, result = HttpMetricResults.UserError)
-        }
+            assertMetricSent(metrics, result = HttpMetricResults.UserError)
+          }
       }
     }
 
     it("returns a 500 Server Error if reading from DynamoDB fails") {
-      withBrokenApp { case (_, _, metrics, baseUrl) =>
-        whenGetRequestReady(s"$baseUrl/ingests/$randomUUID") { response =>
-          assertIsInternalServerErrorResponse(response)
+      withBrokenApp {
+        case (_, _, metrics, baseUrl) =>
+          whenGetRequestReady(s"$baseUrl/ingests/$randomUUID") { response =>
+            assertIsInternalServerErrorResponse(response)
 
-          assertMetricSent(metrics, result = HttpMetricResults.ServerError)
-        }
+            assertMetricSent(metrics, result = HttpMetricResults.ServerError)
+          }
       }
     }
   }
@@ -262,48 +267,50 @@ class IngestsApiFeatureTest
     }
 
     it("allows requesting an ingestType 'create'") {
-      withConfiguredApp() { case (_, messageSender, metrics, baseUrl) =>
-        val url = s"$baseUrl/ingests"
+      withConfiguredApp() {
+        case (_, messageSender, metrics, baseUrl) =>
+          val url = s"$baseUrl/ingests"
 
-        val entity = createRequestWith(
-          ingestType = "create"
-        )
+          val entity = createRequestWith(
+            ingestType = "create"
+          )
 
-        whenPostRequestReady(url, entity) { response: HttpResponse =>
-          response.status shouldBe StatusCodes.Created
+          whenPostRequestReady(url, entity) { response: HttpResponse =>
+            response.status shouldBe StatusCodes.Created
 
-          val actualIngest = getT[ResponseDisplayIngest](response.entity)
-          actualIngest.ingestType.id shouldBe "create"
+            val actualIngest = getT[ResponseDisplayIngest](response.entity)
+            actualIngest.ingestType.id shouldBe "create"
 
-          val payload =
-            messageSender.getMessages[SourceLocationPayload].head
-          payload.context.ingestType shouldBe CreateIngestType
+            val payload =
+              messageSender.getMessages[SourceLocationPayload].head
+            payload.context.ingestType shouldBe CreateIngestType
 
-          assertMetricSent(metrics, result = HttpMetricResults.Success)
-        }
+            assertMetricSent(metrics, result = HttpMetricResults.Success)
+          }
       }
     }
 
     it("allows requesting an ingestType 'update'") {
-      withConfiguredApp() { case (_, messageSender, metrics, baseUrl) =>
-        val url = s"$baseUrl/ingests"
+      withConfiguredApp() {
+        case (_, messageSender, metrics, baseUrl) =>
+          val url = s"$baseUrl/ingests"
 
-        val entity = createRequestWith(
-          ingestType = "update"
-        )
+          val entity = createRequestWith(
+            ingestType = "update"
+          )
 
-        whenPostRequestReady(url, entity) { response: HttpResponse =>
-          response.status shouldBe StatusCodes.Created
+          whenPostRequestReady(url, entity) { response: HttpResponse =>
+            response.status shouldBe StatusCodes.Created
 
-          val actualIngest = getT[ResponseDisplayIngest](response.entity)
+            val actualIngest = getT[ResponseDisplayIngest](response.entity)
 
-          actualIngest.ingestType.id shouldBe "update"
+            actualIngest.ingestType.id shouldBe "update"
 
-          val payload = messageSender.getMessages[SourceLocationPayload].head
-          payload.context.ingestType shouldBe UpdateIngestType
+            val payload = messageSender.getMessages[SourceLocationPayload].head
+            payload.context.ingestType shouldBe UpdateIngestType
 
-          assertMetricSent(metrics, result = HttpMetricResults.Success)
-        }
+            assertMetricSent(metrics, result = HttpMetricResults.Success)
+          }
       }
     }
 
@@ -495,15 +502,14 @@ class IngestsApiFeatureTest
     }
 
     it("returns a 500 Server Error if updating the ingest starter fails") {
-      withBrokenApp { case (_, _, metrics, baseUrl) =>
-        whenPostRequestReady(s"$baseUrl/ingests/$randomUUID", createRequest) {
-          response =>
-            assertIsInternalServerErrorResponse(response)
+      withBrokenApp {
+        case (_, _, metrics, baseUrl) =>
+          whenPostRequestReady(s"$baseUrl/ingests/$randomUUID", createRequest) {
+            response =>
+              assertIsInternalServerErrorResponse(response)
 
-            assertMetricSent(
-              metrics,
-              result = HttpMetricResults.ServerError)
-        }
+              assertMetricSent(metrics, result = HttpMetricResults.ServerError)
+          }
       }
     }
   }

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayBag.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayBag.scala
@@ -7,7 +7,6 @@ case class RequestDisplayBag(
   @JsonKey("type") ontologyType: String = "Bag"
 )
 
-
 case class ResponseDisplayBag(
   info: ResponseDisplayBagInfo,
   @JsonKey("type") ontologyType: String = "Bag"

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayBag.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayBag.scala
@@ -6,3 +6,9 @@ case class RequestDisplayBag(
   info: RequestDisplayBagInfo,
   @JsonKey("type") ontologyType: String = "Bag"
 )
+
+
+case class ResponseDisplayBag(
+  info: ResponseDisplayBagInfo,
+  @JsonKey("type") ontologyType: String = "Bag"
+)

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayBagInfo.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayBagInfo.scala
@@ -8,7 +8,6 @@ case class RequestDisplayBagInfo(
   @JsonKey("type") ontologyType: String = "BagInfo"
 )
 
-
 case class ResponseDisplayBagInfo(
   externalIdentifier: ExternalIdentifier,
   version: Option[String],

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayBagInfo.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayBagInfo.scala
@@ -11,5 +11,6 @@ case class RequestDisplayBagInfo(
 
 case class ResponseDisplayBagInfo(
   externalIdentifier: ExternalIdentifier,
+  version: Option[String],
   @JsonKey("type") ontologyType: String = "BagInfo"
 )

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayBagInfo.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayBagInfo.scala
@@ -7,3 +7,9 @@ case class RequestDisplayBagInfo(
   externalIdentifier: ExternalIdentifier,
   @JsonKey("type") ontologyType: String = "BagInfo"
 )
+
+
+case class ResponseDisplayBagInfo(
+  externalIdentifier: ExternalIdentifier,
+  @JsonKey("type") ontologyType: String = "BagInfo"
+)

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayIngest.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayIngest.scala
@@ -39,7 +39,7 @@ case class ResponseDisplayIngest(@JsonKey("@context") context: String,
                                  ingestType: DisplayIngestType,
                                  space: DisplayStorageSpace,
                                  status: DisplayStatus,
-                                 bag: RequestDisplayBag,
+                                 bag: ResponseDisplayBag,
                                  events: Seq[DisplayIngestEvent] = Seq.empty,
                                  createdDate: String,
                                  lastModifiedDate: Option[String],
@@ -56,8 +56,8 @@ object ResponseDisplayIngest {
       callback = ingest.callback.map { DisplayCallback(_) },
       space = DisplayStorageSpace(ingest.space.toString),
       ingestType = DisplayIngestType(ingest.ingestType),
-      bag = RequestDisplayBag(
-        info = RequestDisplayBagInfo(
+      bag = ResponseDisplayBag(
+        info = ResponseDisplayBagInfo(
           externalIdentifier = ingest.externalIdentifier
         )
       ),

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayIngest.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayIngest.scala
@@ -58,7 +58,8 @@ object ResponseDisplayIngest {
       ingestType = DisplayIngestType(ingest.ingestType),
       bag = ResponseDisplayBag(
         info = ResponseDisplayBagInfo(
-          externalIdentifier = ingest.externalIdentifier
+          externalIdentifier = ingest.externalIdentifier,
+          version = ingest.version.map { _.toString }
         )
       ),
       status = DisplayStatus(ingest.status),

--- a/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
+++ b/notifier/src/test/scala/uk/ac/wellcome/platform/archive/notifier/NotifierFeatureTest.scala
@@ -8,6 +8,7 @@ import org.scalatest.concurrent.{Eventually, IntegrationPatience, ScalaFutures}
 import org.scalatest.{FunSpec, Inside, Matchers}
 import uk.ac.wellcome.akka.fixtures.Akka
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion
 import uk.ac.wellcome.platform.archive.common.generators.IngestGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.TimeTestFixture
 import uk.ac.wellcome.platform.archive.common.ingests.models.{
@@ -47,7 +48,8 @@ class NotifierFeatureTest
             val ingest = createIngestWith(
               id = ingestId,
               callback = Some(createCallbackWith(uri = callbackUri)),
-              events = createIngestEvents(count = 2)
+              events = createIngestEvents(count = 2),
+              version = None
             )
 
             sendNotificationToSQS(
@@ -156,7 +158,8 @@ class NotifierFeatureTest
               val ingest = createIngestWith(
                 id = ingestID,
                 callback = Some(createCallbackWith(uri = callbackUri)),
-                events = createIngestEvents(count = 2)
+                events = createIngestEvents(count = 2),
+                version = Some(BagVersion(2))
               )
 
               sendNotificationToSQS(
@@ -182,6 +185,7 @@ class NotifierFeatureTest
                    |    "type": "Bag",
                    |    "info": {
                    |      "type": "BagInfo",
+                   |      "version": "v2",
                    |      "externalIdentifier": "${ingest.externalIdentifier.underlying}"
                    |    }
                    |  },


### PR DESCRIPTION
If we've stored an internal version on the `Ingest`, expose it externally in the ingests API and the callbacks.

Plus a small tidy up in the ingests API tests.

Closes #280. Closes https://github.com/wellcometrust/platform/issues/3770.