### PR TITLE
Collect the sizes in StorageManifestService

### DIFF
--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/models/DisplayFile.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/models/DisplayFile.scala
@@ -7,6 +7,7 @@ case class DisplayFile(
   checksum: String,
   name: String,
   path: String,
+  size: Long,
   @JsonKey("type") ontologyType: String = "File"
 )
 
@@ -15,6 +16,7 @@ case object DisplayFile {
     DisplayFile(
       checksum = file.checksum.value,
       name = file.name,
-      path = file.path
+      path = file.path,
+      size = file.size
     )
 }

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/Main.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/Main.scala
@@ -28,7 +28,10 @@ import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 
 import scala.concurrent.ExecutionContext
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.platform.archive.common.storage.services.S3SizeFinder
+import uk.ac.wellcome.platform.archive.common.storage.services.{
+  S3SizeFinder,
+  StorageManifestService
+}
 
 object Main extends WellcomeTypesafeApp {
   runWithConfig { config: Config =>
@@ -56,10 +59,14 @@ object Main extends WellcomeTypesafeApp {
       operationName
     )
 
+    val storageManifestService = new StorageManifestService(
+      sizeFinder = new S3SizeFinder()
+    )
+
     val register = new Register(
       bagReader = new S3BagReader(),
-      storageManifestVHS,
-      sizeFinder = new S3SizeFinder()
+      storageManifestDao = storageManifestVHS,
+      storageManifestService = storageManifestService
     )
 
     val outgoingPublisher = OutgoingPublisherBuilder.build(

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/Main.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/Main.scala
@@ -28,6 +28,7 @@ import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
 
 import scala.concurrent.ExecutionContext
 import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.platform.archive.common.storage.services.S3SizeFinder
 
 object Main extends WellcomeTypesafeApp {
   runWithConfig { config: Config =>
@@ -57,7 +58,8 @@ object Main extends WellcomeTypesafeApp {
 
     val register = new Register(
       bagReader = new S3BagReader(),
-      storageManifestVHS
+      storageManifestVHS,
+      sizeFinder = new S3SizeFinder()
     )
 
     val outgoingPublisher = OutgoingPublisherBuilder.build(

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
@@ -25,7 +25,10 @@ import uk.ac.wellcome.platform.archive.common.ingests.models.{
   IngestStatusUpdate
 }
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.platform.archive.common.storage.services.StorageManifestDao
+import uk.ac.wellcome.platform.archive.common.storage.services.{
+  MemorySizeFinder,
+  StorageManifestDao
+}
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.store.fixtures.StringNamespaceFixtures
 import uk.ac.wellcome.storage.store.memory.{MemoryStreamStore, MemoryTypedStore}
@@ -57,10 +60,13 @@ trait BagRegisterFixtures
 
         val bagReader = new MemoryBagReader()
 
+        val sizeFinder = new MemorySizeFinder(streamStore.memoryStore)
+
         withLocalSqsQueueAndDlq { queuePair =>
           val register = new Register(
             bagReader = bagReader,
-            storageManifestDao
+            storageManifestDao,
+            sizeFinder = sizeFinder
           )
 
           val service = new BagRegisterWorker(

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
@@ -27,7 +27,8 @@ import uk.ac.wellcome.platform.archive.common.ingests.models.{
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.platform.archive.common.storage.services.{
   MemorySizeFinder,
-  StorageManifestDao
+  StorageManifestDao,
+  StorageManifestService
 }
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.store.fixtures.StringNamespaceFixtures
@@ -60,13 +61,15 @@ trait BagRegisterFixtures
 
         val bagReader = new MemoryBagReader()
 
-        val sizeFinder = new MemorySizeFinder(streamStore.memoryStore)
+        val storageManifestService = new StorageManifestService(
+          sizeFinder = new MemorySizeFinder(streamStore.memoryStore)
+        )
 
         withLocalSqsQueueAndDlq { queuePair =>
           val register = new Register(
             bagReader = bagReader,
             storageManifestDao,
-            sizeFinder = sizeFinder
+            storageManifestService = storageManifestService
           )
 
           val service = new BagRegisterWorker(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageManifest.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageManifest.scala
@@ -16,7 +16,8 @@ import uk.ac.wellcome.platform.archive.common.verify.{
 case class StorageManifestFile(
   checksum: ChecksumValue,
   name: String,
-  path: String
+  path: String,
+  size: Long
 )
 
 case class FileManifest(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageManifest.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageManifest.scala
@@ -3,7 +3,6 @@ package uk.ac.wellcome.platform.archive.common.storage.models
 import java.time.Instant
 
 import uk.ac.wellcome.platform.archive.common.bagit.models.{
-  BagFile,
   BagId,
   BagInfo,
   BagVersion
@@ -14,22 +13,11 @@ import uk.ac.wellcome.platform.archive.common.verify.{
   HashingAlgorithm
 }
 
-// TODO: These need better names!
 case class StorageManifestFile(
   checksum: ChecksumValue,
   name: String,
   path: String
 )
-
-case object StorageManifestFile {
-  // TODO: Ditch this, temporary method
-  def apply(bagFile: BagFile): StorageManifestFile =
-    StorageManifestFile(
-      checksum = bagFile.checksum.value,
-      name = bagFile.path.value,
-      path = bagFile.path.value
-    )
-}
 
 case class FileManifest(
   checksumAlgorithm: HashingAlgorithm,

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/SizeFinder.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/SizeFinder.scala
@@ -1,0 +1,39 @@
+package uk.ac.wellcome.platform.archive.common.storage.services
+
+import com.amazonaws.services.s3.AmazonS3
+import uk.ac.wellcome.storage.listing.s3.S3ObjectSummaryListing
+import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryStreamStoreEntry}
+import uk.ac.wellcome.storage.{ListingFailure, ObjectLocation, ObjectLocationPrefix}
+
+trait SizeFinder {
+  def getSizesUnder(prefix: ObjectLocationPrefix): Either[ListingFailure[ObjectLocationPrefix], Map[ObjectLocation, Long]]
+}
+
+class MemorySizeFinder(memoryStore: MemoryStore[ObjectLocation, MemoryStreamStoreEntry]) extends SizeFinder {
+  override def getSizesUnder(prefix: ObjectLocationPrefix): Either[ListingFailure[ObjectLocationPrefix], Map[ObjectLocation, Long]] =
+    Right(
+      memoryStore.entries
+        .filter { case (location, entry) =>
+          prefix.namespace == location.namespace && location.path.startsWith(prefix.path)
+        }
+        .map { case (location, entry) => (location, entry.bytes.length.toLong) }
+    )
+}
+
+class S3SizeFinder(implicit s3Client: AmazonS3) extends SizeFinder {
+  val listing = new S3ObjectSummaryListing()
+
+  override def getSizesUnder(prefix: ObjectLocationPrefix): Either[ListingFailure[ObjectLocationPrefix], Map[ObjectLocation, Long]] =
+    listing.list(prefix)
+      .map { iterator =>
+        iterator.map { summary =>
+          val location = ObjectLocation(
+            namespace = summary.getBucketName,
+            path = summary.getKey
+          )
+
+          location -> summary.getSize
+        }
+          .toMap
+      }
+}

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/SizeFinder.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/SizeFinder.scala
@@ -3,18 +3,28 @@ package uk.ac.wellcome.platform.archive.common.storage.services
 import com.amazonaws.services.s3.AmazonS3
 import uk.ac.wellcome.storage.listing.s3.S3ObjectSummaryListing
 import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryStreamStoreEntry}
-import uk.ac.wellcome.storage.{ListingFailure, ObjectLocation, ObjectLocationPrefix}
-
-trait SizeFinder {
-  def getSizesUnder(prefix: ObjectLocationPrefix): Either[ListingFailure[ObjectLocationPrefix], Map[ObjectLocation, Long]]
+import uk.ac.wellcome.storage.{
+  ListingFailure,
+  ObjectLocation,
+  ObjectLocationPrefix
 }
 
-class MemorySizeFinder(memoryStore: MemoryStore[ObjectLocation, MemoryStreamStoreEntry]) extends SizeFinder {
-  override def getSizesUnder(prefix: ObjectLocationPrefix): Either[ListingFailure[ObjectLocationPrefix], Map[ObjectLocation, Long]] =
+trait SizeFinder {
+  def getSizesUnder(prefix: ObjectLocationPrefix)
+    : Either[ListingFailure[ObjectLocationPrefix], Map[ObjectLocation, Long]]
+}
+
+class MemorySizeFinder(
+  memoryStore: MemoryStore[ObjectLocation, MemoryStreamStoreEntry])
+    extends SizeFinder {
+  override def getSizesUnder(prefix: ObjectLocationPrefix)
+    : Either[ListingFailure[ObjectLocationPrefix], Map[ObjectLocation, Long]] =
     Right(
       memoryStore.entries
-        .filter { case (location, entry) =>
-          prefix.namespace == location.namespace && location.path.startsWith(prefix.path)
+        .filter {
+          case (location, entry) =>
+            prefix.namespace == location.namespace && location.path.startsWith(
+              prefix.path)
         }
         .map { case (location, entry) => (location, entry.bytes.length.toLong) }
     )
@@ -23,8 +33,10 @@ class MemorySizeFinder(memoryStore: MemoryStore[ObjectLocation, MemoryStreamStor
 class S3SizeFinder(implicit s3Client: AmazonS3) extends SizeFinder {
   val listing = new S3ObjectSummaryListing()
 
-  override def getSizesUnder(prefix: ObjectLocationPrefix): Either[ListingFailure[ObjectLocationPrefix], Map[ObjectLocation, Long]] =
-    listing.list(prefix)
+  override def getSizesUnder(prefix: ObjectLocationPrefix)
+    : Either[ListingFailure[ObjectLocationPrefix], Map[ObjectLocation, Long]] =
+    listing
+      .list(prefix)
       .map { iterator =>
         iterator.map { summary =>
           val location = ObjectLocation(
@@ -33,7 +45,6 @@ class S3SizeFinder(implicit s3Client: AmazonS3) extends SizeFinder {
           )
 
           location -> summary.getSize
-        }
-          .toMap
+        }.toMap
       }
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/SizeFinder.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/SizeFinder.scala
@@ -1,50 +1,33 @@
 package uk.ac.wellcome.platform.archive.common.storage.services
 
 import com.amazonaws.services.s3.AmazonS3
-import uk.ac.wellcome.storage.listing.s3.S3ObjectSummaryListing
+import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryStreamStoreEntry}
-import uk.ac.wellcome.storage.{
-  ListingFailure,
-  ObjectLocation,
-  ObjectLocationPrefix
-}
+
+import scala.util.Try
 
 trait SizeFinder {
-  def getSizesUnder(prefix: ObjectLocationPrefix)
-    : Either[ListingFailure[ObjectLocationPrefix], Map[ObjectLocation, Long]]
+  def getSize(location: ObjectLocation): Try[Long]
 }
 
 class MemorySizeFinder(
   memoryStore: MemoryStore[ObjectLocation, MemoryStreamStoreEntry])
     extends SizeFinder {
-  override def getSizesUnder(prefix: ObjectLocationPrefix)
-    : Either[ListingFailure[ObjectLocationPrefix], Map[ObjectLocation, Long]] =
-    Right(
-      memoryStore.entries
-        .filter {
-          case (location, entry) =>
-            prefix.namespace == location.namespace && location.path.startsWith(
-              prefix.path)
-        }
-        .map { case (location, entry) => (location, entry.bytes.length.toLong) }
-    )
+  override def getSize(location: ObjectLocation): Try[Long] = Try {
+    memoryStore
+      .entries
+      .getOrElse(location,
+        throw new Throwable(s"No such entry $location!")
+      )
+      .bytes.length
+  }
 }
 
 class S3SizeFinder(implicit s3Client: AmazonS3) extends SizeFinder {
-  val listing = new S3ObjectSummaryListing()
-
-  override def getSizesUnder(prefix: ObjectLocationPrefix)
-    : Either[ListingFailure[ObjectLocationPrefix], Map[ObjectLocation, Long]] =
-    listing
-      .list(prefix)
-      .map { iterator =>
-        iterator.map { summary =>
-          val location = ObjectLocation(
-            namespace = summary.getBucketName,
-            path = summary.getKey
-          )
-
-          location -> summary.getSize
-        }.toMap
-      }
+  def getSize(location: ObjectLocation): Try[Long] = Try {
+    s3Client
+      .getObject(location.namespace, location.path)
+      .getObjectMetadata
+      .getContentLength
+  }
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/SizeFinder.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/SizeFinder.scala
@@ -14,12 +14,10 @@ class MemorySizeFinder(
   memoryStore: MemoryStore[ObjectLocation, MemoryStreamStoreEntry])
     extends SizeFinder {
   override def getSize(location: ObjectLocation): Try[Long] = Try {
-    memoryStore
-      .entries
-      .getOrElse(location,
-        throw new Throwable(s"No such entry $location!")
-      )
-      .bytes.length
+    memoryStore.entries
+      .getOrElse(location, throw new Throwable(s"No such entry $location!"))
+      .bytes
+      .length
   }
 }
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
@@ -119,9 +119,10 @@ class StorageManifestService(sizeFinder: SizeFinder) extends Logging {
         )
     }
 
-  private def getSizeAndLocation(matchedLocation: MatchedLocation,
-                                 bagRoot: ObjectLocationPrefix,
-                                 version: BagVersion): (ObjectLocation, Option[Long]) =
+  private def getSizeAndLocation(
+    matchedLocation: MatchedLocation,
+    bagRoot: ObjectLocationPrefix,
+    version: BagVersion): (ObjectLocation, Option[Long]) =
     matchedLocation.fetchEntry match {
       // This is a concrete file inside the replicated bag,
       // so it's inside the versioned replica directory.
@@ -175,7 +176,9 @@ class StorageManifestService(sizeFinder: SizeFinder) extends Logging {
     version: BagVersion): Try[Map[BagPath, (ObjectLocation, Option[Long])]] =
     Try {
       matchedLocations.map { matchedLoc =>
-        (matchedLoc.bagFile.path, getSizeAndLocation(matchedLoc, bagRoot, version))
+        (
+          matchedLoc.bagFile.path,
+          getSizeAndLocation(matchedLoc, bagRoot, version))
       }.toMap
     }
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
@@ -38,7 +38,10 @@ object StorageManifestService extends Logging {
     for {
       bagRoot <- getBagRoot(replicaRoot, version)
 
-      entries <- createPathLocationMap(bag, bagRoot = bagRoot, version = version)
+      entries <- createPathLocationMap(
+        bag,
+        bagRoot = bagRoot,
+        version = version)
 
       fileManifestFiles <- createManifestFiles(
         bagRoot = bagRoot,
@@ -121,7 +124,10 @@ object StorageManifestService extends Logging {
           val location = matchedLoc.fetchEntry match {
             // This is a concrete file inside the replicated bag,
             // so it's inside the versioned replica directory.
-            case None => bagRoot.asLocation(version.toString, matchedLoc.bagFile.path.value)
+            case None =>
+              bagRoot.asLocation(
+                version.toString,
+                matchedLoc.bagFile.path.value)
 
             // This is referring to a fetch file somewhere else.
             // We need to check it's in another versioned directory
@@ -184,9 +190,10 @@ object StorageManifestService extends Logging {
 
       val size: Long = sizes.get(location) match {
         case Some(s) => s
-        case None => throw new StorageManifestException(
-          s"Could not find size for location $location"
-        )
+        case None =>
+          throw new StorageManifestException(
+            s"Could not find size for location $location"
+          )
       }
 
       StorageManifestFile(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
@@ -189,12 +189,11 @@ object StorageManifestService extends Logging {
         )
       }
 
-      debug(s"size = $size")
-
       StorageManifestFile(
         checksum = bagFile.checksum.value,
         name = bagFile.path.value,
-        path = path
+        path = path,
+        size = size
       )
     }
   }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/BagFileGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/BagFileGenerators.scala
@@ -4,6 +4,7 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.{BagFile, BagPath}
 import uk.ac.wellcome.platform.archive.common.verify.{
   Checksum,
   ChecksumValue,
+  HashingAlgorithm,
   SHA256
 }
 import uk.ac.wellcome.storage.generators.RandomThings
@@ -11,11 +12,12 @@ import uk.ac.wellcome.storage.generators.RandomThings
 trait BagFileGenerators extends RandomThings {
   def createBagFileWith(
     path: String = randomAlphanumeric,
-    checksum: String = randomAlphanumeric
+    checksum: String = randomAlphanumeric,
+    checksumAlgorithm: HashingAlgorithm = SHA256
   ): BagFile =
     BagFile(
       checksum = Checksum(
-        algorithm = SHA256,
+        algorithm = checksumAlgorithm,
         value = ChecksumValue(checksum)
       ),
       path = BagPath(path)

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
@@ -32,7 +32,8 @@ trait StorageManifestGenerators
     StorageManifestFile(
       checksum = bagFile.checksum.value,
       name = bagFile.path.value,
-      path = bagFile.path.value
+      path = bagFile.path.value,
+      size = Random.nextLong().abs
     )
   }
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
@@ -27,6 +27,15 @@ trait StorageManifestGenerators
 
   val checksumAlgorithm = SHA256
 
+  private def createStorageManifestFile: StorageManifestFile = {
+    val bagFile = createBagFile
+    StorageManifestFile(
+      checksum = bagFile.checksum.value,
+      name = bagFile.path.value,
+      path = bagFile.path.value
+    )
+  }
+
   def createStorageManifestWith(
     space: StorageSpace = createStorageSpace,
     bagInfo: BagInfo = createBagInfo,
@@ -40,17 +49,17 @@ trait StorageManifestGenerators
       manifest = FileManifest(
         checksumAlgorithm,
         files = Seq(
-          StorageManifestFile(createBagFile),
-          StorageManifestFile(createBagFile),
-          StorageManifestFile(createBagFile)
+          createStorageManifestFile,
+          createStorageManifestFile,
+          createStorageManifestFile
         )
       ),
       tagManifest = FileManifest(
         checksumAlgorithm,
         files = Seq(
-          StorageManifestFile(createBagFile),
-          StorageManifestFile(createBagFile),
-          StorageManifestFile(createBagFile)
+          createStorageManifestFile,
+          createStorageManifestFile,
+          createStorageManifestFile
         )
       ),
       locations = locations.map { StorageLocation(StandardStorageProvider, _) },

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/SizeFinderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/SizeFinderTest.scala
@@ -10,14 +10,19 @@ import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
 import uk.ac.wellcome.storage.streaming.Codec._
 import uk.ac.wellcome.storage.streaming.InputStreamWithLengthAndMetadata
 
-trait SizeFinderTestCases[Context] extends FunSpec with Matchers with EitherValues {
+trait SizeFinderTestCases[Context]
+    extends FunSpec
+    with Matchers
+    with EitherValues {
   def withContext[R](testWith: TestWith[Context, R]): R
 
-  def withSizeFinder[R](testWith: TestWith[SizeFinder, R])(implicit context: Context): R
+  def withSizeFinder[R](testWith: TestWith[SizeFinder, R])(
+    implicit context: Context): R
 
   def createLocation(implicit context: Context): ObjectLocation
 
-  def createObjectAtLocation(location: ObjectLocation, contents: String)(implicit context: Context): Unit
+  def createObjectAtLocation(location: ObjectLocation, contents: String)(
+    implicit context: Context): Unit
 
   describe("it behaves as a size finder") {
     it("finds the sizes of objects in a prefix") {
@@ -47,8 +52,11 @@ trait SizeFinderTestCases[Context] extends FunSpec with Matchers with EitherValu
   }
 }
 
-class MemorySizeFinderTest extends SizeFinderTestCases[MemoryStreamStore[ObjectLocation]] with ObjectLocationGenerators {
-  override def withContext[R](testWith: TestWith[MemoryStreamStore[ObjectLocation], R]): R =
+class MemorySizeFinderTest
+    extends SizeFinderTestCases[MemoryStreamStore[ObjectLocation]]
+    with ObjectLocationGenerators {
+  override def withContext[R](
+    testWith: TestWith[MemoryStreamStore[ObjectLocation], R]): R =
     testWith(MemoryStreamStore[ObjectLocation]())
 
   override def withSizeFinder[R](testWith: TestWith[SizeFinder, R])(
@@ -61,9 +69,9 @@ class MemorySizeFinderTest extends SizeFinderTestCases[MemoryStreamStore[ObjectL
     implicit streamStore: MemoryStreamStore[ObjectLocation]): ObjectLocation =
     createObjectLocation
 
-  override def createObjectAtLocation(
-    location: ObjectLocation,
-    contents: String)(implicit streamStore: MemoryStreamStore[ObjectLocation]): Unit = {
+  override def createObjectAtLocation(location: ObjectLocation,
+                                      contents: String)(
+    implicit streamStore: MemoryStreamStore[ObjectLocation]): Unit = {
     val is = stringCodec.toStream(contents).right.value
     streamStore.put(location)(
       InputStreamWithLengthAndMetadata(is, metadata = Map.empty)
@@ -75,7 +83,8 @@ class S3SizeFinderTest extends SizeFinderTestCases[Bucket] with S3Fixtures {
   override def withContext[R](testWith: TestWith[Bucket, R]): R =
     withLocalS3Bucket { testWith }
 
-  override def withSizeFinder[R](testWith: TestWith[SizeFinder, R])(implicit bucket: Bucket): R =
+  override def withSizeFinder[R](testWith: TestWith[SizeFinder, R])(
+    implicit bucket: Bucket): R =
     testWith(
       new S3SizeFinder()
     )
@@ -83,7 +92,9 @@ class S3SizeFinderTest extends SizeFinderTestCases[Bucket] with S3Fixtures {
   override def createLocation(implicit bucket: Bucket): ObjectLocation =
     createObjectLocationWith(bucket)
 
-  override def createObjectAtLocation(location: ObjectLocation, contents:  String)(implicit context: Bucket): Unit =
+  override def createObjectAtLocation(
+    location: ObjectLocation,
+    contents: String)(implicit context: Bucket): Unit =
     s3Client.putObject(
       location.namespace,
       location.path,

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/SizeFinderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/SizeFinderTest.scala
@@ -1,0 +1,100 @@
+package uk.ac.wellcome.platform.archive.common.storage.services
+
+import org.scalatest.{EitherValues, FunSpec, Matchers}
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.storage.{ListingFailure, ObjectLocation}
+import uk.ac.wellcome.storage.fixtures.S3Fixtures
+import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
+import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
+import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
+import uk.ac.wellcome.storage.streaming.Codec._
+import uk.ac.wellcome.storage.streaming.InputStreamWithLengthAndMetadata
+
+trait SizeFinderTestCases[Context] extends FunSpec with Matchers with EitherValues {
+  def withContext[R](testWith: TestWith[Context, R]): R
+
+  def withSizeFinder[R](testWith: TestWith[SizeFinder, R])(implicit context: Context): R
+
+  def createLocation(implicit context: Context): ObjectLocation
+
+  def createObjectAtLocation(location: ObjectLocation, contents: String)(implicit context: Context): Unit
+
+  describe("it behaves as a size finder") {
+    it("finds the sizes of objects in a prefix") {
+      withContext { implicit context =>
+        val location = createLocation
+        createObjectAtLocation(location, "the quick brown fox")
+
+        val result = withSizeFinder {
+          _.getSizesUnder(location.asPrefix)
+        }
+
+        result.right.value shouldBe Map(location -> 19L)
+      }
+    }
+
+    it("returns an empty list if there's nothing under the prefix") {
+      withContext { implicit context =>
+        val prefix = createLocation.asPrefix
+
+        val result = withSizeFinder {
+          _.getSizesUnder(prefix)
+        }
+
+        result.right.value shouldBe Map.empty
+      }
+    }
+  }
+}
+
+class MemorySizeFinderTest extends SizeFinderTestCases[MemoryStreamStore[ObjectLocation]] with ObjectLocationGenerators {
+  override def withContext[R](testWith: TestWith[MemoryStreamStore[ObjectLocation], R]): R =
+    testWith(MemoryStreamStore[ObjectLocation]())
+
+  override def withSizeFinder[R](testWith: TestWith[SizeFinder, R])(
+    implicit streamStore: MemoryStreamStore[ObjectLocation]): R =
+    testWith(
+      new MemorySizeFinder(streamStore.memoryStore)
+    )
+
+  override def createLocation(
+    implicit streamStore: MemoryStreamStore[ObjectLocation]): ObjectLocation =
+    createObjectLocation
+
+  override def createObjectAtLocation(
+    location: ObjectLocation,
+    contents: String)(implicit streamStore: MemoryStreamStore[ObjectLocation]): Unit = {
+    val is = stringCodec.toStream(contents).right.value
+    streamStore.put(location)(
+      InputStreamWithLengthAndMetadata(is, metadata = Map.empty)
+    )
+  }
+}
+
+class S3SizeFinderTest extends SizeFinderTestCases[Bucket] with S3Fixtures {
+  override def withContext[R](testWith: TestWith[Bucket, R]): R =
+    withLocalS3Bucket { testWith }
+
+  override def withSizeFinder[R](testWith: TestWith[SizeFinder, R])(implicit bucket: Bucket): R =
+    testWith(
+      new S3SizeFinder()
+    )
+
+  override def createLocation(implicit bucket: Bucket): ObjectLocation =
+    createObjectLocationWith(bucket)
+
+  override def createObjectAtLocation(location: ObjectLocation, contents:  String)(implicit context: Bucket): Unit =
+    s3Client.putObject(
+      location.namespace,
+      location.path,
+      contents
+    )
+
+  it("fails if the prefix is for a non-existent S3 bucket") {
+    val finder = new S3SizeFinder()
+
+    val result = finder.getSizesUnder(createObjectLocationPrefix)
+
+    result.left.value shouldBe a[ListingFailure[_]]
+  }
+}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/SizeFinderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/SizeFinderTest.scala
@@ -83,7 +83,10 @@ class MemorySizeFinderTest
   }
 }
 
-class S3SizeFinderTest extends SizeFinderTestCases[Bucket] with S3Fixtures with EitherValues {
+class S3SizeFinderTest
+    extends SizeFinderTestCases[Bucket]
+    with S3Fixtures
+    with EitherValues {
   override def withContext[R](testWith: TestWith[Bucket, R]): R =
     withLocalS3Bucket { testWith }
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
@@ -471,7 +471,8 @@ class StorageManifestServiceTest
       )
 
       result.failed.get shouldBe a[StorageManifestException]
-      result.failed.get.getMessage should startWith(s"Error getting size of ${replicaRoot.join("data/file1.txt")}")
+      result.failed.get.getMessage should startWith(
+        s"Error getting size of ${replicaRoot.join("data/file1.txt")}")
     }
 
     it("uses the provided sizes") {
@@ -527,12 +528,14 @@ class StorageManifestServiceTest
         ),
         fetchEntries = Seq(
           BagFetchEntry(
-            uri = new URI(s"s3://${fetchLocation.namespace}/${fetchLocation.path}"),
+            uri =
+              new URI(s"s3://${fetchLocation.namespace}/${fetchLocation.path}"),
             length = Some(10),
             path = BagPath("data/1.txt")
           ),
           BagFetchEntry(
-            uri = new URI(s"s3://${fetchLocation.namespace}/${fetchLocation.path}"),
+            uri =
+              new URI(s"s3://${fetchLocation.namespace}/${fetchLocation.path}"),
             length = Some(20),
             path = BagPath("data/2.txt")
           )
@@ -546,12 +549,15 @@ class StorageManifestServiceTest
 
       val service = new StorageManifestService(brokenSizeFinder)
 
-      val storageManifest = service.createManifest(
-        bag = bag,
-        replicaRoot = replicaRoot,
-        space = createStorageSpace,
-        version = BagVersion(version)
-      ).success.value
+      val storageManifest = service
+        .createManifest(
+          bag = bag,
+          replicaRoot = replicaRoot,
+          space = createStorageSpace,
+          version = BagVersion(version)
+        )
+        .success
+        .value
 
       val actualSizes =
         storageManifest.manifest.files
@@ -575,9 +581,9 @@ class StorageManifestServiceTest
   ): StorageManifest = {
     val sizeFinder = new SizeFinder {
       override def getSize(location: ObjectLocation): Try[Long] = Try {
-        sizes.getOrElse(location,
-          throw new Throwable(s"No such size for location $location!")
-        )
+        sizes.getOrElse(
+          location,
+          throw new Throwable(s"No such size for location $location!"))
       }
     }
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
@@ -159,7 +159,8 @@ class StorageManifestServiceTest
 
       val fetchEntries = Seq(
         BagFetchEntry(
-          uri = new URI(s"s3://${fetchLocation.namespace}/${fetchLocation.path}"),
+          uri =
+            new URI(s"s3://${fetchLocation.namespace}/${fetchLocation.path}"),
           length = None,
           path = BagPath("data/file1.txt")
         )
@@ -204,7 +205,8 @@ class StorageManifestServiceTest
 
       val fetchEntries = Seq(
         BagFetchEntry(
-          uri = new URI(s"s3://${fetchLocation.namespace}/${fetchLocation.path}"),
+          uri =
+            new URI(s"s3://${fetchLocation.namespace}/${fetchLocation.path}"),
           length = None,
           path = BagPath("data/file1.txt")
         )
@@ -283,7 +285,8 @@ class StorageManifestServiceTest
     }
 
     it("uses the checksum values from the tag manifest") {
-      val paths = Seq("bag-info.txt", "tag-manifest-sha256.txt", "manifest-sha256.txt")
+      val paths =
+        Seq("bag-info.txt", "tag-manifest-sha256.txt", "manifest-sha256.txt")
 
       val filesWithChecksums =
         paths.map { _ -> ChecksumValue(randomAlphanumeric) }
@@ -514,7 +517,9 @@ class StorageManifestServiceTest
 
       val version = randomInt(from = 1, to = 10)
       val replicaRoot = createObjectLocation.join(s"v$version")
-      val sizes = expectedSizes.map { case (path, size) => replicaRoot.join(path) -> size }
+      val sizes = expectedSizes.map {
+        case (path, size) => replicaRoot.join(path) -> size
+      }
 
       val storageManifest = createManifest(
         bag = bag,

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/fixtures/DisplayJsonHelpers.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/fixtures/DisplayJsonHelpers.scala
@@ -61,7 +61,8 @@ trait DisplayJsonHelpers {
        |  "type": "File",
        |  "path": "${f.path}",
        |  "name": "${f.name}",
-       |  "checksum": "${f.checksum.value}"
+       |  "checksum": "${f.checksum.value}",
+       |  "size": ${f.size}
        |}
      """.stripMargin
 


### PR DESCRIPTION
Closes https://github.com/wellcometrust/platform/issues/3790

The bag register will now read all the sizes of objects in a bag (either from the fetch.txt or from S3), and then include those in the StorageManifest it saves to S3.