### PR TITLE
Rename "bag_auditor" to "bag_versioner" in the infra

### DIFF
--- a/terraform/stack/dynamo.tf
+++ b/terraform/stack/dynamo.tf
@@ -1,8 +1,8 @@
-module "auditor_lock_table" {
+module "versioner_lock_table" {
   source = "../modules/lock_table"
 
   namespace = "${var.namespace}"
-  owner     = "auditor"
+  owner     = "versioner"
 }
 
 module "replicator_lock_table" {
@@ -13,13 +13,13 @@ module "replicator_lock_table" {
 }
 
 locals {
-  auditor_versions_table_name  = "${aws_dynamodb_table.auditor_versions_table.name}"
-  auditor_versions_table_index = "ingestId_index"
+  versioner_versions_table_name  = "${aws_dynamodb_table.versioner_versions_table.name}"
+  versioner_versions_table_index = "ingestId_index"
 }
 
 # TODO: MOve this into the 'critical' part
-resource "aws_dynamodb_table" "auditor_versions_table" {
-  name      = "${var.namespace}_auditor_versions_table"
+resource "aws_dynamodb_table" "versioner_versions_table" {
+  name      = "${var.namespace}_versioner_versions_table"
   hash_key  = "id"
   range_key = "version"
 
@@ -41,13 +41,13 @@ resource "aws_dynamodb_table" "auditor_versions_table" {
   }
 
   global_secondary_index {
-    name            = "${local.auditor_versions_table_index}"
+    name            = "${local.versioner_versions_table_index}"
     hash_key        = "ingestId"
     projection_type = "ALL"
   }
 }
 
-data "aws_iam_policy_document" "auditor_versions_table_table_readwrite" {
+data "aws_iam_policy_document" "versioner_versions_table_table_readwrite" {
   statement {
     actions = [
       "dynamodb:DeleteItem",
@@ -58,7 +58,7 @@ data "aws_iam_policy_document" "auditor_versions_table_table_readwrite" {
     ]
 
     resources = [
-      "${aws_dynamodb_table.auditor_versions_table.arn}",
+      "${aws_dynamodb_table.versioner_versions_table.arn}",
     ]
   }
 
@@ -68,7 +68,7 @@ data "aws_iam_policy_document" "auditor_versions_table_table_readwrite" {
     ]
 
     resources = [
-      "${aws_dynamodb_table.auditor_versions_table.arn}/index/*",
+      "${aws_dynamodb_table.versioner_versions_table.arn}/index/*",
     ]
   }
 }

--- a/terraform/stack/iam_role_policy.tf
+++ b/terraform/stack/iam_role_policy.tf
@@ -78,21 +78,21 @@ resource "aws_iam_role_policy" "bag_root_finder_metrics" {
   policy = "${data.aws_iam_policy_document.cloudwatch_put.json}"
 }
 
-# bag auditor
+# bag versioner
 
-resource "aws_iam_role_policy" "bag_auditor_metrics" {
-  role   = "${module.bag_auditor.task_role_name}"
+resource "aws_iam_role_policy" "bag_versioner_metrics" {
+  role   = "${module.bag_versioner.task_role_name}"
   policy = "${data.aws_iam_policy_document.cloudwatch_put.json}"
 }
 
-resource "aws_iam_role_policy" "bag_auditor_locking_table" {
-  role   = "${module.bag_auditor.task_role_name}"
-  policy = "${module.auditor_lock_table.iam_policy}"
+resource "aws_iam_role_policy" "bag_versioner_locking_table" {
+  role   = "${module.bag_versioner.task_role_name}"
+  policy = "${module.versioner_lock_table.iam_policy}"
 }
 
-resource "aws_iam_role_policy" "bag_auditor_versions_table" {
-  role   = "${module.bag_auditor.task_role_name}"
-  policy = "${data.aws_iam_policy_document.auditor_versions_table_table_readwrite.json}"
+resource "aws_iam_role_policy" "bag_versioner_versions_table" {
+  role   = "${module.bag_versioner.task_role_name}"
+  policy = "${data.aws_iam_policy_document.versioner_versions_table_table_readwrite.json}"
 }
 
 # bag_verifier pre-replication

--- a/terraform/stack/locals.tf
+++ b/terraform/stack/locals.tf
@@ -7,13 +7,13 @@ locals {
 
   bag_unpacker_service_name           = "${var.namespace}-bag-unpacker"
   bag_root_finder_service_name        = "${var.namespace}-bag-root-finder"
-  bag_auditor_service_name            = "${var.namespace}-bag-auditor"
+  bag_versioner_service_name            = "${var.namespace}-bag-versioner"
   bag_replicator_service_name         = "${var.namespace}-bag-replicator"
   bag_register_service_name           = "${var.namespace}-bag-register"
   bag_verifier_post_repl_service_name = "${var.namespace}-bag-verifier-post-replication"
   bag_verifier_pre_repl_service_name  = "${var.namespace}-bag-verifier-pre-replication"
 
-  bag_auditor_image     = "${module.images.services["bag_auditor"]}"
+  bag_versioner_image     = "${module.images.services["bag_versioner"]}"
   bag_register_image    = "${module.images.services["bag_register"]}"
   bag_root_finder_image = "${module.images.services["bag_root_finder"]}"
   bags_api_image        = "${module.images.services["bags_api"]}"

--- a/terraform/stack/main.tf
+++ b/terraform/stack/main.tf
@@ -109,9 +109,9 @@ module "bag_verifier_pre_replication" {
   container_image = "${local.bag_verifier_image}"
 }
 
-# bag auditor
+# bag versioner
 
-module "bag_auditor" {
+module "bag_versioner" {
   source = "../modules/service/worker"
 
   security_group_ids = [
@@ -123,22 +123,22 @@ module "bag_auditor" {
   cluster_id   = "${aws_ecs_cluster.cluster.id}"
   namespace_id = "${aws_service_discovery_private_dns_namespace.namespace.id}"
   subnets      = "${var.private_subnets}"
-  service_name = "${local.bag_auditor_service_name}"
+  service_name = "${local.bag_versioner_service_name}"
 
   env_vars = {
-    queue_url          = "${module.bag_auditor_queue.url}"
+    queue_url          = "${module.bag_versioner_queue.url}"
     ingest_topic_arn   = "${module.ingests_topic.arn}"
-    outgoing_topic_arn = "${module.bag_auditor_output_topic.arn}"
-    metrics_namespace  = "${local.bag_auditor_service_name}"
-    operation_name     = "auditing bag"
+    outgoing_topic_arn = "${module.bag_versioner_output_topic.arn}"
+    metrics_namespace  = "${local.bag_versioner_service_name}"
+    operation_name     = "assigning bag version"
 
-    locking_table_name  = "${module.auditor_lock_table.table_name}"
-    locking_table_index = "${module.auditor_lock_table.index_name}"
+    locking_table_name  = "${module.versioner_lock_table.table_name}"
+    locking_table_index = "${module.versioner_lock_table.index_name}"
 
-    versions_table_name  = "${local.auditor_versions_table_name}"
-    versions_table_index = "${local.auditor_versions_table_index}"
+    versions_table_name  = "${local.versioner_versions_table_name}"
+    versions_table_index = "${local.versioner_versions_table_index}"
 
-    JAVA_OPTS = "-Dcom.amazonaws.sdk.enableDefaultMetrics=cloudwatchRegion=${var.aws_region},metricNameSpace=${local.bag_auditor_service_name}"
+    JAVA_OPTS = "-Dcom.amazonaws.sdk.enableDefaultMetrics=cloudwatchRegion=${var.aws_region},metricNameSpace=${local.bag_versioner_service_name}"
   }
 
   env_vars_length = 10
@@ -149,7 +149,7 @@ module "bag_auditor" {
   min_capacity = 1
   max_capacity = 10
 
-  container_image = "${local.bag_auditor_image}"
+  container_image = "${local.bag_versioner_image}"
 }
 
 # bag_replicator

--- a/terraform/stack/messaging.tf
+++ b/terraform/stack/messaging.tf
@@ -14,7 +14,7 @@ module "ingests_topic" {
     "${module.bag_unpacker.task_role_name}",
     "${module.ingests.task_role_name}",
     "${module.notifier.task_role_name}",
-    "${module.bag_auditor.task_role_name}",
+    "${module.bag_versioner.task_role_name}",
   ]
 }
 
@@ -205,36 +205,36 @@ module "bag_verifier_pre_replicate_output_topic" {
   ]
 }
 
-# bag auditor
+# bag versioner
 
-module "bag_auditor_queue" {
+module "bag_versioner_queue" {
   source = "../modules/queue"
 
-  name = "${var.namespace}_bag_auditor_input"
+  name = "${var.namespace}_bag_versioner_input"
 
   topic_names = ["${module.bag_verifier_pre_replicate_output_topic.name}"]
 
-  role_names = ["${module.bag_auditor.task_role_name}"]
+  role_names = ["${module.bag_versioner.task_role_name}"]
 
   queue_high_actions = [
-    "${module.bag_auditor.scale_up_arn}",
+    "${module.bag_versioner.scale_up_arn}",
   ]
 
   queue_low_actions = [
-    "${module.bag_auditor.scale_down_arn}",
+    "${module.bag_versioner.scale_down_arn}",
   ]
 
   aws_region    = "${var.aws_region}"
   dlq_alarm_arn = "${var.dlq_alarm_arn}"
 }
 
-module "bag_auditor_output_topic" {
+module "bag_versioner_output_topic" {
   source = "../modules/topic"
 
-  name = "${var.namespace}_bag_auditor_output"
+  name = "${var.namespace}_bag_versioner_output"
 
   role_names = [
-    "${module.bag_auditor.task_role_name}",
+    "${module.bag_versioner.task_role_name}",
   ]
 }
 
@@ -245,7 +245,7 @@ module "bag_replicator_input_queue" {
 
   name = "${var.namespace}_bag_replicator_input"
 
-  topic_names = ["${module.bag_auditor_output_topic.name}"]
+  topic_names = ["${module.bag_versioner_output_topic.name}"]
 
   role_names = ["${module.bag_replicator.task_role_name}"]
 

--- a/terraform/stack/release_uris.tf
+++ b/terraform/stack/release_uris.tf
@@ -10,7 +10,7 @@ module "images" {
     "ingests_api",
     "notifier",
     "bagger",
-    "bag_auditor",
+    "bag_versioner",
     "bag_register",
     "bag_replicator",
     "bag_root_finder",


### PR DESCRIPTION
Plus the message you get for the event is now:

"Starting assigning bag version" or "Succeeded assigning bag version".

Closes https://github.com/wellcometrust/platform/issues/3689