### PR TITLE
If the fetch.txt in a bag register update is wrong, tell the user

### DIFF
--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/Register.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/Register.scala
@@ -13,6 +13,7 @@ import uk.ac.wellcome.platform.archive.common.storage.models.{
   StorageSpace
 }
 import uk.ac.wellcome.platform.archive.common.storage.services.{
+  BadFetchLocationException,
   StorageManifestDao,
   StorageManifestService
 }
@@ -63,7 +64,17 @@ class Register(
 
     result match {
       case Success(stepResult) => Success(stepResult)
-      case Failure(err)        => Success(IngestFailed(registration.complete, err))
+
+      case Failure(err: BadFetchLocationException) =>
+        Success(
+          IngestFailed(
+            registration.complete,
+            err,
+            maybeUserFacingMessage = Some(err.getMessage)
+          )
+        )
+
+      case Failure(err) => Success(IngestFailed(registration.complete, err))
     }
   }
 }

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
@@ -114,7 +114,7 @@ class BagRegisterWorkerTest
                 space = space,
                 version = 2,
                 dataFileCount) {
-                case (location2, bagInfo2) =>
+                case (location2, _) =>
                   val payload1 = createEnrichedBagInformationPayloadWith(
                     context = createPipelineContextWith(
                       storageSpace = space

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/RegisterTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/RegisterTest.scala
@@ -1,0 +1,88 @@
+package uk.ac.wellcome.platform.archive.bag_register.services
+
+import org.scalatest.{FunSpec, Matchers, TryValues}
+import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion
+import uk.ac.wellcome.platform.archive.common.bagit.services.memory.MemoryBagReader
+import uk.ac.wellcome.platform.archive.common.fixtures.{
+  BagBuilder,
+  StorageManifestVHSFixture
+}
+import uk.ac.wellcome.platform.archive.common.generators.StorageSpaceGenerators
+import uk.ac.wellcome.platform.archive.common.storage.models.IngestFailed
+import uk.ac.wellcome.platform.archive.common.storage.services.{
+  BadFetchLocationException,
+  MemorySizeFinder,
+  StorageManifestService
+}
+import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.generators.RandomThings
+import uk.ac.wellcome.storage.store.fixtures.StringNamespaceFixtures
+import uk.ac.wellcome.storage.store.memory.{MemoryStreamStore, MemoryTypedStore}
+
+class RegisterTest
+  extends FunSpec
+    with Matchers
+    with StorageManifestVHSFixture
+    with RandomThings
+    with StorageSpaceGenerators
+    with StringNamespaceFixtures
+    with TryValues {
+
+  it("includes a user-facing message if the fetch.txt refers to the wrong namespace") {
+    implicit val streamStore: MemoryStreamStore[ObjectLocation] =
+      MemoryStreamStore[ObjectLocation]()
+
+    implicit val typedStore: MemoryTypedStore[ObjectLocation, String] =
+      new MemoryTypedStore[ObjectLocation, String]()
+
+    val bagReader = new MemoryBagReader()
+
+    val storageManifestService = new StorageManifestService(
+      sizeFinder = new MemorySizeFinder(streamStore.memoryStore)
+    )
+
+    val space = createStorageSpace
+    val version = randomInt(1, 15)
+
+    val storageManifestDao = createStorageManifestDao()
+
+    val register = new Register(
+      bagReader = bagReader,
+      storageManifestDao,
+      storageManifestService = storageManifestService
+    )
+
+    val (bagObjects, bagRoot, _) =
+      withNamespace { implicit namespace =>
+        BagBuilder.createBagContentsWith(
+          version = BagVersion(version)
+        )
+      }
+
+    // Actually upload the bag objects into a different namespace,
+    // so the entries in the fetch.txt will be wrong.
+    val badBagObjects = bagObjects.map { bagObject =>
+      bagObject.copy(
+        location = bagObject.location.copy(
+          namespace = bagObject.location.namespace + "_wrong"
+        )
+      )
+    }
+    BagBuilder.uploadBagObjects(badBagObjects)
+
+    val result = register.update(
+      bagRootLocation = bagRoot.copy(
+        namespace = bagRoot.namespace + "_wrong"
+      ),
+      version = BagVersion(version),
+      storageSpace = space
+    )
+
+    result.success.value shouldBe a[IngestFailed[_]]
+    val ingestFailed = result.success.value.asInstanceOf[IngestFailed[_]]
+
+    ingestFailed.e shouldBe a[BadFetchLocationException]
+    ingestFailed.maybeUserFacingMessage.get should fullyMatch regex
+      """Fetch entry for data/[0-9A-Za-z/]+ refers to a file in the wrong namespace: [0-9A-Za-z/]+"""
+  }
+}

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/RegisterTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/RegisterTest.scala
@@ -20,7 +20,7 @@ import uk.ac.wellcome.storage.store.fixtures.StringNamespaceFixtures
 import uk.ac.wellcome.storage.store.memory.{MemoryStreamStore, MemoryTypedStore}
 
 class RegisterTest
-  extends FunSpec
+    extends FunSpec
     with Matchers
     with StorageManifestVHSFixture
     with RandomThings
@@ -28,7 +28,8 @@ class RegisterTest
     with StringNamespaceFixtures
     with TryValues {
 
-  it("includes a user-facing message if the fetch.txt refers to the wrong namespace") {
+  it(
+    "includes a user-facing message if the fetch.txt refers to the wrong namespace") {
     implicit val streamStore: MemoryStreamStore[ObjectLocation] =
       MemoryStreamStore[ObjectLocation]()
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
@@ -28,6 +28,9 @@ import scala.util.{Failure, Success, Try}
 class StorageManifestException(message: String)
     extends RuntimeException(message)
 
+class BadFetchLocationException(message: String)
+    extends StorageManifestException(message)
+
 class StorageManifestService(sizeFinder: SizeFinder) extends Logging {
   def createManifest(
     bag: Bag,
@@ -144,15 +147,15 @@ class StorageManifestService(sizeFinder: SizeFinder) extends Logging {
         )
 
         if (fetchLocation.namespace != bagRoot.namespace) {
-          throw new StorageManifestException(
-            s"Fetch entry for ${matchedLocation.bagFile.path.value} refers to an object in the wrong namespace: ${fetchLocation.namespace}"
+          throw new BadFetchLocationException(
+            s"Fetch entry for ${matchedLocation.bagFile.path.value} refers to a file in the wrong namespace: ${fetchLocation.namespace}"
           )
         }
 
         // TODO: This check could actually look for a /v1, /v2, etc.
         if (!fetchLocation.path.startsWith(bagRoot.path + "/")) {
-          throw new StorageManifestException(
-            s"Fetch entry for ${matchedLocation.bagFile.path.value} refers to an object in the wrong path: /${fetchLocation.path}"
+          throw new BadFetchLocationException(
+            s"Fetch entry for ${matchedLocation.bagFile.path.value} refers to a file in the wrong path: /${fetchLocation.path}"
           )
         }
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
@@ -43,8 +43,9 @@ class StorageManifestServiceTest
     val replicaRootLocation = createObjectLocation
     val version = randomInt(1, 10)
 
-    assertIsError(replicaRoot = replicaRootLocation, version = version) {
-      _ shouldBe s"Malformed bag root: $replicaRootLocation (expected suffix /v$version)"
+    assertIsError(replicaRoot = replicaRootLocation, version = version) { err =>
+      err shouldBe a[StorageManifestException]
+      err.getMessage shouldBe s"Malformed bag root: $replicaRootLocation (expected suffix /v$version)"
     }
   }
 
@@ -52,8 +53,9 @@ class StorageManifestServiceTest
     val version = randomInt(1, 10)
     val replicaRootLocation = createObjectLocation.join(s"/v${version + 1}")
 
-    assertIsError(replicaRoot = replicaRootLocation, version = version) {
-      _ shouldBe s"Malformed bag root: $replicaRootLocation (expected suffix /v$version)"
+    assertIsError(replicaRoot = replicaRootLocation, version = version) { err =>
+      err shouldBe a[StorageManifestException]
+      err.getMessage shouldBe s"Malformed bag root: $replicaRootLocation (expected suffix /v$version)"
     }
   }
 
@@ -312,7 +314,8 @@ class StorageManifestServiceTest
       )
 
       assertIsError(bag = bag) {
-        _ shouldBe s"Mismatched checksum algorithms in manifest: entry $badPath has algorithm MD5, but manifest uses SHA-256"
+        err =>
+          err.getMessage shouldBe s"Mismatched checksum algorithms in manifest: entry $badPath has algorithm MD5, but manifest uses SHA-256"
       }
     }
 
@@ -332,8 +335,9 @@ class StorageManifestServiceTest
         tagManifestChecksumAlgorithm = SHA256
       )
 
-      assertIsError(bag = bag) {
-        _ shouldBe s"Mismatched checksum algorithms in manifest: entry $badPath has algorithm MD5, but manifest uses SHA-256"
+      assertIsError(bag = bag) { err =>
+        err shouldBe a[StorageManifestException]
+        err.getMessage shouldBe s"Mismatched checksum algorithms in manifest: entry $badPath has algorithm MD5, but manifest uses SHA-256"
       }
     }
   }
@@ -352,9 +356,10 @@ class StorageManifestServiceTest
         fetchEntries = fetchEntries
       )
 
-      assertIsError(bag = bag) { msg =>
-        msg should startWith("Unable to resolve fetch entries:")
-        msg should include(
+      assertIsError(bag = bag) { err =>
+        err shouldBe a[StorageManifestException]
+        err.getMessage should startWith("Unable to resolve fetch entries:")
+        err.getMessage should include(
           s"Fetch entry refers to a path that isn't in the bag manifest: ${fetchEntries.head.path}")
       }
     }
@@ -375,8 +380,8 @@ class StorageManifestServiceTest
         fetchEntries = fetchEntries
       )
 
-      assertIsError(bag = bag) {
-        _ shouldBe "Fetch entry for data/file1.txt refers to an object in the wrong namespace: not-the-replica-bucket"
+      assertIsError(bag = bag) { err =>
+        err.getMessage shouldBe "Fetch entry for data/file1.txt refers to an object in the wrong namespace: not-the-replica-bucket"
       }
     }
 
@@ -401,7 +406,8 @@ class StorageManifestServiceTest
       )
 
       assertIsError(bag = bag, replicaRoot = replicaRoot, version = version) {
-        _ shouldBe "Fetch entry for data/file1.txt refers to an object in the wrong path: /file1.txt"
+        err =>
+          err.getMessage shouldBe "Fetch entry for data/file1.txt refers to an object in the wrong path: /file1.txt"
       }
     }
   }
@@ -607,7 +613,7 @@ class StorageManifestServiceTest
     bag: Bag = createBag,
     replicaRoot: ObjectLocation = createObjectLocation.join("/v1"),
     version: Int = 1
-  )(assertMessage: String => Assertion): Assertion = {
+  )(assertError: Throwable => Assertion): Assertion = {
     val sizeFinder = new SizeFinder {
       override def getSize(location: ObjectLocation): Try[Long] = Success(1)
     }
@@ -621,7 +627,6 @@ class StorageManifestServiceTest
       version = BagVersion(version)
     )
 
-    result.failure.exception shouldBe a[StorageManifestException]
-    assertMessage(result.failure.exception.getMessage)
+    assertError(result.failure.exception)
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
@@ -313,9 +313,8 @@ class StorageManifestServiceTest
         manifestChecksumAlgorithm = SHA256
       )
 
