### PR TITLE
Include the name of bad files in the verifier output

### DIFF
--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -333,12 +333,13 @@ class BagVerifier()(
         warn(s"Errors verifying $root:\n$verificationFailureMessage")
 
         val errorCount = result.failure.size
+        val pathList = result.failure.map { _.verifiableLocation.path.value }.mkString(", ")
 
         val userFacingMessage =
           if (errorCount == 1)
-            "There was 1 error verifying the bag"
+            s"Unable to verify one file in the bag: $pathList"
           else
-            s"There were $errorCount errors verifying the bag"
+            s"Unable to verify $errorCount files in the bag: $pathList"
 
         IngestFailed(
           summary = VerificationFailureSummary(

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -333,7 +333,8 @@ class BagVerifier()(
         warn(s"Errors verifying $root:\n$verificationFailureMessage")
 
         val errorCount = result.failure.size
-        val pathList = result.failure.map { _.verifiableLocation.path.value }.mkString(", ")
+        val pathList =
+          result.failure.map { _.verifiableLocation.path.value }.mkString(", ")
 
         val userFacingMessage =
           if (errorCount == 1)

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
@@ -115,7 +115,7 @@ class BagVerifierTest
 
       val userFacingMessage =
         result.asInstanceOf[IngestFailed[_]].maybeUserFacingMessage
-      userFacingMessage.get shouldBe "There was 1 error verifying the bag"
+      userFacingMessage.get should startWith("Unable to verify one file in the bag:")
     }
   }
 
@@ -182,7 +182,7 @@ class BagVerifierTest
 
       val userFacingMessage =
         result.asInstanceOf[IngestFailed[_]].maybeUserFacingMessage
-      userFacingMessage.get shouldBe s"There were $payloadFileCount errors verifying the bag"
+      userFacingMessage.get should startWith(s"Unable to verify $payloadFileCount files in the bag:")
     }
   }
 

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
@@ -115,7 +115,8 @@ class BagVerifierTest
 
       val userFacingMessage =
         result.asInstanceOf[IngestFailed[_]].maybeUserFacingMessage
-      userFacingMessage.get should startWith("Unable to verify one file in the bag:")
+      userFacingMessage.get should startWith(
+        "Unable to verify one file in the bag:")
     }
   }
 
@@ -182,7 +183,8 @@ class BagVerifierTest
 
       val userFacingMessage =
         result.asInstanceOf[IngestFailed[_]].maybeUserFacingMessage
-      userFacingMessage.get should startWith(s"Unable to verify $payloadFileCount files in the bag:")
+      userFacingMessage.get should startWith(
+        s"Unable to verify $payloadFileCount files in the bag:")
     }
   }
 


### PR DESCRIPTION
Previously it'd say something like:

> There was 1 error verifying the bag

Now it says:

> Unable to verify one file in the bag: fetch.txt

This makes it easier for end-users to debug issues with their bags, especially in manual testing.