### PR TITLE
Make sure we close S3InputStreams correctly in the replicator

### DIFF
--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/Main.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/Main.scala
@@ -5,29 +5,14 @@ import akka.stream.ActorMaterializer
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.typesafe.config.Config
-import uk.ac.wellcome.messaging.typesafe.{
-  AlpakkaSqsWorkerConfigBuilder,
-  CloudwatchMonitoringClientBuilder,
-  SQSBuilder
-}
+import uk.ac.wellcome.messaging.typesafe.{AlpakkaSqsWorkerConfigBuilder, CloudwatchMonitoringClientBuilder, SQSBuilder}
 import uk.ac.wellcome.messaging.worker.monitoring.CloudwatchMonitoringClient
 import uk.ac.wellcome.platform.archive.bagreplicator.config.ReplicatorDestinationConfig
 import uk.ac.wellcome.platform.archive.bagreplicator.models.ReplicationSummary
-import uk.ac.wellcome.platform.archive.bagreplicator.services.{
-  BagReplicator,
-  BagReplicatorWorker
-}
-import uk.ac.wellcome.platform.archive.common.config.builders.{
-  IngestUpdaterBuilder,
-  OperationNameBuilder,
-  OutgoingPublisherBuilder
-}
+import uk.ac.wellcome.platform.archive.bagreplicator.services.{BagReplicator, BagReplicatorWorker}
+import uk.ac.wellcome.platform.archive.common.config.builders.{IngestUpdaterBuilder, OperationNameBuilder, OutgoingPublisherBuilder}
 import uk.ac.wellcome.platform.archive.common.storage.models.IngestStepResult
-import uk.ac.wellcome.storage.locking.dynamo.{
-  DynamoLockDao,
-  DynamoLockDaoConfig,
-  DynamoLockingService
-}
+import uk.ac.wellcome.storage.locking.dynamo.{DynamoLockDao, DynamoLockDaoConfig, DynamoLockingService}
 import uk.ac.wellcome.storage.typesafe.{DynamoBuilder, S3Builder}
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
@@ -37,6 +22,7 @@ import scala.util.Try
 import uk.ac.wellcome.json.JsonUtil._
 import org.scanamo.auto._
 import org.scanamo.time.JavaTimeFormats._
