### PR TITLE
Disambiguate between ObjectLocation and the Prefix

### DIFF
--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/models/RegistrationSummary.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/models/RegistrationSummary.scala
@@ -4,10 +4,10 @@ import java.time.Instant
 
 import uk.ac.wellcome.platform.archive.common.operation.models.Summary
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.ObjectLocationPrefix
 
 case class RegistrationSummary(
-  bagRootLocation: ObjectLocation,
+  bagRoot: ObjectLocationPrefix,
   storageSpace: StorageSpace,
   startTime: Instant,
   maybeEndTime: Option[Instant] = None
@@ -18,7 +18,7 @@ case class RegistrationSummary(
     )
 
   override def toString: String =
-    f"""|bag=$bagRootLocation
+    f"""|bag=$bagRoot
         |space=$storageSpace
         |durationSeconds=$durationSeconds
         |duration=$formatDuration""".stripMargin

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorker.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorker.scala
@@ -35,7 +35,7 @@ class BagRegisterWorker[IngestDestination, OutgoingDestination](
       _ <- ingestUpdater.start(payload.ingestId)
 
       registrationSummary <- register.update(
-        bagRoot = payload.bagRootLocation.asPrefix,
+        bagRoot = payload.bagRoot.asPrefix,
         version = payload.version,
         storageSpace = payload.storageSpace
       )

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorker.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorker.scala
@@ -35,7 +35,7 @@ class BagRegisterWorker[IngestDestination, OutgoingDestination](
       _ <- ingestUpdater.start(payload.ingestId)
 
       registrationSummary <- register.update(
-        bagRoot = payload.bagRoot.asPrefix,
+        bagRoot = payload.bagRoot,
         version = payload.version,
         storageSpace = payload.storageSpace
       )

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorker.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorker.scala
@@ -35,7 +35,7 @@ class BagRegisterWorker[IngestDestination, OutgoingDestination](
       _ <- ingestUpdater.start(payload.ingestId)
 
       registrationSummary <- register.update(
-        bagRootLocation = payload.bagRootLocation,
+        bagRoot = payload.bagRootLocation.asPrefix,
         version = payload.version,
         storageSpace = payload.storageSpace
       )

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/Register.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/Register.scala
@@ -40,7 +40,7 @@ class Register(
     )
 
     val result: Try[IngestStepResult[RegistrationSummary]] = for {
-      bag <- bagReader.get(bagRoot.asLocation()) match {
+      bag <- bagReader.get(bagRoot) match {
         case Right(value) => Success(value)
         case Left(err) =>
           Failure(new RuntimeException(s"Bag unavailable: ${err.msg}"))
@@ -48,7 +48,7 @@ class Register(
 
       storageManifest <- storageManifestService.createManifest(
         bag = bag,
-        replicaRoot = bagRoot.asLocation(),
+        replicaRoot = bagRoot,
         space = storageSpace,
         version = version
       )

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/Register.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/Register.scala
@@ -17,7 +17,7 @@ import uk.ac.wellcome.platform.archive.common.storage.services.{
   StorageManifestDao,
   StorageManifestService
 }
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.ObjectLocationPrefix
 
 import scala.util.{Failure, Success, Try}
 
@@ -28,19 +28,19 @@ class Register(
 ) extends Logging {
 
   def update(
-    bagRootLocation: ObjectLocation,
+    bagRoot: ObjectLocationPrefix,
     version: BagVersion,
     storageSpace: StorageSpace
   ): Try[IngestStepResult[RegistrationSummary]] = {
 
     val registration = RegistrationSummary(
       startTime = Instant.now(),
-      bagRootLocation = bagRootLocation,
+      bagRoot = bagRoot,
       storageSpace = storageSpace
     )
 
     val result: Try[IngestStepResult[RegistrationSummary]] = for {
-      bag <- bagReader.get(bagRootLocation) match {
+      bag <- bagReader.get(bagRoot.asLocation()) match {
         case Right(value) => Success(value)
         case Left(err) =>
           Failure(new RuntimeException(s"Bag unavailable: ${err.msg}"))
@@ -48,7 +48,7 @@ class Register(
 
       storageManifest <- storageManifestService.createManifest(
         bag = bag,
-        replicaRoot = bagRootLocation,
+        replicaRoot = bagRoot.asLocation(),
         space = storageSpace,
         version = version
       )

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/BagRegisterFeatureTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/BagRegisterFeatureTest.scala
@@ -43,12 +43,12 @@ class BagRegisterFeatureTest
             version,
             dataFileCount = dataFileCount
           ) {
-            case (bagRootLocation, bagInfo) =>
+            case (bagRoot, bagInfo) =>
               val payload = createEnrichedBagInformationPayloadWith(
                 context = createPipelineContextWith(
                   storageSpace = space
                 ),
-                bagRootLocation = bagRootLocation,
+                bagRootLocation = bagRoot,
                 version = version
               )
 

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
@@ -7,30 +7,15 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
-import uk.ac.wellcome.platform.archive.bag_register.services.{
-  BagRegisterWorker,
-  Register
-}
-import uk.ac.wellcome.platform.archive.common.bagit.models.{
-  BagInfo,
-  BagVersion,
-  ExternalIdentifier
-}
+import uk.ac.wellcome.platform.archive.bag_register.services.{BagRegisterWorker, Register}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{BagInfo, BagVersion, ExternalIdentifier}
 import uk.ac.wellcome.platform.archive.common.bagit.services.memory.MemoryBagReader
 import uk.ac.wellcome.platform.archive.common.fixtures._
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  Ingest,
-  IngestID,
-  IngestStatusUpdate
-}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestID, IngestStatusUpdate}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.platform.archive.common.storage.services.{
-  MemorySizeFinder,
-  StorageManifestDao,
-  StorageManifestService
-}
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.platform.archive.common.storage.services.{MemorySizeFinder, StorageManifestDao, StorageManifestService}
+import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 import uk.ac.wellcome.storage.store.fixtures.StringNamespaceFixtures
 import uk.ac.wellcome.storage.store.memory.{MemoryStreamStore, MemoryTypedStore}
 
@@ -132,7 +117,7 @@ trait BagRegisterFixtures
     space: StorageSpace,
     version: BagVersion,
     dataFileCount: Int
-  )(testWith: TestWith[(ObjectLocation, BagInfo), R])(
+  )(testWith: TestWith[(ObjectLocationPrefix, BagInfo), R])(
     implicit
     namespace: String,
     streamStore: MemoryStreamStore[ObjectLocation]

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/fixtures/BagRegisterFixtures.scala
@@ -7,14 +7,29 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS.QueuePair
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
-import uk.ac.wellcome.platform.archive.bag_register.services.{BagRegisterWorker, Register}
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagInfo, BagVersion, ExternalIdentifier}
+import uk.ac.wellcome.platform.archive.bag_register.services.{
+  BagRegisterWorker,
+  Register
+}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagInfo,
+  BagVersion,
+  ExternalIdentifier
+}
 import uk.ac.wellcome.platform.archive.common.bagit.services.memory.MemoryBagReader
 import uk.ac.wellcome.platform.archive.common.fixtures._
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.ingests.models.{Ingest, IngestID, IngestStatusUpdate}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  Ingest,
+  IngestID,
+  IngestStatusUpdate
+}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.platform.archive.common.storage.services.{MemorySizeFinder, StorageManifestDao, StorageManifestService}
+import uk.ac.wellcome.platform.archive.common.storage.services.{
+  MemorySizeFinder,
+  StorageManifestDao,
+  StorageManifestService
+}
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 import uk.ac.wellcome.storage.store.fixtures.StringNamespaceFixtures
 import uk.ac.wellcome.storage.store.memory.{MemoryStreamStore, MemoryTypedStore}

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
@@ -53,7 +53,7 @@ class BagRegisterWorkerTest
                 context = createPipelineContextWith(
                   storageSpace = space
                 ),
-                bagRootLocation = bagRoot,
+                bagRoot = bagRoot,
                 version = version
               )
 

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
@@ -48,12 +48,12 @@ class BagRegisterWorkerTest
             dataFileCount = dataFileCount,
             version = version
           ) {
-            case (bagRootLocation, bagInfo) =>
+            case (bagRoot, bagInfo) =>
               val payload = createEnrichedBagInformationPayloadWith(
                 context = createPipelineContextWith(
                   storageSpace = space
                 ),
-                bagRootLocation = bagRootLocation,
+                bagRootLocation = bagRoot,
                 version = version
               )
 
@@ -76,8 +76,8 @@ class BagRegisterWorkerTest
               storageManifest.locations shouldBe List(
                 StorageLocation(
                   provider = InfrequentAccessStorageProvider,
-                  location = bagRootLocation.copy(
-                    path = bagRootLocation.path.stripSuffix(s"/$version")
+                  location = bagRoot.copy(
+                    path = bagRoot.path.stripSuffix(s"/$version")
                   )
                 )
               )

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/RegisterTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/RegisterTest.scala
@@ -72,9 +72,9 @@ class RegisterTest
     BagBuilder.uploadBagObjects(badBagObjects)
 
     val result = register.update(
-      bagRootLocation = bagRoot.copy(
+      bagRoot = bagRoot.copy(
         namespace = bagRoot.namespace + "_wrong"
-      ),
+      ).asPrefix,
       version = version,
       storageSpace = space
     )

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/RegisterTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/RegisterTest.scala
@@ -72,9 +72,11 @@ class RegisterTest
     BagBuilder.uploadBagObjects(badBagObjects)
 
     val result = register.update(
-      bagRoot = bagRoot.copy(
-        namespace = bagRoot.namespace + "_wrong"
-      ).asPrefix,
+      bagRoot = bagRoot
+        .copy(
+          namespace = bagRoot.namespace + "_wrong"
+        )
+        .asPrefix,
       version = version,
       storageSpace = space
     )

--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
@@ -75,7 +75,7 @@ class BagReplicatorWorker[IngestDestination, OutgoingDestination](
         ingestUpdater.start(payload.ingestId)
       }
 
-      srcPrefix = payload.bagRootLocation.asPrefix
+      srcPrefix = payload.bagRoot.asPrefix
 
       dstPrefix = destinationBuilder.buildDestination(
         storageSpace = payload.storageSpace,
@@ -95,7 +95,7 @@ class BagReplicatorWorker[IngestDestination, OutgoingDestination](
     payload: EnrichedBagInformationPayload,
     dstPrefix: ObjectLocationPrefix
   ): Future[IngestStepResult[ReplicationSummary]] = {
-    val srcPrefix = payload.bagRootLocation.asPrefix
+    val srcPrefix = payload.bagRoot.asPrefix
 
     for {
       ingestStep: IngestStepResult[ReplicationSummary] <- bagReplicator
@@ -125,7 +125,7 @@ class BagReplicatorWorker[IngestDestination, OutgoingDestination](
         outgoingPublisher.sendIfSuccessful(
           result,
           payload.copy(
-            bagRootLocation = result.summary.dstPrefix.asLocation()
+            bagRoot = result.summary.dstPrefix.asLocation()
           )
         )
       }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/BagReplicatorFeatureTest.scala
@@ -26,12 +26,12 @@ class BagReplicatorFeatureTest
         val ingests = new MemoryMessageSender()
         val outgoing = new MemoryMessageSender()
 
-        val (srcBagLocation, _) = S3BagBuilder.createS3BagWith(
+        val (srcBagRoot, _) = S3BagBuilder.createS3BagWith(
           bucket = srcBucket
         )
 
         val payload = createEnrichedBagInformationPayloadWith(
-          bagRootLocation = srcBagLocation
+          bagRoot = srcBagRoot
         )
 
         withLocalSqsQueue { queue =>
@@ -57,7 +57,7 @@ class BagReplicatorFeatureTest
               )
 
               val expectedPayload = payload.copy(
-                bagRootLocation = expectedDst
+                bagRoot = expectedDst
               )
 
               outgoing
@@ -66,8 +66,8 @@ class BagReplicatorFeatureTest
               )
 
               verifyObjectsCopied(
-                src = srcBagLocation,
-                dst = expectedDst
+                src = srcBagRoot,
+                dst = expectedDst.asPrefix
               )
 
               assertTopicReceivesIngestEvents(

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
@@ -11,23 +11,14 @@ import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.bagreplicator.config.ReplicatorDestinationConfig
 import uk.ac.wellcome.platform.archive.bagreplicator.models.ReplicationSummary
-import uk.ac.wellcome.platform.archive.bagreplicator.services.{
-  BagReplicator,
-  BagReplicatorWorker
-}
-import uk.ac.wellcome.platform.archive.common.fixtures.{
-  MonitoringClientFixture,
-  OperationFixtures
-}
+import uk.ac.wellcome.platform.archive.bagreplicator.services.{BagReplicator, BagReplicatorWorker}
+import uk.ac.wellcome.platform.archive.common.fixtures.{MonitoringClientFixture, OperationFixtures}
 import uk.ac.wellcome.platform.archive.common.storage.models.IngestStepResult
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.ObjectLocationPrefix
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.listing.s3.S3ObjectSummaryListing
-import uk.ac.wellcome.storage.locking.memory.{
-  MemoryLockDao,
-  MemoryLockDaoFixtures
-}
+import uk.ac.wellcome.storage.locking.memory.{MemoryLockDao, MemoryLockDaoFixtures}
 import uk.ac.wellcome.storage.locking.{LockDao, LockingService}
 import uk.ac.wellcome.storage.store.s3.S3StreamStore
 import uk.ac.wellcome.storage.transfer.s3.S3PrefixTransfer
@@ -115,15 +106,15 @@ trait BagReplicatorFixtures
   private val listing = new S3ObjectSummaryListing()
 
   def verifyObjectsCopied(
-    src: ObjectLocation,
-    dst: ObjectLocation
+    src: ObjectLocationPrefix,
+    dst: ObjectLocationPrefix
   ): Assertion = {
-    val sourceItems = listing.list(src.asPrefix).right.value
+    val sourceItems = listing.list(src).right.value
     val sourceKeyEtags = sourceItems.map {
       _.getETag
     }
 
-    val destinationItems = listing.list(dst.asPrefix).right.value
+    val destinationItems = listing.list(dst).right.value
     val destinationKeyEtags = destinationItems.map {
       _.getETag
     }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/fixtures/BagReplicatorFixtures.scala
@@ -11,14 +11,23 @@ import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.bagreplicator.config.ReplicatorDestinationConfig
 import uk.ac.wellcome.platform.archive.bagreplicator.models.ReplicationSummary
-import uk.ac.wellcome.platform.archive.bagreplicator.services.{BagReplicator, BagReplicatorWorker}
-import uk.ac.wellcome.platform.archive.common.fixtures.{MonitoringClientFixture, OperationFixtures}
+import uk.ac.wellcome.platform.archive.bagreplicator.services.{
+  BagReplicator,
+  BagReplicatorWorker
+}
+import uk.ac.wellcome.platform.archive.common.fixtures.{
+  MonitoringClientFixture,
+  OperationFixtures
+}
 import uk.ac.wellcome.platform.archive.common.storage.models.IngestStepResult
 import uk.ac.wellcome.storage.ObjectLocationPrefix
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.listing.s3.S3ObjectSummaryListing
-import uk.ac.wellcome.storage.locking.memory.{MemoryLockDao, MemoryLockDaoFixtures}
+import uk.ac.wellcome.storage.locking.memory.{
+  MemoryLockDao,
+  MemoryLockDaoFixtures
+}
 import uk.ac.wellcome.storage.locking.{LockDao, LockingService}
 import uk.ac.wellcome.storage.store.s3.S3StreamStore
 import uk.ac.wellcome.storage.transfer.s3.S3PrefixTransfer

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
@@ -51,12 +51,12 @@ class BagReplicatorWorkerTest
     val outgoing = new MemoryMessageSender()
 
     withLocalS3Bucket { srcBucket =>
-      val (srcBagLocation, _) = S3BagBuilder.createS3BagWith(
+      val (srcBagRoot, _) = S3BagBuilder.createS3BagWith(
         bucket = srcBucket
       )
 
       val payload = createEnrichedBagInformationPayloadWith(
-        bagRootLocation = srcBagLocation
+        bagRootLocation = srcBagRoot.asLocation()
       )
 
       withLocalS3Bucket { dstBucket =>
@@ -84,11 +84,11 @@ class BagReplicatorWorkerTest
         val result = receivedMessages.head
         result.ingestId shouldBe payload.ingestId
 
-        val dstBagLocation = result.bagRootLocation
+        val dstBagRoot = result.bagRoot.asPrefix
 
         verifyObjectsCopied(
-          src = srcBagLocation,
-          dst = dstBagLocation
+          src = srcBagRoot,
+          dst = dstBagRoot
         )
 
         assertTopicReceivesIngestEvents(
@@ -106,12 +106,12 @@ class BagReplicatorWorkerTest
   describe("copies to the correct destination") {
     it("copies the bag to the configured bucket") {
       withLocalS3Bucket { srcBucket =>
-        val (srcBagLocation, _) = S3BagBuilder.createS3BagWith(
+        val (srcBagRoot, _) = S3BagBuilder.createS3BagWith(
           bucket = srcBucket
         )
 
         val payload = createEnrichedBagInformationPayloadWith(
-          bagRootLocation = srcBagLocation
+          bagRoot = srcBagRoot
         )
 
         withLocalS3Bucket { dstBucket =>
@@ -134,12 +134,12 @@ class BagReplicatorWorkerTest
     it("constructs the correct key") {
       withLocalS3Bucket { srcBucket =>
         withLocalS3Bucket { dstBucket =>
-          val (srcBagLocation, _) = S3BagBuilder.createS3BagWith(
+          val (srcBagRoot, _) = S3BagBuilder.createS3BagWith(
             bucket = srcBucket
           )
 
           val payload = createEnrichedBagInformationPayloadWith(
-            bagRootLocation = srcBagLocation
+            bagRoot = srcBagRoot
           )
 
           val future =
@@ -177,13 +177,13 @@ class BagReplicatorWorkerTest
         override def getFetchEntryCount(payloadFileCount: Int): Int = 0
       }
 
-      val (srcBagLocation, _) = bagBuilder.createS3BagWith(
+      val (srcBagRoot, _) = bagBuilder.createS3BagWith(
         bucket = srcBucket,
         payloadFileCount = 50
       )
 
       val payload = createEnrichedBagInformationPayloadWith(
-        bagRootLocation = srcBagLocation
+        bagRoot = srcBagRoot
       )
 
       withLocalS3Bucket { dstBucket =>
@@ -213,12 +213,12 @@ class BagReplicatorWorkerTest
     }
 
     withLocalS3Bucket { srcBucket =>
-      val (srcBagLocation, _) = S3BagBuilder.createS3BagWith(
+      val (srcBagRoot, _) = S3BagBuilder.createS3BagWith(
         bucket = srcBucket
       )
 
       val payload = createEnrichedBagInformationPayloadWith(
-        bagRootLocation = srcBagLocation
+        bagRoot = srcBagRoot
       )
 
       withLocalSqsQueue { queue =>
@@ -263,12 +263,12 @@ class BagReplicatorWorkerTest
       val queue = Queue("any", "any")
 
       withLocalS3Bucket { srcBucket =>
-        val (srcBagLocation, _) = S3BagBuilder.createS3BagWith(
+        val (srcBagRoot, _) = S3BagBuilder.createS3BagWith(
           bucket = srcBucket
         )
 
         val payload = createEnrichedBagInformationPayloadWith(
-          bagRootLocation = srcBagLocation
+          bagRoot = srcBagRoot
         )
 
         withLocalS3Bucket { dstBucket =>
@@ -337,17 +337,17 @@ class BagReplicatorWorkerTest
 
       withLocalS3Bucket { srcBucket =>
         withLocalS3Bucket { dstBucket =>
-          val (srcBagLocation, _) = S3BagBuilder.createS3BagWith(
+          val (srcBagRoot, _) = S3BagBuilder.createS3BagWith(
             bucket = srcBucket
           )
 
           val payload = createEnrichedBagInformationPayloadWith(
-            bagRootLocation = srcBagLocation
+            bagRoot = srcBagRoot
           )
 
           s3Client.deleteObject(
-            srcBagLocation.namespace,
-            srcBagLocation.join("tagmanifest-sha256.txt").path
+            srcBagRoot.namespace,
+            srcBagRoot.asLocation("tagmanifest-sha256.txt").path
           )
 
           val future =

--- a/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/models/RootFinderSummary.scala
+++ b/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/models/RootFinderSummary.scala
@@ -3,10 +3,10 @@ package uk.ac.wellcome.platform.storage.bag_root_finder.models
 import java.time.Instant
 
 import uk.ac.wellcome.platform.archive.common.operation.models.Summary
-import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
+import uk.ac.wellcome.storage.ObjectLocationPrefix
 
 sealed trait RootFinderSummary extends Summary {
-  val location: ObjectLocationPrefix
+  val searchRoot: ObjectLocationPrefix
 
   val endTime: Instant
   override val maybeEndTime: Option[Instant] = Some(endTime)
@@ -15,12 +15,12 @@ sealed trait RootFinderSummary extends Summary {
 case class RootFinderFailureSummary(
   startTime: Instant,
   endTime: Instant,
-  location: ObjectLocationPrefix
+  searchRoot: ObjectLocationPrefix
 ) extends RootFinderSummary
 
 case class RootFinderSuccessSummary(
   startTime: Instant,
   endTime: Instant,
-  location: ObjectLocationPrefix,
-  bagRootLocation: ObjectLocation
+  searchRoot: ObjectLocationPrefix,
+  bagRoot: ObjectLocationPrefix
 ) extends RootFinderSummary

--- a/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/BagRootFinder.scala
+++ b/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/BagRootFinder.scala
@@ -29,8 +29,8 @@ class BagRootFinder()(implicit s3Client: AmazonS3) {
             RootFinderSuccessSummary(
               startTime = startTime,
               endTime = Instant.now(),
-              location = unpackLocation,
-              bagRootLocation = rootLocation
+              searchRoot = unpackLocation,
+              bagRoot = rootLocation.asPrefix
             )
           )
 
@@ -39,7 +39,7 @@ class BagRootFinder()(implicit s3Client: AmazonS3) {
             RootFinderFailureSummary(
               startTime = startTime,
               endTime = Instant.now(),
-              location = unpackLocation
+              searchRoot = unpackLocation
             ),
             err
           )

--- a/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/BagRootFinderWorker.scala
+++ b/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/BagRootFinderWorker.scala
@@ -54,7 +54,7 @@ class BagRootFinderWorker[IngestDestination, OutgoingDestination](
       case IngestStepSucceeded(summary: RootFinderSuccessSummary, _) =>
         val outgoingPayload: BagRootPayload = BagRootLocationPayload(
           context = payload.context,
-          bagRootLocation = summary.bagRootLocation
+          bagRootLocation = summary.bagRoot.asLocation()
         )
         outgoingPublisher.sendIfSuccessful(step, outgoingPayload)
       case _ => Success(())

--- a/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/BagRootFinderWorker.scala
+++ b/bag_root_finder/src/main/scala/uk/ac/wellcome/platform/storage/bag_root_finder/services/BagRootFinderWorker.scala
@@ -54,7 +54,7 @@ class BagRootFinderWorker[IngestDestination, OutgoingDestination](
       case IngestStepSucceeded(summary: RootFinderSuccessSummary, _) =>
         val outgoingPayload: BagRootPayload = BagRootLocationPayload(
           context = payload.context,
-          bagRootLocation = summary.bagRoot.asLocation()
+          bagRoot = summary.bagRoot.asLocation()
         )
         outgoingPublisher.sendIfSuccessful(step, outgoingPayload)
       case _ => Success(())

--- a/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/BagRootFinderFeatureTest.scala
+++ b/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/BagRootFinderFeatureTest.scala
@@ -74,12 +74,12 @@ class BagRootFinderFeatureTest
   it("detects a bag in a subdirectory of the bagLocation") {
     withLocalS3Bucket { bucket =>
       val builder = new S3BagBuilderBase {
-        override protected def createBagRoot(
+        override protected def createBagRootPath(
           space: StorageSpace,
           externalIdentifier: ExternalIdentifier,
           version: BagVersion
         ): String =
-          Seq(super.createBagRoot(space, externalIdentifier, version), "subdir")
+          Seq(super.createBagRootPath(space, externalIdentifier, version), "subdir")
             .mkString("/")
       }
 

--- a/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/BagRootFinderFeatureTest.scala
+++ b/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/BagRootFinderFeatureTest.scala
@@ -78,8 +78,10 @@ class BagRootFinderFeatureTest
           externalIdentifier: ExternalIdentifier,
           version: BagVersion
         ): String =
-          Seq(super.createBagRootPath(space, externalIdentifier, version), "subdir")
-            .mkString("/")
+          Seq(
+            super.createBagRootPath(space, externalIdentifier, version),
+            "subdir"
+          ).mkString("/")
       }
 
       val (unpackedBagLocation, _) = builder.createS3BagWith(bucket)

--- a/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/BagRootFinderFeatureTest.scala
+++ b/bag_root_finder/src/test/scala/uk/ac/wellcome/platform/storage/bag_root_finder/BagRootFinderFeatureTest.scala
@@ -29,16 +29,15 @@ class BagRootFinderFeatureTest
 
   it("detects a bag in the root of the bagLocation") {
     withLocalS3Bucket { bucket =>
-      val (unpackedBagLocation, _) = S3BagBuilder.createS3BagWith(bucket)
+      val (unpackedBagRoot, _) = S3BagBuilder.createS3BagWith(bucket)
 
-      // TODO: Bag root location should really be a prefix here
       val payload = createUnpackedBagLocationPayloadWith(
-        unpackedBagLocation = unpackedBagLocation.asPrefix
+        unpackedBagLocation = unpackedBagRoot
       )
 
       val expectedPayload = createBagRootLocationPayloadWith(
         context = payload.context,
-        bagRootLocation = unpackedBagLocation
+        bagRootLocation = unpackedBagRoot
       )
 
       withLocalSqsQueue { queue =>

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/models/UnpackSummary.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/models/UnpackSummary.scala
@@ -9,7 +9,7 @@ import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 case class UnpackSummary(
   id: IngestID,
   srcLocation: ObjectLocation,
-  dstLocation: ObjectLocationPrefix,
+  dstPrefix: ObjectLocationPrefix,
   fileCount: Int = 0,
   bytesUnpacked: Long = 0L,
   startTime: Instant,
@@ -20,7 +20,7 @@ case class UnpackSummary(
   override def toString: String = {
     f"""|id=$id
         |src=$srcLocation
-        |dst=$dstLocation
+        |dst=$dstPrefix
         |files=$fileCount
         |bytesSize=$bytesUnpacked
         |size=${formatBytes(bytesUnpacked)}

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorker.scala
@@ -49,7 +49,7 @@ class BagUnpackerWorker[IngestDestination, OutgoingDestination](
       stepResult <- unpacker.unpack(
         ingestId = payload.ingestId,
         srcLocation = payload.sourceLocation,
-        dstLocation = unpackedBagLocation
+        dstPrefix = unpackedBagLocation
       )
 
       _ <- ingestUpdater.send(payload.ingestId, stepResult)

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
@@ -47,7 +47,7 @@ trait UnpackerTestCases[Namespace]
               .unpack(
                 ingestId = createIngestID,
                 srcLocation = archiveLocation,
-                dstLocation = dstLocation
+                dstPrefix = dstLocation
               )
 
             val unpacked = summaryResult.success.value
@@ -85,7 +85,7 @@ trait UnpackerTestCases[Namespace]
               .unpack(
                 ingestId = createIngestID,
                 srcLocation = archiveLocation,
-                dstLocation = dstLocation
+                dstPrefix = dstLocation
               )
 
             val unpacked = summaryResult.success.value
@@ -113,7 +113,7 @@ trait UnpackerTestCases[Namespace]
         unpacker.unpack(
           ingestId = createIngestID,
           srcLocation = srcLocation,
-          dstLocation = createObjectLocationPrefix
+          dstPrefix = createObjectLocationPrefix
         )
 
       val ingestResult = result.success.value
@@ -144,7 +144,7 @@ trait UnpackerTestCases[Namespace]
           unpacker.unpack(
             ingestId = createIngestID,
             srcLocation = srcLocation,
-            dstLocation = createObjectLocationPrefix
+            dstPrefix = createObjectLocationPrefix
           )
 
         val ingestResult = result.success.value

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3UnpackerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/s3/S3UnpackerTest.scala
@@ -88,7 +88,7 @@ class S3UnpackerTest extends UnpackerTestCases[Bucket] with S3Fixtures {
             unpacker.unpack(
               ingestId = createIngestID,
               srcLocation = archiveLocation,
-              dstLocation = dstLocation
+              dstPrefix = dstLocation
             )
 
           val ingestResult = result.success.value
@@ -134,7 +134,7 @@ class S3UnpackerTest extends UnpackerTestCases[Bucket] with S3Fixtures {
               badUnpacker.unpack(
                 ingestId = createIngestID,
                 srcLocation = archiveLocation,
-                dstLocation = dstLocation
+                dstPrefix = dstLocation
               )
 
             assertIsError(result) { maybeMessage =>
@@ -154,7 +154,7 @@ class S3UnpackerTest extends UnpackerTestCases[Bucket] with S3Fixtures {
           unpacker.unpack(
             ingestId = createIngestID,
             srcLocation = srcLocation,
-            dstLocation = dstLocation
+            dstPrefix = dstLocation
           )
 
         assertIsError(result) { maybeMessage =>
@@ -174,7 +174,7 @@ class S3UnpackerTest extends UnpackerTestCases[Bucket] with S3Fixtures {
             unpacker.unpack(
               ingestId = createIngestID,
               srcLocation = srcLocation,
-              dstLocation = dstLocation
+              dstPrefix = dstLocation
             )
 
           assertIsError(result) { maybeMessage =>
@@ -193,7 +193,7 @@ class S3UnpackerTest extends UnpackerTestCases[Bucket] with S3Fixtures {
           unpacker.unpack(
             ingestId = createIngestID,
             srcLocation = srcLocation,
-            dstLocation = dstLocation
+            dstPrefix = dstLocation
           )
 
         assertIsError(result) { maybeMessage =>

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorker.scala
@@ -37,7 +37,7 @@ class BagVerifierWorker[IngestDestination, OutgoingDestination](
     for {
       _ <- ingestUpdater.start(payload.ingestId)
       summary <- verifier.verify(
-        root = payload.bagRootLocation,
+        bagRoot = payload.bagRootLocation.asPrefix,
         externalIdentifier = payload.externalIdentifier
       )
       _ <- ingestUpdater.send(payload.ingestId, summary)

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorker.scala
@@ -37,7 +37,7 @@ class BagVerifierWorker[IngestDestination, OutgoingDestination](
     for {
       _ <- ingestUpdater.start(payload.ingestId)
       summary <- verifier.verify(
-        bagRoot = payload.bagRootLocation.asPrefix,
+        bagRoot = payload.bagRoot.asPrefix,
         externalIdentifier = payload.externalIdentifier
       )
       _ <- ingestUpdater.send(payload.ingestId, summary)

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
@@ -52,7 +52,7 @@ class BagVerifierFeatureTest
               context = createPipelineContextWith(
                 externalIdentifier = bagInfo.externalIdentifier
               ),
-              bagRootLocation = bagRoot
+              bagRoot = bagRoot
             )
 
             sendNotificationToSQS[BagRootPayload](queue, payload)
@@ -108,7 +108,7 @@ class BagVerifierFeatureTest
               context = createPipelineContextWith(
                 externalIdentifier = bagInfo.externalIdentifier
               ),
-              bagRootLocation = bagRootLocation
+              bagRoot = bagRootLocation
             )
 
             sendNotificationToSQS[BagRootPayload](queue, payload)

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/BagVerifierFeatureTest.scala
@@ -45,14 +45,14 @@ class BagVerifierFeatureTest
           stepName = "verification"
         ) { _ =>
           withLocalS3Bucket { bucket =>
-            val (bagRootLocation, bagInfo) =
+            val (bagRoot, bagInfo) =
               S3BagBuilder.createS3BagWith(bucket)
 
             val payload = createEnrichedBagInformationPayloadWith(
               context = createPipelineContextWith(
                 externalIdentifier = bagInfo.externalIdentifier
               ),
-              bagRootLocation = bagRootLocation
+              bagRootLocation = bagRoot
             )
 
             sendNotificationToSQS[BagRootPayload](queue, payload)

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
@@ -49,17 +49,14 @@ class BagVerifierTest
 
   it("passes a bag with correct checksum values") {
     withLocalS3Bucket { bucket =>
-      val (root, bagInfo) = S3BagBuilder.createS3BagWith(
+      val (bagRoot, bagInfo) = S3BagBuilder.createS3BagWith(
         bucket,
         payloadFileCount = payloadFileCount
       )
 
-      println(root)
-      println(listKeysInBucket(bucket))
-
       val ingestStep =
         withVerifier {
-          _.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+          _.verify(bagRoot.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
         }
 
       val result = ingestStep.success.get
@@ -89,12 +86,12 @@ class BagVerifierTest
           )
       }
 
-      val (root, bagInfo) =
+      val (bagRoot, bagInfo) =
         badBuilder.createS3BagWith(bucket, payloadFileCount = payloadFileCount)
 
       val ingestStep =
         withVerifier {
-          _.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+          _.verify(bagRoot.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
         }
 
       val result = ingestStep.success.get
@@ -137,12 +134,12 @@ class BagVerifierTest
           )
       }
 
-      val (root, bagInfo) =
+      val (bagRoot, bagInfo) =
         badBuilder.createS3BagWith(bucket, payloadFileCount = payloadFileCount)
 
       val ingestStep =
         withVerifier {
-          _.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+          _.verify(bagRoot.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
         }
 
       val result = ingestStep.success.get
@@ -179,12 +176,12 @@ class BagVerifierTest
           )
       }
 
-      val (root, bagInfo) =
+      val (bagRoot, bagInfo) =
         badBuilder.createS3BagWith(bucket, payloadFileCount = payloadFileCount)
 
       val ingestStep =
         withVerifier {
-          _.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+          _.verify(bagRoot.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
         }
 
       val result = ingestStep.success.get
@@ -217,12 +214,12 @@ class BagVerifierTest
         override protected def getFetchEntryCount(payloadFileCount: Int) = 0
       }
 
-      val (root, bagInfo) =
+      val (bagRoot, bagInfo) =
         badBuilder.createS3BagWith(bucket, payloadFileCount = payloadFileCount)
 
       val ingestStep =
         withVerifier {
-          _.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+          _.verify(bagRoot.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
         }
 
       val result = ingestStep.success.get
@@ -258,11 +255,11 @@ class BagVerifierTest
           None
       }
 
-      val (root, bagInfo) = badBuilder.createS3BagWith(bucket)
+      val (bagRoot, bagInfo) = badBuilder.createS3BagWith(bucket)
 
       val ingestStep =
         withVerifier {
-          _.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+          _.verify(bagRoot.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
         }
 
       val result = ingestStep.success.get
@@ -292,11 +289,11 @@ class BagVerifierTest
           None
       }
 
-      val (root, bagInfo) = badBuilder.createS3BagWith(bucket)
+      val (bagRoot, bagInfo) = badBuilder.createS3BagWith(bucket)
 
       val ingestStep =
         withVerifier {
-          _.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+          _.verify(bagRoot.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
         }
 
       val result = ingestStep.success.get
@@ -325,14 +322,14 @@ class BagVerifierTest
       ExternalIdentifier(externalIdentifier + "_payload")
 
     withLocalS3Bucket { bucket =>
-      val (root, _) = S3BagBuilder.createS3BagWith(
+      val (bagRoot, _) = S3BagBuilder.createS3BagWith(
         bucket,
         externalIdentifier = bagInfoExternalIdentifier
       )
 
       val ingestStep =
         withVerifier {
-          _.verify(root, externalIdentifier = payloadExternalIdentifier)
+          _.verify(bagRoot.asPrefix, externalIdentifier = payloadExternalIdentifier)
         }
 
       val result = ingestStep.success.get
@@ -365,12 +362,12 @@ class BagVerifierTest
             )
         }
 
-        val (root, bagInfo) =
+        val (bagRoot, bagInfo) =
           badBuilder.createS3BagWith(bucket)
 
         val ingestStep =
           withVerifier {
-            _.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+            _.verify(bagRoot.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
           }
 
         val result = ingestStep.success.get
@@ -393,9 +390,9 @@ class BagVerifierTest
   describe("checks for unreferenced files") {
     it("fails if there is one unreferenced file") {
       withLocalS3Bucket { bucket =>
-        val (root, bagInfo) = S3BagBuilder.createS3BagWith(bucket)
+        val (bagRoot, bagInfo) = S3BagBuilder.createS3BagWith(bucket)
 
-        val location = root.join("unreferencedfile.txt")
+        val location = bagRoot.join("unreferencedfile.txt")
         s3Client.putObject(
           location.namespace,
           location.path,
@@ -404,7 +401,7 @@ class BagVerifierTest
 
         val ingestStep =
           withVerifier {
-            _.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+            _.verify(bagRoot.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
           }
 
         val result = ingestStep.success.get
@@ -422,10 +419,10 @@ class BagVerifierTest
 
     it("fails if there are multiple unreferenced files") {
       withLocalS3Bucket { bucket =>
-        val (root, bagInfo) = S3BagBuilder.createS3BagWith(bucket)
+        val (bagRoot, bagInfo) = S3BagBuilder.createS3BagWith(bucket)
 
         val locations = (1 to 3).map { i =>
-          val location = root.join(s"unreferencedfile_$i.txt")
+          val location = bagRoot.join(s"unreferencedfile_$i.txt")
           s3Client.putObject(
             location.namespace,
             location.path,
@@ -436,7 +433,7 @@ class BagVerifierTest
 
         val ingestStep =
           withVerifier {
-            _.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+            _.verify(bagRoot.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
           }
 
         val result = ingestStep.success.get
@@ -462,13 +459,13 @@ class BagVerifierTest
             payloadFileCount
         }
 
-        val (root, bagInfo) = alwaysWriteAsFetchBuilder.createS3BagWith(bucket)
+        val (bagRoot, bagInfo) = alwaysWriteAsFetchBuilder.createS3BagWith(bucket)
 
-        val bag = new S3BagReader().get(root).right.value
+        val bag = new S3BagReader().get(bagRoot).right.value
 
         // Write one of the fetch.txt entries as a concrete file
         val badFetchEntry = bag.fetch.get.files.head
-        val badFetchLocation = root.join(badFetchEntry.path.value)
+        val badFetchLocation = bagRoot.join(badFetchEntry.path.value)
 
         s3Client.putObject(
           badFetchLocation.namespace,
@@ -478,7 +475,7 @@ class BagVerifierTest
 
         val ingestStep =
           withVerifier {
-            _.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+            _.verify(bagRoot.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
           }
 
         val result = ingestStep.success.get
@@ -487,7 +484,8 @@ class BagVerifierTest
         val ingestFailed = result.asInstanceOf[IngestFailed[_]]
 
         ingestFailed.e.getMessage shouldBe
-          s"Files referred to in the fetch.txt also appear in the bag: ${root
+          s"Files referred to in the fetch.txt also appear in the bag: ${
+            bagRoot
             .join(badFetchEntry.path.value)}"
 
         ingestFailed.maybeUserFacingMessage.get shouldBe
@@ -499,9 +497,9 @@ class BagVerifierTest
       "passes a bag that includes a manifest/tag manifest for another algorithm"
     ) {
       withLocalS3Bucket { bucket =>
-        val (root, bagInfo) = S3BagBuilder.createS3BagWith(bucket)
+        val (bagRoot, bagInfo) = S3BagBuilder.createS3BagWith(bucket)
 
-        val location = root.join("tagmanifest-sha512.txt")
+        val location = bagRoot.join("tagmanifest-sha512.txt")
 
         s3Client.putObject(
           location.namespace,
@@ -511,7 +509,7 @@ class BagVerifierTest
 
         val ingestStep =
           withVerifier {
-            _.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+            _.verify(bagRoot.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
           }
 
         ingestStep.success.get shouldBe a[IngestStepSucceeded[_]]
@@ -532,14 +530,14 @@ class BagVerifierTest
           }
         }
 
-        val (root, bagInfo) = badBuilder.createS3BagWith(
+        val (bagRoot, bagInfo) = badBuilder.createS3BagWith(
           bucket,
           payloadFileCount = payloadFileCount
         )
 
         val ingestStep =
           withVerifier {
-            _.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+            _.verify(bagRoot.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
           }
 
         val result = ingestStep.success.get
@@ -566,11 +564,11 @@ class BagVerifierTest
           }
         }
 
-        val (root, bagInfo) = badBuilder.createS3BagWith(bucket)
+        val (bagRoot, bagInfo) = badBuilder.createS3BagWith(bucket)
 
         val ingestStep =
           withVerifier {
-            _.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+            _.verify(bagRoot.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
           }
 
         val result = ingestStep.success.get

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
@@ -56,7 +56,10 @@ class BagVerifierTest
 
       val ingestStep =
         withVerifier {
-          _.verify(bagRoot.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
+          _.verify(
+            bagRoot.asPrefix,
+            externalIdentifier = bagInfo.externalIdentifier
+          )
         }
 
       val result = ingestStep.success.get
@@ -91,7 +94,10 @@ class BagVerifierTest
 
       val ingestStep =
         withVerifier {
-          _.verify(bagRoot.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
+          _.verify(
+            bagRoot.asPrefix,
+            externalIdentifier = bagInfo.externalIdentifier
+          )
         }
 
       val result = ingestStep.success.get
@@ -139,7 +145,10 @@ class BagVerifierTest
 
       val ingestStep =
         withVerifier {
-          _.verify(bagRoot.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
+          _.verify(
+            bagRoot.asPrefix,
+            externalIdentifier = bagInfo.externalIdentifier
+          )
         }
 
       val result = ingestStep.success.get
@@ -181,7 +190,10 @@ class BagVerifierTest
 
       val ingestStep =
         withVerifier {
-          _.verify(bagRoot.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
+          _.verify(
+            bagRoot.asPrefix,
+            externalIdentifier = bagInfo.externalIdentifier
+          )
         }
 
       val result = ingestStep.success.get
@@ -219,7 +231,10 @@ class BagVerifierTest
 
       val ingestStep =
         withVerifier {
-          _.verify(bagRoot.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
+          _.verify(
+            bagRoot.asPrefix,
+            externalIdentifier = bagInfo.externalIdentifier
+          )
         }
 
       val result = ingestStep.success.get
@@ -259,7 +274,10 @@ class BagVerifierTest
 
       val ingestStep =
         withVerifier {
-          _.verify(bagRoot.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
+          _.verify(
+            bagRoot.asPrefix,
+            externalIdentifier = bagInfo.externalIdentifier
+          )
         }
 
       val result = ingestStep.success.get
@@ -293,7 +311,10 @@ class BagVerifierTest
 
       val ingestStep =
         withVerifier {
-          _.verify(bagRoot.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
+          _.verify(
+            bagRoot.asPrefix,
+            externalIdentifier = bagInfo.externalIdentifier
+          )
         }
 
       val result = ingestStep.success.get
@@ -329,7 +350,10 @@ class BagVerifierTest
 
       val ingestStep =
         withVerifier {
-          _.verify(bagRoot.asPrefix, externalIdentifier = payloadExternalIdentifier)
+          _.verify(
+            bagRoot.asPrefix,
+            externalIdentifier = payloadExternalIdentifier
+          )
         }
 
       val result = ingestStep.success.get
@@ -367,7 +391,10 @@ class BagVerifierTest
 
         val ingestStep =
           withVerifier {
-            _.verify(bagRoot.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
+            _.verify(
+              bagRoot.asPrefix,
+              externalIdentifier = bagInfo.externalIdentifier
+            )
           }
 
         val result = ingestStep.success.get
@@ -401,7 +428,10 @@ class BagVerifierTest
 
         val ingestStep =
           withVerifier {
-            _.verify(bagRoot.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
+            _.verify(
+              bagRoot.asPrefix,
+              externalIdentifier = bagInfo.externalIdentifier
+            )
           }
 
         val result = ingestStep.success.get
@@ -433,7 +463,10 @@ class BagVerifierTest
 
         val ingestStep =
           withVerifier {
-            _.verify(bagRoot.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
+            _.verify(
+              bagRoot.asPrefix,
+              externalIdentifier = bagInfo.externalIdentifier
+            )
           }
 
         val result = ingestStep.success.get
@@ -459,7 +492,8 @@ class BagVerifierTest
             payloadFileCount
         }
 
-        val (bagRoot, bagInfo) = alwaysWriteAsFetchBuilder.createS3BagWith(bucket)
+        val (bagRoot, bagInfo) =
+          alwaysWriteAsFetchBuilder.createS3BagWith(bucket)
 
         val bag = new S3BagReader().get(bagRoot).right.value
 
@@ -475,7 +509,10 @@ class BagVerifierTest
 
         val ingestStep =
           withVerifier {
-            _.verify(bagRoot.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
+            _.verify(
+              bagRoot.asPrefix,
+              externalIdentifier = bagInfo.externalIdentifier
+            )
           }
 
         val result = ingestStep.success.get
@@ -484,8 +521,7 @@ class BagVerifierTest
         val ingestFailed = result.asInstanceOf[IngestFailed[_]]
 
         ingestFailed.e.getMessage shouldBe
-          s"Files referred to in the fetch.txt also appear in the bag: ${
-            bagRoot
+          s"Files referred to in the fetch.txt also appear in the bag: ${bagRoot
             .join(badFetchEntry.path.value)}"
 
         ingestFailed.maybeUserFacingMessage.get shouldBe
@@ -509,7 +545,10 @@ class BagVerifierTest
 
         val ingestStep =
           withVerifier {
-            _.verify(bagRoot.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
+            _.verify(
+              bagRoot.asPrefix,
+              externalIdentifier = bagInfo.externalIdentifier
+            )
           }
 
         ingestStep.success.get shouldBe a[IngestStepSucceeded[_]]
@@ -537,7 +576,10 @@ class BagVerifierTest
 
         val ingestStep =
           withVerifier {
-            _.verify(bagRoot.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
+            _.verify(
+              bagRoot.asPrefix,
+              externalIdentifier = bagInfo.externalIdentifier
+            )
           }
 
         val result = ingestStep.success.get
@@ -568,7 +610,10 @@ class BagVerifierTest
 
         val ingestStep =
           withVerifier {
-            _.verify(bagRoot.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
+            _.verify(
+              bagRoot.asPrefix,
+              externalIdentifier = bagInfo.externalIdentifier
+            )
           }
 
         val result = ingestStep.success.get

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
@@ -44,7 +44,7 @@ class BagVerifierWorkerTest
         context = createPipelineContextWith(
           externalIdentifier = bagInfo.externalIdentifier
         ),
-        bagRootLocation = bagRoot
+        bagRoot = bagRoot
       )
 
       withBagVerifierWorker(ingests, outgoing, stepName = "verification") {
@@ -76,7 +76,7 @@ class BagVerifierWorkerTest
           context = createPipelineContextWith(
             externalIdentifier = bagInfo.externalIdentifier
           ),
-          bagRootLocation = bagRootLocation
+          bagRoot = bagRootLocation
         )
 
         withBagVerifierWorker(ingests, outgoing, stepName = "verification") {
@@ -132,7 +132,7 @@ class BagVerifierWorkerTest
         context = createPipelineContextWith(
           externalIdentifier = bagInfo.externalIdentifier
         ),
-        bagRootLocation = bagRootLocation
+        bagRoot = bagRootLocation
       )
 
       withBagVerifierWorker(ingests, outgoing, stepName = "verification") {
@@ -170,7 +170,7 @@ class BagVerifierWorkerTest
         context = createPipelineContextWith(
           externalIdentifier = bagInfo.externalIdentifier
         ),
-        bagRootLocation = bagRootLocation
+        bagRoot = bagRootLocation
       )
 
       withBagVerifierWorker(ingests, outgoing, stepName = "verification") {
@@ -210,7 +210,7 @@ class BagVerifierWorkerTest
         context = createPipelineContextWith(
           externalIdentifier = payloadExternalIdentifier
         ),
-        bagRootLocation = bagRootLocation
+        bagRoot = bagRootLocation
       )
 
       withBagVerifierWorker(ingests, outgoing, stepName = "verification") {
@@ -245,7 +245,7 @@ class BagVerifierWorkerTest
         context = createPipelineContextWith(
           externalIdentifier = bagInfo.externalIdentifier
         ),
-        bagRootLocation = bagRootLocation
+        bagRoot = bagRootLocation
       )
 
       withBagVerifierWorker(ingests, outgoing, stepName = "verification") {

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorkerTest.scala
@@ -38,13 +38,13 @@ class BagVerifierWorkerTest
     val outgoing = new MemoryMessageSender()
 
     withLocalS3Bucket { bucket =>
-      val (bagRootLocation, bagInfo) = S3BagBuilder.createS3BagWith(bucket)
+      val (bagRoot, bagInfo) = S3BagBuilder.createS3BagWith(bucket)
 
       val payload = createEnrichedBagInformationPayloadWith(
         context = createPipelineContextWith(
           externalIdentifier = bagInfo.externalIdentifier
         ),
-        bagRootLocation = bagRootLocation
+        bagRootLocation = bagRoot
       )
 
       withBagVerifierWorker(ingests, outgoing, stepName = "verification") {

--- a/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/services/BagVersionerWorker.scala
+++ b/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/services/BagVersionerWorker.scala
@@ -89,7 +89,7 @@ class BagVersionerWorker[IngestDestination, OutgoingDestination](
           step,
           EnrichedBagInformationPayload(
             context = payload.context,
-            bagRootLocation = payload.bagRootLocation,
+            bagRoot = payload.bagRoot,
             version = summary.version
           )
         )

--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/BagVersionerFeatureTest.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/BagVersionerFeatureTest.scala
@@ -97,7 +97,7 @@ class BagVersionerFeatureTest
         ingestDate = Instant.ofEpochSecond(1),
         storageSpace = storageSpace
       ),
-      bagRootLocation = bagRootLocation
+      bagRoot = bagRootLocation
     )
 
     val payload2 = payload1.copy(

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/PipelinePayload.scala
@@ -43,16 +43,16 @@ case class UnpackedBagLocationPayload(
 ) extends PipelinePayload
 
 sealed trait BagRootPayload extends PipelinePayload {
-  val bagRootLocation: ObjectLocation
+  val bagRoot: ObjectLocationPrefix
 }
 
 case class BagRootLocationPayload(
   context: PipelineContext,
-  bagRootLocation: ObjectLocation
+  bagRoot: ObjectLocationPrefix
 ) extends BagRootPayload
 
 case class EnrichedBagInformationPayload(
   context: PipelineContext,
-  bagRootLocation: ObjectLocation,
+  bagRoot: ObjectLocationPrefix,
   version: BagVersion
 ) extends BagRootPayload

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagReader.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagReader.scala
@@ -2,9 +2,19 @@ package uk.ac.wellcome.platform.archive.common.bagit.services
 
 import java.io.InputStream
 
-import uk.ac.wellcome.platform.archive.common.bagit.models.{Bag, BagFetch, BagInfo, BagManifest, BagPath}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  Bag,
+  BagFetch,
+  BagInfo,
+  BagManifest,
+  BagPath
+}
 import uk.ac.wellcome.platform.archive.common.verify.{HashingAlgorithm, SHA256}
-import uk.ac.wellcome.storage.{DoesNotExistError, ObjectLocation, ObjectLocationPrefix}
+import uk.ac.wellcome.storage.{
+  DoesNotExistError,
+  ObjectLocation,
+  ObjectLocationPrefix
+}
 import uk.ac.wellcome.storage.store.StreamStore
 import uk.ac.wellcome.storage.streaming.InputStreamWithLength
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
@@ -34,7 +34,7 @@ class BadFetchLocationException(message: String)
 class StorageManifestService(sizeFinder: SizeFinder) extends Logging {
   def createManifest(
     bag: Bag,
-    replicaRoot: ObjectLocation,
+    replicaRoot: ObjectLocationPrefix,
     space: StorageSpace,
     version: BagVersion
   ): Try[StorageManifest] = {
@@ -98,12 +98,12 @@ class StorageManifestService(sizeFinder: SizeFinder) extends Logging {
     *
     */
   private def getBagRoot(
-    replicaRoot: ObjectLocation,
+    replicaRoot: ObjectLocationPrefix,
     version: BagVersion
   ): Try[ObjectLocationPrefix] =
     if (replicaRoot.path.endsWith(s"/$version")) {
       Success(
-        replicaRoot.asPrefix.copy(
+        replicaRoot.copy(
           path = replicaRoot.path.stripSuffix(s"/$version")
         )
       )

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagReaderTestCases.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagReaderTestCases.scala
@@ -3,7 +3,10 @@ package uk.ac.wellcome.platform.archive.common.bagit.services
 import org.scalatest.{Assertion, EitherValues, FunSpec, Matchers}
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagInfo
-import uk.ac.wellcome.platform.archive.common.fixtures.{BagBuilder, StorageRandomThings}
+import uk.ac.wellcome.platform.archive.common.fixtures.{
+  BagBuilder,
+  StorageRandomThings
+}
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 import uk.ac.wellcome.storage.store.{TypedStore, TypedStoreEntry}
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/memory/MemoryBagReaderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/memory/MemoryBagReaderTest.scala
@@ -1,7 +1,10 @@
 package uk.ac.wellcome.platform.archive.common.bagit.services.memory
 
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.archive.common.bagit.services.{BagReader, BagReaderTestCases}
+import uk.ac.wellcome.platform.archive.common.bagit.services.{
+  BagReader,
+  BagReaderTestCases
+}
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 import uk.ac.wellcome.storage.store.TypedStore
 import uk.ac.wellcome.storage.store.memory.{MemoryStreamStore, MemoryTypedStore}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/memory/MemoryBagReaderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/memory/MemoryBagReaderTest.scala
@@ -1,11 +1,8 @@
 package uk.ac.wellcome.platform.archive.common.bagit.services.memory
 
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.archive.common.bagit.services.{
-  BagReader,
-  BagReaderTestCases
-}
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.platform.archive.common.bagit.services.{BagReader, BagReaderTestCases}
+import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 import uk.ac.wellcome.storage.store.TypedStore
 import uk.ac.wellcome.storage.store.memory.{MemoryStreamStore, MemoryTypedStore}
 
@@ -35,10 +32,10 @@ class MemoryBagReaderTest
   override def withNamespace[R](testWith: TestWith[String, R]): R =
     testWith(randomAlphanumeric)
 
-  override def deleteFile(rootLocation: ObjectLocation, path: String)(
+  override def deleteFile(bagRoot: ObjectLocationPrefix, path: String)(
     implicit context: MemoryStreamStore[ObjectLocation]
   ): Unit =
     context.memoryStore.entries = context.memoryStore.entries.filter {
-      case (location, _) => location != rootLocation.join(path)
+      case (location, _) => location != bagRoot.asLocation(path)
     }
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/s3/S3BagReaderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/s3/S3BagReaderTest.scala
@@ -1,11 +1,8 @@
 package uk.ac.wellcome.platform.archive.common.bagit.services.s3
 
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.archive.common.bagit.services.{
-  BagReader,
-  BagReaderTestCases
-}
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.platform.archive.common.bagit.services.{BagReader, BagReaderTestCases}
+import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
 import uk.ac.wellcome.storage.store.TypedStore
@@ -25,12 +22,12 @@ class S3BagReaderTest extends BagReaderTestCases[Unit, Bucket] with S3Fixtures {
       testWith(bucket)
     }
 
-  override def deleteFile(rootLocation: ObjectLocation, path: String)(
+  override def deleteFile(bagRoot: ObjectLocationPrefix, path: String)(
     implicit context: Unit
   ): Unit =
     s3Client.deleteObject(
-      rootLocation.namespace,
-      rootLocation.join(path).path
+      bagRoot.namespace,
+      bagRoot.asLocation(path).path
     )
 
   override def withContext[R](testWith: TestWith[Unit, R]): R = testWith(())

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/s3/S3BagReaderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/s3/S3BagReaderTest.scala
@@ -1,7 +1,10 @@
 package uk.ac.wellcome.platform.archive.common.bagit.services.s3
 
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.archive.common.bagit.services.{BagReader, BagReaderTestCases}
+import uk.ac.wellcome.platform.archive.common.bagit.services.{
+  BagReader,
+  BagReaderTestCases
+}
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 import uk.ac.wellcome.storage.fixtures.S3Fixtures
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilderBase.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/BagBuilderBase.scala
@@ -2,8 +2,17 @@ package uk.ac.wellcome.platform.archive.common.fixtures
 
 import java.security.MessageDigest
 
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagInfo, BagPath, BagVersion, ExternalIdentifier, PayloadOxum}
-import uk.ac.wellcome.platform.archive.common.generators.{BagInfoGenerators, StorageSpaceGenerators}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagInfo,
+  BagPath,
+  BagVersion,
+  ExternalIdentifier,
+  PayloadOxum
+}
+import uk.ac.wellcome.platform.archive.common.generators.{
+  BagInfoGenerators,
+  StorageSpaceGenerators
+}
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 import uk.ac.wellcome.storage.fixtures.S3Fixtures

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/PayloadGenerators.scala
@@ -72,12 +72,12 @@ trait PayloadGenerators
 
   def createEnrichedBagInformationPayloadWith(
     context: PipelineContext = createPipelineContext,
-    bagRootLocation: ObjectLocation = createObjectLocation,
+    bagRoot: ObjectLocationPrefix = createObjectLocationPrefix,
     version: BagVersion = createBagVersion
   ): EnrichedBagInformationPayload =
     EnrichedBagInformationPayload(
       context = context,
-      bagRootLocation = bagRootLocation,
+      bagRoot = bagRoot,
       version = version
     )
 
@@ -86,11 +86,11 @@ trait PayloadGenerators
 
   def createBagRootLocationPayloadWith(
     context: PipelineContext = createPipelineContext,
-    bagRootLocation: ObjectLocation = createObjectLocation
+    bagRoot: ObjectLocationPrefix = createObjectLocationPrefix
   ): BagRootLocationPayload =
     BagRootLocationPayload(
       context = context,
-      bagRootLocation = bagRootLocation
+      bagRoot = bagRoot
     )
 
   def createBagRootLocationPayload: BagRootLocationPayload =

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
@@ -3,11 +3,26 @@ package uk.ac.wellcome.platform.archive.common.storage.services
 import java.net.URI
 
 import org.scalatest.{Assertion, FunSpec, Matchers, TryValues}
-import uk.ac.wellcome.platform.archive.common.bagit.models.{Bag, BagFetchEntry, BagPath, BagVersion}
-import uk.ac.wellcome.platform.archive.common.generators.{BagFileGenerators, BagGenerators, StorageSpaceGenerators}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  Bag,
+  BagFetchEntry,
+  BagPath,
+  BagVersion
+}
+import uk.ac.wellcome.platform.archive.common.generators.{
+  BagFileGenerators,
+  BagGenerators,
+  StorageSpaceGenerators
+}
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.TimeTestFixture
-import uk.ac.wellcome.platform.archive.common.ingests.models.{InfrequentAccessStorageProvider, StorageLocation}
-import uk.ac.wellcome.platform.archive.common.storage.models.{StorageManifest, StorageSpace}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  InfrequentAccessStorageProvider,
+  StorageLocation
+}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  StorageManifest,
+  StorageSpace
+}
 import uk.ac.wellcome.platform.archive.common.verify.{MD5, SHA256}
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
@@ -83,7 +98,8 @@ class StorageManifestServiceTest
         bag = bag,
         replicaRoot = replicaRoot,
         version = version,
-        sizes = files.map { replicaRoot.asLocation(_) -> Random.nextLong().abs }.toMap
+        sizes =
+          files.map { replicaRoot.asLocation(_) -> Random.nextLong().abs }.toMap
       )
 
       val namePathMap =
@@ -115,7 +131,8 @@ class StorageManifestServiceTest
         bag = bag,
         replicaRoot = replicaRoot,
         version = version,
-        sizes = files.map { replicaRoot.asLocation(_) -> Random.nextLong().abs }.toMap
+        sizes =
+          files.map { replicaRoot.asLocation(_) -> Random.nextLong().abs }.toMap
       )
 
       val namePathMap =
@@ -493,7 +510,8 @@ class StorageManifestServiceTest
       val version = randomInt(from = 1, to = 10)
       val replicaRoot = createObjectLocation.join(s"v$version").asPrefix
       val sizes = expectedSizes.map {
-        case (path, expectedSize) => replicaRoot.asLocation(path) -> expectedSize
+        case (path, expectedSize) =>
+          replicaRoot.asLocation(path) -> expectedSize
       }
 
       val storageManifest = createManifest(
@@ -576,7 +594,8 @@ class StorageManifestServiceTest
   private def createManifest(
     space: StorageSpace = createStorageSpace,
     bag: Bag = createBag,
-    replicaRoot: ObjectLocationPrefix = createObjectLocation.join("/v1").asPrefix,
+    replicaRoot: ObjectLocationPrefix =
+      createObjectLocation.join("/v1").asPrefix,
     version: Int = 1,
     sizes: Map[ObjectLocation, Long] = Map.empty
   ): StorageManifest = {
@@ -607,7 +626,8 @@ class StorageManifestServiceTest
 
   private def assertIsError(
     bag: Bag = createBag,
-    replicaRoot: ObjectLocationPrefix = createObjectLocation.join("/v1").asPrefix,
+    replicaRoot: ObjectLocationPrefix =
+      createObjectLocation.join("/v1").asPrefix,
     version: Int = 1
   )(assertError: Throwable => Assertion): Assertion = {
     val sizeFinder = new SizeFinder {

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/ReplicaResult.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/ReplicaResult.scala
@@ -20,7 +20,7 @@ case object ReplicaResult {
       ingestId = payload.ingestId,
       storageLocation = PrimaryStorageLocation(
         provider = InfrequentAccessStorageProvider,
-        location = payload.bagRootLocation
+        location = payload.bagRoot
       ),
       timestamp = Instant.now()
     )

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorker.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorker.scala
@@ -39,7 +39,7 @@ class ReplicaAggregatorWorker[IngestDestination, OutgoingDestination](
     val replicaResult = ReplicaResult(payload)
 
     val replicationSet = ReplicationSet(
-      path = ReplicaPath(payload.bagRootLocation.path),
+      path = ReplicaPath(payload.bagRoot.path),
       results = Set(replicaResult)
     )
 


### PR DESCRIPTION
It’s semantically cleaner if ObjectLocation only refers to a specific object that exists, and the Prefix refers to a directory or similar.

Unfortunately we have StorageLocation doing double-duty as both the source location (a tar.gz that exists in S3) and in the storage manifest.

I might finish this off later, see how I go.