### PR TITLE
Add formatting helpers for the ObjectLocation in the unpacker

### DIFF
--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
@@ -87,7 +87,8 @@ trait Unpacker extends Logging {
 
       case UnpackerUnarchiverError(_) =>
         Some(
-          s"Error trying to unpack the archive at ${formatLocation(srcLocation)} - is it the correct format?")
+          s"Error trying to unpack the archive at ${formatLocation(srcLocation)} - is it the correct format?"
+        )
 
       case _ => None
     }

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
@@ -34,6 +34,8 @@ trait Unpacker extends Logging {
     inputStream: InputStreamWithLength
   ): Either[StorageError, Unit]
 
+  def formatLocation(location: ObjectLocation): String
+
   def unpack(
     ingestId: IngestID,
     srcLocation: ObjectLocation,
@@ -81,12 +83,11 @@ trait Unpacker extends Logging {
   ): Option[String] =
     error match {
       case UnpackerStorageError(_: DoesNotExistError) =>
-        Some(s"There is no archive at $srcLocation")
+        Some(s"There is no archive at ${formatLocation(srcLocation)}")
 
       case UnpackerUnarchiverError(_) =>
         Some(
-          s"Error trying to unpack the archive at $srcLocation - is it the correct format?"
-        )
+          s"Error trying to unpack the archive at ${formatLocation(srcLocation)} - is it the correct format?")
 
       case _ => None
     }

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/memory/MemoryUnpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/memory/MemoryUnpacker.scala
@@ -31,4 +31,7 @@ class MemoryUnpacker()(implicit streamStore: MemoryStreamStore[ObjectLocation])
       .map { _ =>
         ()
       }