+import uk.ac.wellcome.storage.transfer.s3.S3PrefixTransfer
 
 object Main extends WellcomeTypesafeApp {
   runWithConfig { config: Config =>
@@ -51,6 +37,9 @@ object Main extends WellcomeTypesafeApp {
 
     implicit val s3Client: AmazonS3 =
       S3Builder.buildS3Client(config)
+
+    implicit val prefixTransfer: S3PrefixTransfer =
+      S3PrefixTransfer()
 
     implicit val monitoringClient: CloudwatchMonitoringClient =
       CloudwatchMonitoringClientBuilder.buildCloudwatchMonitoringClient(config)

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/Main.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/Main.scala
@@ -5,14 +5,29 @@ import akka.stream.ActorMaterializer
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.typesafe.config.Config
-import uk.ac.wellcome.messaging.typesafe.{AlpakkaSqsWorkerConfigBuilder, CloudwatchMonitoringClientBuilder, SQSBuilder}
+import uk.ac.wellcome.messaging.typesafe.{
+  AlpakkaSqsWorkerConfigBuilder,
+  CloudwatchMonitoringClientBuilder,
+  SQSBuilder
+}
 import uk.ac.wellcome.messaging.worker.monitoring.CloudwatchMonitoringClient
 import uk.ac.wellcome.platform.archive.bagreplicator.config.ReplicatorDestinationConfig
 import uk.ac.wellcome.platform.archive.bagreplicator.models.ReplicationSummary
-import uk.ac.wellcome.platform.archive.bagreplicator.services.{BagReplicator, BagReplicatorWorker}
-import uk.ac.wellcome.platform.archive.common.config.builders.{IngestUpdaterBuilder, OperationNameBuilder, OutgoingPublisherBuilder}
+import uk.ac.wellcome.platform.archive.bagreplicator.services.{
+  BagReplicator,
+  BagReplicatorWorker
+}
+import uk.ac.wellcome.platform.archive.common.config.builders.{
+  IngestUpdaterBuilder,
+  OperationNameBuilder,
+  OutgoingPublisherBuilder
+}
 import uk.ac.wellcome.platform.archive.common.storage.models.IngestStepResult
-import uk.ac.wellcome.storage.locking.dynamo.{DynamoLockDao, DynamoLockDaoConfig, DynamoLockingService}
+import uk.ac.wellcome.storage.locking.dynamo.{
+  DynamoLockDao,
+  DynamoLockDaoConfig,
+  DynamoLockingService
+}
 import uk.ac.wellcome.storage.typesafe.{DynamoBuilder, S3Builder}
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicator.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicator.scala
@@ -17,7 +17,8 @@ import scala.util.{Success, Try}
 
 class BagReplicator(
   implicit
-  prefixTransfer: PrefixTransfer[ObjectLocationPrefix, ObjectLocation]) extends Logging {
+  prefixTransfer: PrefixTransfer[ObjectLocationPrefix, ObjectLocation])
+    extends Logging {
 
   def replicate(bagRootLocation: ObjectLocation,
                 storageSpace: StorageSpace,

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicator.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicator.scala
@@ -2,7 +2,6 @@ package uk.ac.wellcome.platform.archive.bagreplicator.services
 
 import java.time.Instant
 
-import com.amazonaws.services.s3.AmazonS3
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.bagreplicator.models.ReplicationSummary
 import uk.ac.wellcome.platform.archive.common.storage.models.{
@@ -11,13 +10,14 @@ import uk.ac.wellcome.platform.archive.common.storage.models.{
   IngestStepSucceeded,
   StorageSpace
 }
+import uk.ac.wellcome.storage.transfer.PrefixTransfer
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
-import uk.ac.wellcome.storage.transfer.s3.S3PrefixTransfer
 
 import scala.util.{Success, Try}
 
-class BagReplicator(implicit s3Client: AmazonS3) extends Logging {
-  val s3PrefixTransfer = S3PrefixTransfer()
+class BagReplicator(
+  implicit
+  prefixTransfer: PrefixTransfer[ObjectLocationPrefix, ObjectLocation]) extends Logging {
 
   def replicate(bagRootLocation: ObjectLocation,
                 storageSpace: StorageSpace,
@@ -32,7 +32,7 @@ class BagReplicator(implicit s3Client: AmazonS3) extends Logging {
 
     // TODO: Plumb the LocationPrefix type back up through destination
     val copyResult =
-      s3PrefixTransfer.transferPrefix(
+      prefixTransfer.transferPrefix(
         srcPrefix = bagRootLocation.asPrefix,
         dstPrefix = destination
       )

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
@@ -12,23 +12,15 @@ import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.bagreplicator.config.ReplicatorDestinationConfig
 import uk.ac.wellcome.platform.archive.bagreplicator.models.ReplicationSummary
-import uk.ac.wellcome.platform.archive.bagreplicator.services.{
-  BagReplicator,
-  BagReplicatorWorker
-}
-import uk.ac.wellcome.platform.archive.common.fixtures.{
-  MonitoringClientFixture,
-  OperationFixtures
-}
+import uk.ac.wellcome.platform.archive.bagreplicator.services.{BagReplicator, BagReplicatorWorker}
+import uk.ac.wellcome.platform.archive.common.fixtures.{MonitoringClientFixture, OperationFixtures}
 import uk.ac.wellcome.platform.archive.common.storage.models.IngestStepResult
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
-import uk.ac.wellcome.storage.locking.memory.{
-  MemoryLockDao,
-  MemoryLockDaoFixtures
-}
+import uk.ac.wellcome.storage.locking.memory.{MemoryLockDao, MemoryLockDaoFixtures}
 import uk.ac.wellcome.storage.locking.{LockDao, LockingService}
+import uk.ac.wellcome.storage.transfer.s3.S3PrefixTransfer
 
 import scala.collection.JavaConverters._
 import scala.util.{Random, Try}
@@ -69,6 +61,9 @@ trait BagReplicatorFixtures
 
         val replicatorDestinationConfig =
           createReplicatorDestinationConfigWith(bucket, rootPath)
+
+        implicit val prefixTransfer: S3PrefixTransfer =
+          S3PrefixTransfer()
 
         val service = new BagReplicatorWorker(
           config = createAlpakkaSQSWorkerConfig(queue),

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
@@ -12,13 +12,22 @@ import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.bagreplicator.config.ReplicatorDestinationConfig
 import uk.ac.wellcome.platform.archive.bagreplicator.models.ReplicationSummary
-import uk.ac.wellcome.platform.archive.bagreplicator.services.{BagReplicator, BagReplicatorWorker}
-import uk.ac.wellcome.platform.archive.common.fixtures.{MonitoringClientFixture, OperationFixtures}
+import uk.ac.wellcome.platform.archive.bagreplicator.services.{
+  BagReplicator,
+  BagReplicatorWorker
+}
+import uk.ac.wellcome.platform.archive.common.fixtures.{
+  MonitoringClientFixture,
+  OperationFixtures
+}
 import uk.ac.wellcome.platform.archive.common.storage.models.IngestStepResult
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
-import uk.ac.wellcome.storage.locking.memory.{MemoryLockDao, MemoryLockDaoFixtures}
+import uk.ac.wellcome.storage.locking.memory.{
+  MemoryLockDao,
+  MemoryLockDaoFixtures
+}
 import uk.ac.wellcome.storage.locking.{LockDao, LockingService}
 import uk.ac.wellcome.storage.transfer.s3.S3PrefixTransfer
 

--- a/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/tracker/dynamo/DynamoIngestTrackerTest.scala
+++ b/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/tracker/dynamo/DynamoIngestTrackerTest.scala
@@ -84,6 +84,12 @@ class DynamoIngestTrackerTest
       ) {
         override val underlying = new VersionedStore[IngestID, Int, Ingest](
           new DynamoHashStore[IngestID, Int, Ingest](config) {
+            override def max(hashKey: IngestID): Either[ReadError, Int] =
+              Left(StoreReadError(new Throwable("BOOM!")))
+
+            override def get(id: Version[IngestID, Int]): ReadEither =
+              Left(StoreReadError(new Throwable("BOOM!")))
+
             override def put(id: Version[IngestID, Int])(
               t: Ingest): WriteEither =
               Left(StoreWriteError(new Throwable("BOOM!")))

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object WellcomeDependencies {
     val json       = "1.1.1"
     val messaging  = "5.3.1"
     val monitoring = "2.3.0"
-    val storage = "7.18.6"
+    val storage    = "7.18.9"
     val typesafe = "1.0.0"
   }
 


### PR DESCRIPTION
This means we don't leave InputStreams open in the replicator, which means drops lots of warnings in the tests and means the replicator might start getting "HTTP connection pool exhausted" errors if under load.

Closes https://github.com/wellcometrust/platform/issues/3742