### PR TITLE
Start disambiguating between ObjectLocation and ObjectLocationPrefix

### DIFF
--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/models/RegistrationSummary.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/models/RegistrationSummary.scala
@@ -4,11 +4,11 @@ import java.time.Instant
 
 import uk.ac.wellcome.platform.archive.common.operation.models.Summary
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.ObjectLocationPrefix
 
 case class RegistrationSummary(
-  bagRootLocation: ObjectLocation,
-  storageSpace: StorageSpace,
+  bagRoot: ObjectLocationPrefix,
+  space: StorageSpace,
   startTime: Instant,
   maybeEndTime: Option[Instant] = None
 ) extends Summary {
@@ -18,8 +18,8 @@ case class RegistrationSummary(
     )
 
   override def toString: String =
-    f"""|bag=$bagRootLocation
-        |space=$storageSpace
+    f"""|bag=$bagRoot
+        |space=$space
         |durationSeconds=$durationSeconds
         |duration=$formatDuration""".stripMargin
       .replaceAll("\n", ", ")

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorker.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorker.scala
@@ -35,7 +35,7 @@ class BagRegisterWorker[IngestDestination, OutgoingDestination](
       _ <- ingestUpdater.start(payload.ingestId)
 
       registrationSummary <- register.update(
-        bagRootLocation = payload.bagRootLocation,
+        bagRoot = payload.bagRootLocation.asPrefix,
         version = payload.version,
         storageSpace = payload.storageSpace
       )

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/Register.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/Register.scala
@@ -17,7 +17,7 @@ import uk.ac.wellcome.platform.archive.common.storage.services.{
   StorageManifestDao,
   StorageManifestService
 }
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.ObjectLocationPrefix
 
 import scala.util.{Failure, Success, Try}
 
@@ -28,19 +28,19 @@ class Register(
 ) extends Logging {
 
   def update(
-    bagRootLocation: ObjectLocation,
+    bagRoot: ObjectLocationPrefix,
     version: BagVersion,
     storageSpace: StorageSpace
   ): Try[IngestStepResult[RegistrationSummary]] = {
 
     val registration = RegistrationSummary(
       startTime = Instant.now(),
-      bagRootLocation = bagRootLocation,
-      storageSpace = storageSpace
+      bagRoot = bagRoot,
+      space = storageSpace
     )
 
     val result: Try[IngestStepResult[RegistrationSummary]] = for {
-      bag <- bagReader.get(bagRootLocation.asPrefix) match {
+      bag <- bagReader.get(bagRoot) match {
         case Right(value) => Success(value)
         case Left(err) =>
           Failure(new RuntimeException(s"Bag unavailable: ${err.msg}"))
@@ -48,7 +48,7 @@ class Register(
 
       storageManifest <- storageManifestService.createManifest(
         bag = bag,
-        replicaRoot = bagRootLocation,
+        replicaRoot = bagRoot.asLocation(),
         space = storageSpace,
         version = version
       )

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/Register.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/Register.scala
@@ -40,7 +40,7 @@ class Register(
     )
 
     val result: Try[IngestStepResult[RegistrationSummary]] = for {
-      bag <- bagReader.get(bagRootLocation) match {
+      bag <- bagReader.get(bagRootLocation.asPrefix) match {
         case Right(value) => Success(value)
         case Left(err) =>
           Failure(new RuntimeException(s"Bag unavailable: ${err.msg}"))

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/Register.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/Register.scala
@@ -48,7 +48,7 @@ class Register(
 
       storageManifest <- storageManifestService.createManifest(
         bag = bag,
-        replicaRoot = bagRoot.asLocation(),
+        replicaRoot = bagRoot,
         space = storageSpace,
         version = version
       )

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/RegisterTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/RegisterTest.scala
@@ -72,9 +72,9 @@ class RegisterTest
     BagBuilder.uploadBagObjects(badBagObjects)
 
     val result = register.update(
-      bagRootLocation = bagRoot.copy(
+      bagRoot = bagRoot.copy(
         namespace = bagRoot.namespace + "_wrong"
-      ),
+      ).asPrefix,
       version = version,
       storageSpace = space
     )

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/RegisterTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/RegisterTest.scala
@@ -72,9 +72,11 @@ class RegisterTest
     BagBuilder.uploadBagObjects(badBagObjects)
 
     val result = register.update(
-      bagRoot = bagRoot.copy(
-        namespace = bagRoot.namespace + "_wrong"
-      ).asPrefix,
+      bagRoot = bagRoot
+        .copy(
+          namespace = bagRoot.namespace + "_wrong"
+        )
+        .asPrefix,
       version = version,
       storageSpace = space
     )

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/models/VerificationSummary.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/models/VerificationSummary.scala
@@ -9,10 +9,10 @@ import uk.ac.wellcome.platform.archive.common.verify.{
   VerificationResult,
   VerificationSuccess
 }
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.ObjectLocationPrefix
 
 sealed trait VerificationSummary extends Summary {
-  val rootLocation: ObjectLocation
+  val rootLocation: ObjectLocationPrefix
   val verification: Option[VerificationResult]
 
   val endTime: Instant
@@ -24,7 +24,7 @@ sealed trait VerificationSummary extends Summary {
       case Some(VerificationIncomplete(msg)) =>
         f"""
            |status=incomplete
-           |message=${msg}
+           |message=$msg
          """.stripMargin
       case Some(VerificationFailure(failed, succeeded)) =>
         f"""
@@ -55,7 +55,7 @@ sealed trait VerificationSummary extends Summary {
 
 object VerificationSummary {
   def incomplete(
-    root: ObjectLocation,
+    root: ObjectLocationPrefix,
     e: Throwable,
     t: Instant
   ): VerificationIncompleteSummary =
@@ -67,7 +67,7 @@ object VerificationSummary {
     )
 
   def create(
-    root: ObjectLocation,
+    root: ObjectLocationPrefix,
     v: VerificationResult,
     t: Instant
   ): VerificationSummary = v match {
@@ -96,7 +96,7 @@ object VerificationSummary {
 }
 
 case class VerificationIncompleteSummary(
-  rootLocation: ObjectLocation,
+  rootLocation: ObjectLocationPrefix,
   e: Throwable,
   startTime: Instant,
   endTime: Instant
@@ -105,14 +105,14 @@ case class VerificationIncompleteSummary(
 }
 
 case class VerificationSuccessSummary(
-  rootLocation: ObjectLocation,
+  rootLocation: ObjectLocationPrefix,
   verification: Some[VerificationSuccess],
   startTime: Instant,
   endTime: Instant
 ) extends VerificationSummary
 
 case class VerificationFailureSummary(
-  rootLocation: ObjectLocation,
+  rootLocation: ObjectLocationPrefix,
   verification: Option[VerificationFailure],
   startTime: Instant,
   endTime: Instant

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -33,7 +33,7 @@ class BagVerifier()(
   type InternalResult[T] = Either[BagVerifierError, T]
 
   def verify(
-    root: ObjectLocation,
+    root: ObjectLocationPrefix,
     externalIdentifier: ExternalIdentifier
   ): Try[IngestStepResult[VerificationSummary]] =
     Try {
@@ -55,7 +55,7 @@ class BagVerifier()(
             bag = bag
           )
 
-          actualLocations <- listing.list(root.asPrefix) match {
+          actualLocations <- listing.list(root) match {
             case Right(iterable) => Right(iterable.toSeq)
             case Left(listingFailure) =>
               Left(BagVerifierError(listingFailure.e))
@@ -85,10 +85,10 @@ class BagVerifier()(
     }
 
   private def getBag(
-    root: ObjectLocation,
+    root: ObjectLocationPrefix,
     startTime: Instant
   ): InternalResult[Bag] =
-    bagReader.get(root.asPrefix) match {
+    bagReader.get(root) match {
       case Left(bagUnavailable) =>
         Left(
           BagVerifierError(
@@ -120,11 +120,11 @@ class BagVerifier()(
     }
 
   private def verifyChecksums(
-    root: ObjectLocation,
+    root: ObjectLocationPrefix,
     bag: Bag
   ): InternalResult[VerificationResult] = {
     implicit val bagVerifiable: BagVerifiable =
-      new BagVerifiable(root)
+      new BagVerifiable(root.asLocation())
 
     Try { bag.verify } match {
       case Failure(err)    => Left(BagVerifierError(err))
@@ -188,7 +188,7 @@ class BagVerifier()(
   // also have a fetch file entry.
   private def verifyNoConcreteFetchEntries(
     bag: Bag,
-    root: ObjectLocation,
+    root: ObjectLocationPrefix,
     actualLocations: Seq[ObjectLocation],
     verificationResult: VerificationResult
   ): InternalResult[Unit] =
@@ -199,7 +199,7 @@ class BagVerifier()(
             fetchEntry.files
               .map { _.path }
               .map { path =>
-                root.join(path.value)
+                root.asLocation(path.value)
               }
 
           case None => Seq.empty
@@ -268,7 +268,7 @@ class BagVerifier()(
   // Check that there aren't any files in the bag that aren't referenced in
   // either the file manifest or the tag manifest.
   private def verifyNoUnreferencedFiles(
-    root: ObjectLocation,
+    root: ObjectLocationPrefix,
     actualLocations: Seq[ObjectLocation],
     verificationResult: VerificationResult
   ): InternalResult[Unit] =
@@ -281,7 +281,7 @@ class BagVerifier()(
         val unreferencedFiles = actualLocations
           .filterNot { expectedLocations.contains(_) }
           .filterNot { location =>
-            excludedFiles.exists { root.join(_) == location }
+            excludedFiles.exists { root.asLocation(_) == location }
           }
 
         if (unreferencedFiles.isEmpty) {
@@ -324,7 +324,7 @@ class BagVerifier()(
 
   private def buildStepResult(
     internalResult: InternalResult[VerificationResult],
-    root: ObjectLocation,
+    root: ObjectLocationPrefix,
     startTime: Instant
   ): IngestStepResult[VerificationSummary] =
     internalResult match {

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -88,7 +88,7 @@ class BagVerifier()(
     root: ObjectLocation,
     startTime: Instant
   ): InternalResult[Bag] =
-    bagReader.get(root) match {
+    bagReader.get(root.asPrefix) match {
       case Left(bagUnavailable) =>
         Left(
           BagVerifierError(

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorker.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierWorker.scala
@@ -37,7 +37,7 @@ class BagVerifierWorker[IngestDestination, OutgoingDestination](
     for {
       _ <- ingestUpdater.start(payload.ingestId)
       summary <- verifier.verify(
-        root = payload.bagRootLocation,
+        root = payload.bagRootLocation.asPrefix,
         externalIdentifier = payload.externalIdentifier
       )
       _ <- ingestUpdater.send(payload.ingestId, summary)

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
@@ -54,12 +54,9 @@ class BagVerifierTest
         payloadFileCount = payloadFileCount
       )
 
-      println(root)
-      println(listKeysInBucket(bucket))
-
       val ingestStep =
         withVerifier {
-          _.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+          _.verify(root.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
         }
 
       val result = ingestStep.success.get
@@ -94,7 +91,7 @@ class BagVerifierTest
 
       val ingestStep =
         withVerifier {
-          _.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+          _.verify(root.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
         }
 
       val result = ingestStep.success.get
@@ -142,7 +139,7 @@ class BagVerifierTest
 
       val ingestStep =
         withVerifier {
-          _.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+          _.verify(root.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
         }
 
       val result = ingestStep.success.get
@@ -184,7 +181,7 @@ class BagVerifierTest
 
       val ingestStep =
         withVerifier {
-          _.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+          _.verify(root.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
         }
 
       val result = ingestStep.success.get
@@ -222,7 +219,7 @@ class BagVerifierTest
 
       val ingestStep =
         withVerifier {
-          _.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+          _.verify(root.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
         }
 
       val result = ingestStep.success.get
@@ -262,7 +259,7 @@ class BagVerifierTest
 
       val ingestStep =
         withVerifier {
-          _.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+          _.verify(root.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
         }
 
       val result = ingestStep.success.get
@@ -296,7 +293,7 @@ class BagVerifierTest
 
       val ingestStep =
         withVerifier {
-          _.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+          _.verify(root.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
         }
 
       val result = ingestStep.success.get
@@ -332,7 +329,7 @@ class BagVerifierTest
 
       val ingestStep =
         withVerifier {
-          _.verify(root, externalIdentifier = payloadExternalIdentifier)
+          _.verify(root.asPrefix, externalIdentifier = payloadExternalIdentifier)
         }
 
       val result = ingestStep.success.get
@@ -370,7 +367,7 @@ class BagVerifierTest
 
         val ingestStep =
           withVerifier {
-            _.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+            _.verify(root.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
           }
 
         val result = ingestStep.success.get
@@ -404,7 +401,7 @@ class BagVerifierTest
 
         val ingestStep =
           withVerifier {
-            _.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+            _.verify(root.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
           }
 
         val result = ingestStep.success.get
@@ -436,7 +433,7 @@ class BagVerifierTest
 
         val ingestStep =
           withVerifier {
-            _.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+            _.verify(root.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
           }
 
         val result = ingestStep.success.get
@@ -478,7 +475,7 @@ class BagVerifierTest
 
         val ingestStep =
           withVerifier {
-            _.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+            _.verify(root.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
           }
 
         val result = ingestStep.success.get
@@ -511,7 +508,7 @@ class BagVerifierTest
 
         val ingestStep =
           withVerifier {
-            _.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+            _.verify(root.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
           }
 
         ingestStep.success.get shouldBe a[IngestStepSucceeded[_]]
@@ -539,7 +536,7 @@ class BagVerifierTest
 
         val ingestStep =
           withVerifier {
-            _.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+            _.verify(root.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
           }
 
         val result = ingestStep.success.get
@@ -570,7 +567,7 @@ class BagVerifierTest
 
         val ingestStep =
           withVerifier {
-            _.verify(root, externalIdentifier = bagInfo.externalIdentifier)
+            _.verify(root.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
           }
 
         val result = ingestStep.success.get

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
@@ -56,7 +56,10 @@ class BagVerifierTest
 
       val ingestStep =
         withVerifier {
-          _.verify(root.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
+          _.verify(
+            root.asPrefix,
+            externalIdentifier = bagInfo.externalIdentifier
+          )
         }
 
       val result = ingestStep.success.get
@@ -91,7 +94,10 @@ class BagVerifierTest
 
       val ingestStep =
         withVerifier {
-          _.verify(root.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
+          _.verify(
+            root.asPrefix,
+            externalIdentifier = bagInfo.externalIdentifier
+          )
         }
 
       val result = ingestStep.success.get
@@ -139,7 +145,10 @@ class BagVerifierTest
 
       val ingestStep =
         withVerifier {
-          _.verify(root.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
+          _.verify(
+            root.asPrefix,
+            externalIdentifier = bagInfo.externalIdentifier
+          )
         }
 
       val result = ingestStep.success.get
@@ -181,7 +190,10 @@ class BagVerifierTest
 
       val ingestStep =
         withVerifier {
-          _.verify(root.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
+          _.verify(
+            root.asPrefix,
+            externalIdentifier = bagInfo.externalIdentifier
+          )
         }
 
       val result = ingestStep.success.get
@@ -219,7 +231,10 @@ class BagVerifierTest
 
       val ingestStep =
         withVerifier {
-          _.verify(root.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
+          _.verify(
+            root.asPrefix,
+            externalIdentifier = bagInfo.externalIdentifier
+          )
         }
 
       val result = ingestStep.success.get
@@ -259,7 +274,10 @@ class BagVerifierTest
 
       val ingestStep =
         withVerifier {
-          _.verify(root.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
+          _.verify(
+            root.asPrefix,
+            externalIdentifier = bagInfo.externalIdentifier
+          )
         }
 
       val result = ingestStep.success.get
@@ -293,7 +311,10 @@ class BagVerifierTest
 
       val ingestStep =
         withVerifier {
-          _.verify(root.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
+          _.verify(
+            root.asPrefix,
+            externalIdentifier = bagInfo.externalIdentifier
+          )
         }
 
       val result = ingestStep.success.get
@@ -329,7 +350,10 @@ class BagVerifierTest
 
       val ingestStep =
         withVerifier {
-          _.verify(root.asPrefix, externalIdentifier = payloadExternalIdentifier)
+          _.verify(
+            root.asPrefix,
+            externalIdentifier = payloadExternalIdentifier
+          )
         }
 
       val result = ingestStep.success.get
@@ -367,7 +391,10 @@ class BagVerifierTest
 
         val ingestStep =
           withVerifier {
-            _.verify(root.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
+            _.verify(
+              root.asPrefix,
+              externalIdentifier = bagInfo.externalIdentifier
+            )
           }
 
         val result = ingestStep.success.get
@@ -401,7 +428,10 @@ class BagVerifierTest
 
         val ingestStep =
           withVerifier {
-            _.verify(root.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
+            _.verify(
+              root.asPrefix,
+              externalIdentifier = bagInfo.externalIdentifier
+            )
           }
 
         val result = ingestStep.success.get
@@ -433,7 +463,10 @@ class BagVerifierTest
 
         val ingestStep =
           withVerifier {
-            _.verify(root.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
+            _.verify(
+              root.asPrefix,
+              externalIdentifier = bagInfo.externalIdentifier
+            )
           }
 
         val result = ingestStep.success.get
@@ -475,7 +508,10 @@ class BagVerifierTest
 
         val ingestStep =
           withVerifier {
-            _.verify(root.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
+            _.verify(
+              root.asPrefix,
+              externalIdentifier = bagInfo.externalIdentifier
+            )
           }
 
         val result = ingestStep.success.get
@@ -508,7 +544,10 @@ class BagVerifierTest
 
         val ingestStep =
           withVerifier {
-            _.verify(root.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
+            _.verify(
+              root.asPrefix,
+              externalIdentifier = bagInfo.externalIdentifier
+            )
           }
 
         ingestStep.success.get shouldBe a[IngestStepSucceeded[_]]
@@ -536,7 +575,10 @@ class BagVerifierTest
 
         val ingestStep =
           withVerifier {
-            _.verify(root.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
+            _.verify(
+              root.asPrefix,
+              externalIdentifier = bagInfo.externalIdentifier
+            )
           }
 
         val result = ingestStep.success.get
@@ -567,7 +609,10 @@ class BagVerifierTest
 
         val ingestStep =
           withVerifier {
-            _.verify(root.asPrefix, externalIdentifier = bagInfo.externalIdentifier)
+            _.verify(
+              root.asPrefix,
+              externalIdentifier = bagInfo.externalIdentifier
+            )
           }
 
         val result = ingestStep.success.get

--- a/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
+++ b/bag_verifier/src/test/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifierTest.scala
@@ -464,7 +464,7 @@ class BagVerifierTest
 
         val (root, bagInfo) = alwaysWriteAsFetchBuilder.createS3BagWith(bucket)
 
-        val bag = new S3BagReader().get(root).right.value
+        val bag = new S3BagReader().get(root.asPrefix).right.value
 
         // Write one of the fetch.txt entries as a concrete file
         val badFetchEntry = bag.fetch.get.files.head

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
@@ -34,7 +34,7 @@ class BadFetchLocationException(message: String)
 class StorageManifestService(sizeFinder: SizeFinder) extends Logging {
   def createManifest(
     bag: Bag,
-    replicaRoot: ObjectLocation,
+    replicaRoot: ObjectLocationPrefix,
     space: StorageSpace,
     version: BagVersion
   ): Try[StorageManifest] = {
@@ -98,19 +98,20 @@ class StorageManifestService(sizeFinder: SizeFinder) extends Logging {
     *
     */
   private def getBagRoot(
-    replicaRoot: ObjectLocation,
+    replicaRoot: ObjectLocationPrefix,
     version: BagVersion
   ): Try[ObjectLocationPrefix] =
     if (replicaRoot.path.endsWith(s"/$version")) {
       Success(
-        replicaRoot.asPrefix.copy(
+        replicaRoot.copy(
           path = replicaRoot.path.stripSuffix(s"/$version")
         )
       )
     } else {
       Failure(
         new StorageManifestException(
-          s"Malformed bag root: $replicaRoot (expected suffix /$version)"
+          // TODO: Move the toString method for ObjectLocationPrefix into scala-storage
+          s"Malformed bag root: ${replicaRoot.namespace}/${replicaRoot.path} (expected suffix /$version)"
         )
       )
     }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagReaderTestCases.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/services/BagReaderTestCases.scala
@@ -55,10 +55,10 @@ trait BagReaderTestCases[Context, Namespace]
     withFixtures { fixtures =>
       implicit val (context, typedStore, namespace) = fixtures
 
-      val (rootLocation, bagInfo) = createBag()
+      val (bagRoot, bagInfo) = createBag()
 
       val bag = withBagReader {
-        _.get(rootLocation).right.value
+        _.get(bagRoot.asPrefix).right.value
       }
 
       bag.info shouldBe bagInfo
@@ -69,11 +69,11 @@ trait BagReaderTestCases[Context, Namespace]
     withFixtures { fixtures =>
       implicit val (context, typedStore, namespace) = fixtures
 
-      val (rootLocation, _) = createBag()
-      deleteFile(rootLocation, "bag-info.txt")
+      val (bagRoot, _) = createBag()
+      deleteFile(bagRoot, "bag-info.txt")
 
       withBagReader {
-        _.get(rootLocation).left.value.msg should startWith(
+        _.get(bagRoot.asPrefix).left.value.msg should startWith(
           "Error loading bag-info.txt"
         )
       }
@@ -84,11 +84,11 @@ trait BagReaderTestCases[Context, Namespace]
     withFixtures { fixtures =>
       implicit val (context, typedStore, namespace) = fixtures
 
-      val (rootLocation, _) = createBag()
-      scrambleFile(rootLocation, "bag-info.txt")
+      val (bagRoot, _) = createBag()
+      scrambleFile(bagRoot, "bag-info.txt")
 
       withBagReader {
-        _.get(rootLocation).left.value.msg should startWith(
+        _.get(bagRoot.asPrefix).left.value.msg should startWith(
           "Error loading bag-info.txt"
         )
       }
@@ -99,11 +99,11 @@ trait BagReaderTestCases[Context, Namespace]
     withFixtures { fixtures =>
       implicit val (context, typedStore, namespace) = fixtures
 
-      val (rootLocation, _) = createBag()
-      deleteFile(rootLocation, "manifest-sha256.txt")
+      val (bagRoot, _) = createBag()
+      deleteFile(bagRoot, "manifest-sha256.txt")
 
       withBagReader {
-        _.get(rootLocation).left.value.msg should startWith(
+        _.get(bagRoot.asPrefix).left.value.msg should startWith(
           "Error loading manifest-sha256.txt"
         )
       }
@@ -114,11 +114,11 @@ trait BagReaderTestCases[Context, Namespace]
     withFixtures { fixtures =>
       implicit val (context, typedStore, namespace) = fixtures
 
-      val (rootLocation, _) = createBag()
-      scrambleFile(rootLocation, "manifest-sha256.txt")
+      val (bagRoot, _) = createBag()
+      scrambleFile(bagRoot, "manifest-sha256.txt")
 
       withBagReader {
-        _.get(rootLocation).left.value.msg should startWith(
+        _.get(bagRoot.asPrefix).left.value.msg should startWith(
           "Error loading manifest-sha256.txt"
         )
       }
@@ -129,11 +129,11 @@ trait BagReaderTestCases[Context, Namespace]
     withFixtures { fixtures =>
       implicit val (context, typedStore, namespace) = fixtures
 
-      val (rootLocation, _) = createBag()
-      deleteFile(rootLocation, "tagmanifest-sha256.txt")
+      val (bagRoot, _) = createBag()
+      deleteFile(bagRoot, "tagmanifest-sha256.txt")
 
       withBagReader {
-        _.get(rootLocation).left.value.msg should startWith(
+        _.get(bagRoot.asPrefix).left.value.msg should startWith(
           "Error loading tagmanifest-sha256.txt"
         )
       }
@@ -144,11 +144,11 @@ trait BagReaderTestCases[Context, Namespace]
     withFixtures { fixtures =>
       implicit val (context, typedStore, namespace) = fixtures
 
-      val (rootLocation, _) = createBag()
-      scrambleFile(rootLocation, "tagmanifest-sha256.txt")
+      val (bagRoot, _) = createBag()
+      scrambleFile(bagRoot, "tagmanifest-sha256.txt")
 
       withBagReader {
-        _.get(rootLocation).left.value.msg should startWith(
+        _.get(bagRoot.asPrefix).left.value.msg should startWith(
           "Error loading tagmanifest-sha256.txt"
         )
       }
@@ -159,11 +159,11 @@ trait BagReaderTestCases[Context, Namespace]
     withFixtures { fixtures =>
       implicit val (context, typedStore, namespace) = fixtures
 
-      val (rootLocation, _) = createBag()
-      deleteFile(rootLocation, "fetch.txt")
+      val (bagRoot, _) = createBag()
+      deleteFile(bagRoot, "fetch.txt")
 
       withBagReader {
-        _.get(rootLocation).right.value.fetch shouldBe None
+        _.get(bagRoot.asPrefix).right.value.fetch shouldBe None
       }
     }
   }
@@ -172,11 +172,11 @@ trait BagReaderTestCases[Context, Namespace]
     withFixtures { fixtures =>
       implicit val (context, typedStore, namespace) = fixtures
 
-      val (rootLocation, _) = createBag()
-      scrambleFile(rootLocation, "fetch.txt")
+      val (bagRoot, _) = createBag()
+      scrambleFile(bagRoot, "fetch.txt")
 
       withBagReader {
-        _.get(rootLocation).left.value.msg should startWith(
+        _.get(bagRoot.asPrefix).left.value.msg should startWith(
           "Error loading fetch.txt"
         )
       }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
@@ -457,7 +457,7 @@ class StorageManifestServiceTest
   describe("adds the size to the manifest files") {
     it("fails if it cannot get the size of a file") {
       val version = randomInt(1, 10)
-      val replicaRoot = createObjectLocation.join(s"/v$version")
+      val bagRoot = createObjectLocation.join(s"/v$version")
 
       val files = Seq("data/file1.txt", "data/file2.txt", "data/dir/file3.txt")
 
@@ -478,14 +478,14 @@ class StorageManifestServiceTest
 
       val result = service.createManifest(
         bag = bag,
-        replicaRoot = replicaRoot,
+        replicaRoot = bagRoot.asPrefix,
         space = createStorageSpace,
         version = BagVersion(version)
       )
 
       result.failed.get shouldBe a[StorageManifestException]
       result.failed.get.getMessage should startWith(
-        s"Error getting size of ${replicaRoot.join("data/file1.txt")}"
+        s"Error getting size of ${bagRoot.join("data/file1.txt")}"
       )
     }
 
@@ -566,7 +566,7 @@ class StorageManifestServiceTest
       val storageManifest = service
         .createManifest(
           bag = bag,
-          replicaRoot = replicaRoot,
+          replicaRoot = replicaRoot.asPrefix,
           space = createStorageSpace,
           version = BagVersion(version)
         )
@@ -606,7 +606,7 @@ class StorageManifestServiceTest
 
     val result = service.createManifest(
       bag = bag,
-      replicaRoot = replicaRoot,
+      replicaRoot = replicaRoot.asPrefix,
       space = space,
       version = BagVersion(version)
     )
@@ -631,7 +631,7 @@ class StorageManifestServiceTest
 
     val result = service.createManifest(
       bag = bag,
-      replicaRoot = replicaRoot,
+      replicaRoot = replicaRoot.asPrefix,
       space = createStorageSpace,
       version = BagVersion(version)
     )


### PR DESCRIPTION
Spun out of #322 as a small, manageable piece – just the BagReader class, plus some of the verifier and bag register. More bits will follow.