+
+  override def formatLocation(location: ObjectLocation): String =
+    s"mem://$location"
 }

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3Unpacker.scala
@@ -50,7 +50,9 @@ class S3Unpacker()(implicit s3Client: AmazonS3) extends Unpacker {
     error match {
       case UnpackerStorageError(StoreReadError(exc: AmazonS3Exception))
           if exc.getMessage.startsWith("Access Denied") =>
-        Some(s"Access denied while trying to read ${formatLocation(srcLocation)}")
+        Some(
+          s"Access denied while trying to read ${formatLocation(srcLocation)}"
+        )
 
       case UnpackerStorageError(StoreReadError(exc: AmazonS3Exception))
           if exc.getMessage.startsWith("The specified bucket is not valid") =>

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3Unpacker.scala
@@ -40,6 +40,9 @@ class S3Unpacker()(implicit s3Client: AmazonS3) extends Unpacker {
         ()
       }
 
+  override def formatLocation(location: ObjectLocation): String =
+    s"s3://$location"
+
   override def buildMessageFor(
     srcLocation: ObjectLocation,
     error: UnpackerError
@@ -47,7 +50,7 @@ class S3Unpacker()(implicit s3Client: AmazonS3) extends Unpacker {
     error match {
       case UnpackerStorageError(StoreReadError(exc: AmazonS3Exception))
           if exc.getMessage.startsWith("Access Denied") =>
-        Some(s"Access denied while trying to read s3://$srcLocation")
+        Some(s"Access denied while trying to read ${formatLocation(srcLocation)}")
 
       case UnpackerStorageError(StoreReadError(exc: AmazonS3Exception))
           if exc.getMessage.startsWith("The specified bucket is not valid") =>
@@ -57,11 +60,8 @@ class S3Unpacker()(implicit s3Client: AmazonS3) extends Unpacker {
           if exc.getMessage.startsWith("The specified bucket does not exist") =>
         Some(s"There is no S3 bucket ${srcLocation.namespace}")
 
-      case UnpackerStorageError(DoesNotExistError(exc: AmazonS3Exception)) =>
-        Some(s"There is no archive at s3://$srcLocation")
-
       case _ =>
-        println(error)
+        warn(s"Error unpacking bag at $srcLocation: $error")
         super.buildMessageFor(srcLocation, error)
     }
 }

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorkerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorkerTest.scala
@@ -112,7 +112,7 @@ class BagUnpackerWorkerTest
       val failure = result.success.value.asInstanceOf[IngestFailed[_]]
 
       val message =
-        s"Error trying to unpack the archive at $location - is it the correct format?"
+        s"Error trying to unpack the archive at s3://$location - is it the correct format?"
 
       failure.maybeUserFacingMessage.get shouldBe message
 
@@ -160,7 +160,7 @@ class BagUnpackerWorkerTest
       val failure = result.success.value.asInstanceOf[IngestFailed[_]]
 
       val message =
-        s"Error trying to unpack the archive at $location - is it the correct format?"
+        s"Error trying to unpack the archive at s3://$location - is it the correct format?"
 
       failure.maybeUserFacingMessage.get shouldBe message
 

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
@@ -155,7 +155,8 @@ trait UnpackerTestCases[Namespace]
         val ingestFailed =
           ingestResult.asInstanceOf[IngestFailed[UnpackSummary]]
         ingestFailed.maybeUserFacingMessage.get should startWith(
-          s"Error trying to unpack the archive at")
+          s"Error trying to unpack the archive at"
+        )
       }
     }
   }

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
@@ -130,35 +130,32 @@ trait UnpackerTestCases[Namespace]
 
   it("fails if the specified file is not in tar.gz format") {
     withNamespace { srcNamespace =>
-      withNamespace { dstNamespace =>
-        withStreamStore { implicit streamStore =>
-          val srcLocation = createObjectLocationWith(
-            namespace = srcNamespace,
-            path = randomAlphanumeric
+      withStreamStore { implicit streamStore =>
+        val srcLocation = createObjectLocationWith(
+          namespace = srcNamespace,
+          path = randomAlphanumeric
+        )
+
+        streamStore.put(srcLocation)(
+          stringCodec.toStream("hello world").right.value
+        ) shouldBe a[Right[_, _]]
+
+        val result =
+          unpacker.unpack(
+            ingestId = createIngestID,
+            srcLocation = srcLocation,
+            dstLocation = createObjectLocationPrefix
           )
 
-          streamStore.put(srcLocation)(
-            stringCodec.toStream("hello world").right.value
-          ) shouldBe a[Right[_, _]]
+        val ingestResult = result.success.value
+        ingestResult shouldBe a[IngestFailed[_]]
+        ingestResult.summary.fileCount shouldBe 0
+        ingestResult.summary.bytesUnpacked shouldBe 0
 
-          val result =
-            unpacker.unpack(
-              ingestId = createIngestID,
-              srcLocation = srcLocation,
-              dstLocation = createObjectLocationPrefix
-            )
-
-          val ingestResult = result.success.value
-          ingestResult shouldBe a[IngestFailed[_]]
-          ingestResult.summary.fileCount shouldBe 0
-          ingestResult.summary.bytesUnpacked shouldBe 0
-
-          val ingestFailed =
-            ingestResult.asInstanceOf[IngestFailed[UnpackSummary]]
-          ingestFailed.maybeUserFacingMessage.get should startWith(
-            s"Error trying to unpack the archive at $srcLocation"
-          )
-        }
+        val ingestFailed =
+          ingestResult.asInstanceOf[IngestFailed[UnpackSummary]]
+        ingestFailed.maybeUserFacingMessage.get should startWith(
+          s"Error trying to unpack the archive at")
       }
     }
   }


### PR DESCRIPTION
Now, when we send an error message about a location, we'll give a bit
more context about where we were looking.

e.g. rather than saying

> Error trying to unpack the archive at bukkit/key.tar.gz

the user-facing message would say something like:

> Error trying to unpack the archive at mem://bukkit/key.tar.gz
> Error trying to unpack the archive at s3://bukkit/key.tar.gz
> Error trying to unpack the archive at azure://bukkit/key.tar.gz

Tiny fix I spotted after retrying Helen's failed ingest from yesterday; in most places we add the `s3://` prefix but in the archive errors we don't.