-      assertIsError(bag = bag) {
-        err =>
-          err.getMessage shouldBe s"Mismatched checksum algorithms in manifest: entry $badPath has algorithm MD5, but manifest uses SHA-256"
+      assertIsError(bag = bag) { err =>
+        err.getMessage shouldBe s"Mismatched checksum algorithms in manifest: entry $badPath has algorithm MD5, but manifest uses SHA-256"
       }
     }
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
@@ -381,7 +381,8 @@ class StorageManifestServiceTest
       )
 
       assertIsError(bag = bag) { err =>
-        err.getMessage shouldBe "Fetch entry for data/file1.txt refers to an object in the wrong namespace: not-the-replica-bucket"
+        err shouldBe a[BadFetchLocationException]
+        err.getMessage shouldBe "Fetch entry for data/file1.txt refers to a file in the wrong namespace: not-the-replica-bucket"
       }
     }
 
@@ -407,7 +408,8 @@ class StorageManifestServiceTest
 
       assertIsError(bag = bag, replicaRoot = replicaRoot, version = version) {
         err =>
-          err.getMessage shouldBe "Fetch entry for data/file1.txt refers to an object in the wrong path: /file1.txt"
+          err shouldBe a[BadFetchLocationException]
+          err.getMessage shouldBe "Fetch entry for data/file1.txt refers to a file in the wrong path: /file1.txt"
       }
     }
   }


### PR DESCRIPTION
Closes https://github.com/wellcometrust/platform/issues/3778

Now, if you send a bag with a `fetch.txt` that points to an object in the wrong bucket/storage space/external identifier, you get a more helpful error:

> Register failed - Fetch entry for data/objects/RAMC_262_10_0008.jp2 refers to a file in the wrong namespace: wrong-bukkit

This has been the source of most of my register failures over the last few days, and I don't want to keep looking at the CloudWatch logs!