### PR TITLE
Better error message if a bag points to something in the fetch file *and* includes a concrete file

### DIFF
--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -53,8 +53,22 @@ class BagVerifier()(
             bag = bag
           )
 
+          actualLocations <- listing.list(root.asPrefix) match {
+            case Right(iterable) => Right(iterable.toSeq)
+            case Left(listingFailure) =>
+              Left(BagVerifierError(listingFailure.e))
+          }
+
+          _ <- verifyNoConcreteFetchEntries(
+            bag = bag,
+            root = root,
+            actualLocations = actualLocations,
+            verificationResult = verificationResult
+          )
+
           _ <- verifyNoUnreferencedFiles(
             root = root,
+            actualLocations = actualLocations,
             verificationResult = verificationResult
           )
 
@@ -62,7 +76,6 @@ class BagVerifier()(
             bag = bag,
             verificationResult = verificationResult
           )
-
         } yield verificationResult
 
       buildStepResult(internalResult, root = root, startTime = startTime)
@@ -166,6 +179,7 @@ class BagVerifier()(
   // Check that there aren't any files in the bag that aren't referenced in
   // either the file manifest or the tag manifest.
   private def verifyNoUnreferencedFiles(
+    actualLocations: Seq[ObjectLocation],
     root: ObjectLocation,
     verificationResult: VerificationResult): InternalResult[Unit] =
     verificationResult match {
@@ -174,57 +188,109 @@ class BagVerifier()(
 
         debug(s"Expecting the bag to contain: $expectedLocations")
 
-        for {
-          actualLocations <- listing.list(root.asPrefix) match {
-            case Right(iterable) => Right(iterable)
-            case Left(listingFailure) =>
-              Left(BagVerifierError(listingFailure.e))
+        val unreferencedLocations = actualLocations
+          .filterNot { expectedLocations.contains(_) }
+          .filterNot {
+            // The tag manifest isn't referred to by other files, so we don't have
+            // it in the list of verifier successes/failures.  But we expect to
+            // see it in the bag.
+            _ == root.join("tagmanifest-sha256.txt")
           }
 
-          unreferencedFiles = actualLocations
-            .filterNot { expectedLocations.contains(_) }
-            .filterNot {
-              // The tag manifest isn't referred to by other files, so we don't have
-              // it in the list of verifier successes/failures.  But we expect to
-              // see it in the bag.
-              _ == root.join("tagmanifest-sha256.txt")
+        if (unreferencedLocations.isEmpty) {
+          Right(())
+        } else {
+
+          // For internal logging, we want a message that contains the full
+          // S3 locations for easy debugging, e.g.:
+          //
+          //    Bag contains 5 files which are not referenced in the manifest:
+          //    bukkit/ingest-id/bag-id/unreferenced1.txt, ...
+          //
+          // For the user-facing message, we want to trim the first part,
+          // because it's an internal detail of the storage service, e.g.:
+          //
+          //    Bag contains 5 files which are not referenced in the manifest:
+          //    unreferenced1.txt, ...
+          //
+          val messagePrefix =
+            if (unreferencedLocations.size == 1) {
+              "Bag contains a file which is not referenced in the manifest: "
+            } else {
+              s"Bag contains ${unreferencedLocations.size} files which are not referenced in the manifest: "
             }
 
-          result <- if (unreferencedFiles.isEmpty)
-            Right(())
-          else {
+          val internalMessage = messagePrefix + unreferencedLocations.mkString(", ")
 
-            // For internal logging, we want a message that contains the full
-            // S3 locations for easy debugging, e.g.:
-            //
-            //    Bag contains 5 files which are not referenced in the manifest:
-            //    bukkit/ingest-id/bag-id/unreferenced1.txt, ...
-            //
-            // For the user-facing message, we want to trim the first part,
-            // because it's an internal detail of the storage service, e.g.:
-            //
-            //    Bag contains 5 files which are not referenced in the manifest:
-            //    unreferenced1.txt, ...
-            //
-            val messagePrefix =
-              if (unreferencedFiles.size == 1) {
-                "Bag contains a file which is not referenced in the manifest: "
-              } else {
-                s"Bag contains ${unreferencedFiles.size} files which are not referenced in the manifest: "
-              }
+          val userMessage = messagePrefix +
+            unreferencedLocations
+              .map { _.path.stripPrefix(root.path) }
+              .mkString(", ")
 
-            val userMessage = messagePrefix +
-              unreferencedFiles
-                .map { _.path.stripPrefix(root.path) }
-                .mkString(", ")
+          Left(
+            BagVerifierError(
+              new Throwable(internalMessage),
+              userMessage = Some(userMessage)
+            )
+          )
+        }
 
-            Left(
-              BagVerifierError(
-                new Throwable(messagePrefix + unreferencedFiles.mkString(", ")),
-                userMessage = Some(userMessage)
-              ))
+      case _ => Right(())
+    }
+
+  // Check that the user hasn't sent any files in the bag which
+  // also have a fetch file entry.
+  private def verifyNoConcreteFetchEntries(
+    actualLocations: Seq[ObjectLocation],
+    bag: Bag,
+    root: ObjectLocation,
+    verificationResult: VerificationResult): InternalResult[Unit] =
+    verificationResult match {
+      case VerificationSuccess(locations) =>
+        val expectedLocations = locations.map { _.objectLocation }
+
+        val bagFetchLocations = bag.fetch match {
+          case Some(fetchEntry) =>
+            fetchEntry
+              .files.map { _.path }
+              .map { path => root.join(path.value) }
+
+          case None             => Seq.empty
+        }
+
+        debug(s"Expecting the bag to contain: $expectedLocations")
+
+        val concreteFetchLocations = actualLocations
+          .filterNot { expectedLocations.contains(_) }
+          .filterNot {
+            // The tag manifest isn't referred to by other files, so we don't have
+            // it in the list of verifier successes/failures.  But we expect to
+            // see it in the bag.
+            _ == root.join("tagmanifest-sha256.txt")
           }
-        } yield result
+          .filter { bagFetchLocations.contains(_) }
+
+        if (concreteFetchLocations.isEmpty) {
+          Right(())
+        } else {
+
+          val messagePrefix =
+            "Files referred to in the fetch.txt also appear in the bag: "
+
+          val internalMessage = messagePrefix + concreteFetchLocations.mkString(", ")
+
+          val userMessage = messagePrefix +
+            concreteFetchLocations
+              .map { _.path.stripPrefix(root.path) }
+              .mkString(", ")
+
+          Left(
+            BagVerifierError(
+              new Throwable(internalMessage),
+              userMessage = Some(userMessage)
+            )
+          )
+        }
 
       case _ => Right(())
     }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -220,7 +220,8 @@ class BagVerifier()(
               s"Bag contains ${unreferencedLocations.size} files which are not referenced in the manifest: "
             }
 
-          val internalMessage = messagePrefix + unreferencedLocations.mkString(", ")
+          val internalMessage = messagePrefix + unreferencedLocations.mkString(
+            ", ")
 
           val userMessage = messagePrefix +
             unreferencedLocations
@@ -251,11 +252,13 @@ class BagVerifier()(
 
         val bagFetchLocations = bag.fetch match {
           case Some(fetchEntry) =>
-            fetchEntry
-              .files.map { _.path }
-              .map { path => root.join(path.value) }
+            fetchEntry.files
+              .map { _.path }
+              .map { path =>
+                root.join(path.value)
+              }
 
-          case None             => Seq.empty
+          case None => Seq.empty
         }
 
         debug(s"Expecting the bag to contain: $expectedLocations")
@@ -277,7 +280,8 @@ class BagVerifier()(
           val messagePrefix =
             "Files referred to in the fetch.txt also appear in the bag: "
 
-          val internalMessage = messagePrefix + concreteFetchLocations.mkString(", ")
+          val internalMessage = messagePrefix + concreteFetchLocations.mkString(
+            ", ")
 
           val userMessage = messagePrefix +
             concreteFetchLocations

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
@@ -43,8 +43,11 @@ class BagVerifierTest
     "bagit.txt",
     "bag-info.txt").size
 
-  private def verifyResultsSize(locations: Seq[VerifiedLocation], expectedSize: Int): Assertion =
-    if (locations.exists { _.verifiableLocation.path.value.endsWith("fetch.txt") }) {
+  private def verifyResultsSize(locations: Seq[VerifiedLocation],
+                                expectedSize: Int): Assertion =
+    if (locations.exists {
+          _.verifiableLocation.path.value.endsWith("fetch.txt")
+        }) {
       locations.size shouldBe expectedSize + 1
     } else {
       locations.size shouldBe expectedSize
@@ -68,7 +71,9 @@ class BagVerifierTest
               .asInstanceOf[VerificationSuccessSummary]
             val verification = summary.verification.value
 
-            verifyResultsSize(verification.locations, expectedSize = expectedFileCount)
+            verifyResultsSize(
+              verification.locations,
+              expectedSize = expectedFileCount)
           }
       }
     }
@@ -95,7 +100,9 @@ class BagVerifierTest
               .asInstanceOf[VerificationFailureSummary]
             val verification = summary.verification.value
 
-            verifyResultsSize(verification.success, expectedSize = expectedFileCount - 1)
+            verifyResultsSize(
+              verification.success,
+              expectedSize = expectedFileCount - 1)
             verification.failure should have size 1
 
             val location = verification.failure.head
@@ -133,7 +140,9 @@ class BagVerifierTest
               .asInstanceOf[VerificationFailureSummary]
             val verification = summary.verification.value
 
-            verifyResultsSize(verification.success, expectedSize = expectedFileCount - 1)
+            verifyResultsSize(
+              verification.success,
+              expectedSize = expectedFileCount - 1)
             verification.failure should have size 1
 
             val location = verification.failure.head
@@ -185,7 +194,6 @@ class BagVerifierTest
     withLocalS3Bucket { bucket =>
       withS3Bag(bucket, dataFileCount = dataFileCount) {
         case (root, bagInfo) =>
-
           // Delete one of the entries in the bag, so the manifest has
           // an entry that doesn't correspond to a real file.
           val keyToDelete =
@@ -207,7 +215,9 @@ class BagVerifierTest
               .asInstanceOf[VerificationFailureSummary]
             val verification = summary.verification.value
 
-            verifyResultsSize(verification.success, expectedSize = expectedFileCount - 1)
+            verifyResultsSize(
+              verification.success,
+              expectedSize = expectedFileCount - 1)
             verification.failure should have size 1
 
             val location = verification.failure.head
@@ -357,7 +367,6 @@ class BagVerifierTest
               )
               location
             }
-
 
             withVerifier { verifier =>
               val ingestStep = verifier.verify(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/VerifiedLocation.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/verify/VerifiedLocation.scala
@@ -2,7 +2,9 @@ package uk.ac.wellcome.platform.archive.common.verify
 
 import uk.ac.wellcome.storage.ObjectLocation
 
-sealed trait VerifiedLocation
+sealed trait VerifiedLocation {
+  val verifiableLocation: VerifiableLocation
+}
 
 case class VerifiedSuccess(verifiableLocation: VerifiableLocation,
                            objectLocation: ObjectLocation,

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagIt.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagIt.scala
@@ -15,6 +15,16 @@ trait BagIt extends BagInfoGenerators {
     """.stripMargin.trim
   }
 
+  case class GeneratedBag(
+    dataFiles: Seq[FileEntry],
+    tagManifestFiles: Seq[FileEntry],
+    metaManifest: Option[FileEntry],
+    bagInfo: BagInfo
+  ) {
+    def allFiles: Seq[FileEntry] =
+      dataFiles ++ tagManifestFiles ++ metaManifest.toList
+  }
+
   def createBag(
     payloadOxum: Option[PayloadOxum],
     externalIdentifier: ExternalIdentifier,
@@ -26,7 +36,7 @@ trait BagIt extends BagInfoGenerators {
       createValidTagManifest,
     createBagItFile: => Option[FileEntry] = createValidBagItFile,
     createBagInfoFile: BagInfo => Option[FileEntry] = createValidBagInfoFile
-  ): (Seq[FileEntry], BagInfo) = {
+  ): GeneratedBag = {
 
     val dataFiles = createDataFiles(dataFileCount)
 
@@ -58,7 +68,7 @@ trait BagIt extends BagInfoGenerators {
 
     val metaManifest = createTagManifest(tagManifestFileAndDigests)
 
-    (dataFiles ++ tagManifestFiles ++ metaManifest.toList, bagInfo)
+    GeneratedBag(dataFiles, tagManifestFiles, metaManifest, bagInfo)
   }
 
   def createValidBagItFile =

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/S3BagLocationFixtures.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/S3BagLocationFixtures.scala
@@ -103,16 +103,16 @@ trait BagLocationFixtures[Namespace]
 
         // Now we need to add an entry for the fetch.txt to the tag manifest
         // file, or the verifier will complain about it being an unreferenced file.
-        val originalManifest = generatedBag.metaManifest.get
-        originalManifest.copy(
-          contents = originalManifest.contents + s"\n${createValidDigest(fetchContents)} fetch.txt"
-        )
-
+        generatedBag.metaManifest.map { originalManifest =>
+          originalManifest.copy(
+            contents = originalManifest.contents + s"\n${createValidDigest(fetchContents)} fetch.txt"
+          )
+        }
       } else {
-        generatedBag.metaManifest.get
+        generatedBag.metaManifest
       }
 
-    val realFiles = realDataFiles ++ generatedBag.tagManifestFiles :+ tagManifest
+    val realFiles = realDataFiles ++ generatedBag.tagManifestFiles ++ tagManifest.toList
 
     realFiles.map { entry =>
       val entryLocation = unpackedBagLocation.join(entry.name)

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/S3BagLocationFixtures.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/S3BagLocationFixtures.scala
@@ -97,7 +97,7 @@ trait BagLocationFixtures[Namespace]
 
       BagFetchEntry(
         uri = new URI(s"s3://${entryLocation.namespace}/${entryLocation.path}"),
-        length = Some(entry.contents.length),
+        length = Some(entry.contents.getBytes.length),
         path = BagPath(entry.name)
       )
     }


### PR DESCRIPTION
Suppose you supply a bag with `myfile.jpg`. The file appears in two places:

* A remote location in the `fetch.txt`
* A concrete file in the bag

Previously, the verifier would reject this bag with the slightly puzzling message:

> Bag contains a file which is not referenced in the manifest: myfile.jpg

Now it explains it a bit better:

> Files referred to in the fetch.txt also appear in the bag: myfile.jpg

A concrete file or a remote location – pick one!

Plus a bunch of fixes that came from *actually* turning on fetch files in tests – the bags created by `createBag()` will now put some files in a fetch.txt, which should make the tests more robust.

Closes https://github.com/wellcometrust/platform/issues/3776