### PR TITLE
Supply a better message if a user sends a fetch.txt entry *and* a file

### DIFF
--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -53,8 +53,22 @@ class BagVerifier()(
             bag = bag
           )
 
+          actualLocations <- listing.list(root.asPrefix) match {
+            case Right(iterable) => Right(iterable.toSeq)
+            case Left(listingFailure) =>
+              Left(BagVerifierError(listingFailure.e))
+          }
+
+          _ <- verifyNoConcreteFetchEntries(
+            bag = bag,
+            root = root,
+            actualLocations = actualLocations,
+            verificationResult = verificationResult
+          )
+
           _ <- verifyNoUnreferencedFiles(
             root = root,
+            actualLocations = actualLocations,
             verificationResult = verificationResult
           )
 
@@ -163,10 +177,58 @@ class BagVerifier()(
       case _ => Right(())
     }
 
+  // Check that the user hasn't sent any files in the bag which
+  // also have a fetch file entry.
+  private def verifyNoConcreteFetchEntries(
+    bag: Bag,
+    root: ObjectLocation,
+    actualLocations: Seq[ObjectLocation],
+    verificationResult: VerificationResult): InternalResult[Unit] =
+    verificationResult match {
+      case VerificationSuccess(_) =>
+        val bagFetchLocations = bag.fetch match {
+          case Some(fetchEntry) =>
+            fetchEntry.files
+              .map { _.path }
+              .map { path => root.join(path.value) }
+
+          case None => Seq.empty
+        }
+
+        val concreteFetchLocations =
+          bagFetchLocations
+            .filter { actualLocations.contains(_) }
+
+        if (concreteFetchLocations.isEmpty) {
+          Right(())
+        } else {
+          val messagePrefix =
+            "Files referred to in the fetch.txt also appear in the bag: "
+
+          val internalMessage = messagePrefix + concreteFetchLocations.mkString(
+            ", ")
+
+          val userMessage = messagePrefix +
+            concreteFetchLocations
+              .map { _.path.stripPrefix(root.path).stripPrefix("/") }
+              .mkString(", ")
+
+          Left(
+            BagVerifierError(
+              new Throwable(internalMessage),
+              userMessage = Some(userMessage)
+            )
+          )
+        }
+
+      case _ => Right(())
+    }
+
   // Check that there aren't any files in the bag that aren't referenced in
   // either the file manifest or the tag manifest.
   private def verifyNoUnreferencedFiles(
     root: ObjectLocation,
+    actualLocations: Seq[ObjectLocation],
     verificationResult: VerificationResult): InternalResult[Unit] =
     verificationResult match {
       case VerificationSuccess(locations) =>
@@ -174,57 +236,48 @@ class BagVerifier()(
 
         debug(s"Expecting the bag to contain: $expectedLocations")
 
-        for {
-          actualLocations <- listing.list(root.asPrefix) match {
-            case Right(iterable) => Right(iterable)
-            case Left(listingFailure) =>
-              Left(BagVerifierError(listingFailure.e))
+        val unreferencedFiles = actualLocations
+          .filterNot { expectedLocations.contains(_) }
+          .filterNot {
+            // The tag manifest isn't referred to by other files, so we don't have
+            // it in the list of verifier successes/failures.  But we expect to
+            // see it in the bag.
+            _ == root.join("tagmanifest-sha256.txt")
           }
 
-          unreferencedFiles = actualLocations
-            .filterNot { expectedLocations.contains(_) }
-            .filterNot {
-              // The tag manifest isn't referred to by other files, so we don't have
-              // it in the list of verifier successes/failures.  But we expect to
-              // see it in the bag.
-              _ == root.join("tagmanifest-sha256.txt")
-            }
-
-          result <- if (unreferencedFiles.isEmpty)
-            Right(())
-          else {
-
-            // For internal logging, we want a message that contains the full
-            // S3 locations for easy debugging, e.g.:
-            //
-            //    Bag contains 5 files which are not referenced in the manifest:
-            //    bukkit/ingest-id/bag-id/unreferenced1.txt, ...
-            //
-            // For the user-facing message, we want to trim the first part,
-            // because it's an internal detail of the storage service, e.g.:
-            //
-            //    Bag contains 5 files which are not referenced in the manifest:
-            //    unreferenced1.txt, ...
-            //
-            val messagePrefix =
-              if (unreferencedFiles.size == 1) {
-                "Bag contains a file which is not referenced in the manifest: "
-              } else {
-                s"Bag contains ${unreferencedFiles.size} files which are not referenced in the manifest: "
-              }
-
-            val userMessage = messagePrefix +
-              unreferencedFiles
-                .map { _.path.stripPrefix(root.path) }
-                .mkString(", ")
-
-            Left(
-              BagVerifierError(
-                new Throwable(messagePrefix + unreferencedFiles.mkString(", ")),
-                userMessage = Some(userMessage)
-              ))
+        if (unreferencedFiles.isEmpty) {
+          Right(())
+        } else {
+          // For internal logging, we want a message that contains the full
+          // S3 locations for easy debugging, e.g.:
+          //
+          //    Bag contains 5 files which are not referenced in the manifest:
+          //    bukkit/ingest-id/bag-id/unreferenced1.txt, ...
+          //
+          // For the user-facing message, we want to trim the first part,
+          // because it's an internal detail of the storage service, e.g.:
+          //
+          //    Bag contains 5 files which are not referenced in the manifest:
+          //    unreferenced1.txt, ...
+          //
+          val messagePrefix =
+          if (unreferencedFiles.size == 1) {
+            "Bag contains a file which is not referenced in the manifest: "
+          } else {
+            s"Bag contains ${unreferencedFiles.size} files which are not referenced in the manifest: "
           }
-        } yield result
+
+          val userMessage = messagePrefix +
+            unreferencedFiles
+              .map { _.path.stripPrefix(root.path) }
+              .mkString(", ")
+
+          Left(
+            BagVerifierError(
+              new Throwable(messagePrefix + unreferencedFiles.mkString(", ")),
+              userMessage = Some(userMessage)
+            ))
+        }
 
       case _ => Right(())
     }

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -190,7 +190,9 @@ class BagVerifier()(
           case Some(fetchEntry) =>
             fetchEntry.files
               .map { _.path }
-              .map { path => root.join(path.value) }
+              .map { path =>
+                root.join(path.value)
+              }
 
           case None => Seq.empty
         }
@@ -261,11 +263,11 @@ class BagVerifier()(
           //    unreferenced1.txt, ...
           //
           val messagePrefix =
-          if (unreferencedFiles.size == 1) {
-            "Bag contains a file which is not referenced in the manifest: "
-          } else {
-            s"Bag contains ${unreferencedFiles.size} files which are not referenced in the manifest: "
-          }
+            if (unreferencedFiles.size == 1) {
+              "Bag contains a file which is not referenced in the manifest: "
+            } else {
+              s"Bag contains ${unreferencedFiles.size} files which are not referenced in the manifest: "
+            }
 
           val userMessage = messagePrefix +
             unreferencedFiles

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
@@ -14,6 +14,7 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.{
   PayloadOxum
 }
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagUnavailable
+import uk.ac.wellcome.platform.archive.common.bagit.services.s3.S3BagReader
 import uk.ac.wellcome.platform.archive.common.fixtures.{
   S3BagBuilder,
   S3BagBuilderBase
@@ -428,6 +429,45 @@ class BagVerifierTest
         ingestFailed.maybeUserFacingMessage.get shouldBe
           s"Bag contains 3 files which are not referenced in the manifest: " +
             "/unreferencedfile_1.txt, /unreferencedfile_2.txt, /unreferencedfile_3.txt"
+      }
+    }
+
+    it("fails if a file in the fetch.txt also appears in the bag") {
+      withLocalS3Bucket { bucket =>
+        val alwaysWriteAsFetchBuilder = new S3BagBuilderBase {
+          override protected def getFetchEntryCount(payloadFileCount: Int): Int =
+            payloadFileCount
+        }
+
+        val (root, bagInfo) = alwaysWriteAsFetchBuilder.createS3BagWith(bucket)
+
+        val bag = new S3BagReader().get(root).right.value
+
+        // Write one of the fetch.txt entries as a concrete file
+        val badFetchEntry = bag.fetch.get.files.head
+        val badFetchLocation = root.join(badFetchEntry.path.value)
+
+        s3Client.putObject(
+          badFetchLocation.namespace,
+          badFetchLocation.path,
+          randomAlphanumeric
+        )
+
+        val ingestStep =
+          withVerifier {
+            _.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+          }
+
+        val result = ingestStep.success.get
+
+        result shouldBe a[IngestFailed[_]]
+        val ingestFailed = result.asInstanceOf[IngestFailed[_]]
+
+        ingestFailed.e.getMessage shouldBe
+          s"Files referred to in the fetch.txt also appear in the bag: ${root.join(badFetchEntry.path.value)}"
+
+        ingestFailed.maybeUserFacingMessage.get shouldBe
+          s"Files referred to in the fetch.txt also appear in the bag: ${badFetchEntry.path}"
       }
     }
   }

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
@@ -435,7 +435,8 @@ class BagVerifierTest
     it("fails if a file in the fetch.txt also appears in the bag") {
       withLocalS3Bucket { bucket =>
         val alwaysWriteAsFetchBuilder = new S3BagBuilderBase {
-          override protected def getFetchEntryCount(payloadFileCount: Int): Int =
+          override protected def getFetchEntryCount(
+            payloadFileCount: Int): Int =
             payloadFileCount
         }
 
@@ -464,7 +465,8 @@ class BagVerifierTest
         val ingestFailed = result.asInstanceOf[IngestFailed[_]]
 
         ingestFailed.e.getMessage shouldBe
-          s"Files referred to in the fetch.txt also appear in the bag: ${root.join(badFetchEntry.path.value)}"
+          s"Files referred to in the fetch.txt also appear in the bag: ${root
+            .join(badFetchEntry.path.value)}"
 
         ingestFailed.maybeUserFacingMessage.get shouldBe
           s"Files referred to in the fetch.txt also appear in the bag: ${badFetchEntry.path}"

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilderBase.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilderBase.scala
@@ -41,7 +41,7 @@ trait BagBuilderBase extends StorageSpaceGenerators with BagInfoGenerators {
         metadata = Map.empty)) shouldBe a[Right[_, _]]
     }
 
-  protected def getFetchEntryCount(payloadFileCount: Int) =
+  protected def getFetchEntryCount(payloadFileCount: Int): Int =
     randomInt(from = 0, to = payloadFileCount)
 
   def createBagContentsWith(


### PR DESCRIPTION
Currently it gives a less than helpful message:

> Bag contains a file which is not referenced in the manifest: myfile.jpg

Now it explains it a bit better:

> Files referred to in the fetch.txt also appear in the bag: myfile.jpg

A concrete file or a remote location – pick one!

Closes wellcometrust/platform#3776, replaces #288.