### PR TITLE
Don't open an InputStream just to get the size of an object

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/SizeFinder.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/SizeFinder.scala
@@ -24,8 +24,7 @@ class MemorySizeFinder(
 class S3SizeFinder(implicit s3Client: AmazonS3) extends SizeFinder {
   def getSize(location: ObjectLocation): Try[Long] = Try {
     s3Client
-      .getObject(location.namespace, location.path)
-      .getObjectMetadata
+      .getObjectMetadata(location.namespace, location.path)
       .getContentLength
   }
 }


### PR DESCRIPTION
This quickly exhausts the pool of available HTTP connections, and causes the register to fail.

Closes https://github.com/wellcometrust/platform/issues/3800