### PR TITLE
Change the StorageManifest model to support multiple locations

### DIFF
--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/models/ResponseDisplayBag.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/models/ResponseDisplayBag.scala
@@ -16,7 +16,8 @@ case class ResponseDisplayBag(
   info: ResponseDisplayBagInfo,
   manifest: DisplayFileManifest,
   tagManifest: DisplayFileManifest,
-  locations: Seq[DisplayLocation],
+  location: DisplayLocation,
+  replicaLocations: Seq[DisplayLocation],
   createdDate: String,
   version: String,
   @JsonKey("type") ontologyType: String = "Bag"
@@ -34,7 +35,8 @@ object ResponseDisplayBag {
       info = ResponseDisplayBagInfo(storageManifest.info),
       manifest = DisplayFileManifest(storageManifest.manifest),
       tagManifest = DisplayFileManifest(storageManifest.tagManifest),
-      locations = storageManifest.locations.map { DisplayLocation(_) },
+      location = DisplayLocation(storageManifest.location),
+      replicaLocations = storageManifest.replicaLocations.map { DisplayLocation(_) },
       createdDate = storageManifest.createdDate.toString,
       version = storageManifest.version.toString
     )

--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/models/ResponseDisplayBag.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/models/ResponseDisplayBag.scala
@@ -36,7 +36,9 @@ object ResponseDisplayBag {
       manifest = DisplayFileManifest(storageManifest.manifest),
       tagManifest = DisplayFileManifest(storageManifest.tagManifest),
       location = DisplayLocation(storageManifest.location),
-      replicaLocations = storageManifest.replicaLocations.map { DisplayLocation(_) },
+      replicaLocations = storageManifest.replicaLocations.map {
+        DisplayLocation(_)
+      },
       createdDate = storageManifest.createdDate.toString,
       version = storageManifest.version.toString
     )

--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
@@ -31,13 +31,7 @@ class BagsApiFeatureTest
 
   describe("GET /bags/:space/:id") {
     it("finds the latest version of a bag") {
-      val storageManifest = createStorageManifestWith(
-        locations = List(
-          createObjectLocation,
-          createObjectLocation,
-          createObjectLocation
-        )
-      )
+      val storageManifest = createStorageManifest
 
       withConfiguredApp(initialManifests = Seq(storageManifest)) {
         case (_, metrics, baseUrl) =>
@@ -293,13 +287,7 @@ class BagsApiFeatureTest
     }
 
     it("finds a single version of a storage manifest") {
-      val storageManifest = createStorageManifestWith(
-        locations = List(
-          createObjectLocation,
-          createObjectLocation,
-          createObjectLocation
-        )
-      )
+      val storageManifest = createStorageManifest
 
       withConfiguredApp(initialManifests = Seq(storageManifest)) {
         case (_, metrics, baseUrl) =>

--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
@@ -53,8 +53,9 @@ class BagsApiFeatureTest
               |  "info": ${bagInfo(storageManifest.info)},
               |  "manifest": ${manifest(storageManifest.manifest)},
               |  "tagManifest": ${manifest(storageManifest.tagManifest)},
-              |  "locations": [
-              |    ${asList(storageManifest.locations, location)}
+              |  "location": ${location(storageManifest.location)},
+              |  "replicaLocations": [
+              |    ${asList(storageManifest.replicaLocations, location)}
               |  ],
               |  "createdDate": "${DateTimeFormatter.ISO_INSTANT.format(
                  storageManifest.createdDate
@@ -111,8 +112,9 @@ class BagsApiFeatureTest
                 |  "info": ${bagInfo(storageManifest.info)},
                 |  "manifest": ${manifest(storageManifest.manifest)},
                 |  "tagManifest": ${manifest(storageManifest.tagManifest)},
-                |  "locations": [
-                |    ${asList(storageManifest.locations, location)}
+                |  "location": ${location(storageManifest.location)},
+                |  "replicaLocations": [
+                |    ${asList(storageManifest.replicaLocations, location)}
                 |  ],
                 |  "createdDate": "${DateTimeFormatter.ISO_INSTANT.format(
                    storageManifest.createdDate

--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
@@ -243,9 +243,9 @@ class IngestsApiFeatureTest
               val expectedIngest = Ingest(
                 id = IngestID(id),
                 ingestType = CreateIngestType,
-                sourceLocation = StorageLocation(
-                  StandardStorageProvider,
-                  ObjectLocation(bucketName, s3key)
+                sourceLocation = SourceLocation(
+                  provider = StandardStorageProvider,
+                  location = ObjectLocation(bucketName, s3key)
                 ),
                 space = StorageSpace(spaceName),
                 callback = Some(Callback(testCallbackUri, Callback.Pending)),

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
@@ -10,10 +10,7 @@ import uk.ac.wellcome.platform.archive.common.generators.{
   BagInfoGenerators,
   PayloadGenerators
 }
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  InfrequentAccessStorageProvider,
-  StorageLocation
-}
+import uk.ac.wellcome.platform.archive.common.ingests.models.InfrequentAccessStorageProvider
 import uk.ac.wellcome.platform.archive.common.storage.models.{
   IngestCompleted,
   PrimaryStorageLocation

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
@@ -14,7 +14,10 @@ import uk.ac.wellcome.platform.archive.common.ingests.models.{
   InfrequentAccessStorageProvider,
   StorageLocation
 }
-import uk.ac.wellcome.platform.archive.common.storage.models.IngestCompleted
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  IngestCompleted,
+  PrimaryStorageLocation
+}
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.store.memory.MemoryStreamStore
 
@@ -48,12 +51,12 @@ class BagRegisterWorkerTest
             dataFileCount = dataFileCount,
             version = version
           ) {
-            case (bagRootLocation, bagInfo) =>
+            case (bagRoot, bagInfo) =>
               val payload = createEnrichedBagInformationPayloadWith(
                 context = createPipelineContextWith(
                   storageSpace = space
                 ),
-                bagRootLocation = bagRootLocation,
+                bagRootLocation = bagRoot,
                 version = version
               )
 
@@ -73,14 +76,14 @@ class BagRegisterWorkerTest
               storageManifest.info shouldBe bagInfo
               storageManifest.manifest.files should have size dataFileCount
 
-              storageManifest.locations shouldBe List(
-                StorageLocation(
-                  provider = InfrequentAccessStorageProvider,
-                  location = bagRootLocation.copy(
-                    path = bagRootLocation.path.stripSuffix(s"/$version")
-                  )
+              storageManifest.location shouldBe PrimaryStorageLocation(
+                provider = InfrequentAccessStorageProvider,
+                location = bagRoot.copy(
+                  path = bagRoot.path.stripSuffix(s"/$version")
                 )
               )
+
+              storageManifest.replicaLocations shouldBe empty
 
               storageManifest.createdDate.isAfter(createdAfterDate) shouldBe true
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/Ingest.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/Ingest.scala
@@ -11,7 +11,7 @@ import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 case class Ingest(
   id: IngestID,
   ingestType: IngestType,
-  sourceLocation: StorageLocation,
+  sourceLocation: SourceLocation,
   space: StorageSpace,
   callback: Option[Callback],
   status: Ingest.Status,

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/SourceLocation.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/SourceLocation.scala
@@ -1,0 +1,5 @@
+package uk.ac.wellcome.platform.archive.common.ingests.models
+
+import uk.ac.wellcome.storage.ObjectLocation
+
+case class SourceLocation(provider: StorageProvider, location: ObjectLocation)

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/StorageProvider.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/ingests/models/StorageProvider.scala
@@ -1,9 +1,5 @@
 package uk.ac.wellcome.platform.archive.common.ingests.models
 
-import uk.ac.wellcome.storage.ObjectLocation
-
-case class StorageLocation(provider: StorageProvider, location: ObjectLocation)
-
 sealed trait StorageProvider { val id: String }
 
 case object StandardStorageProvider extends StorageProvider {

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/BetterStorageLocation.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/BetterStorageLocation.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.storage.replica_aggregator.models
+package uk.ac.wellcome.platform.archive.common.storage.models
 
 import uk.ac.wellcome.platform.archive.common.ingests.models.StorageProvider
 import uk.ac.wellcome.storage.ObjectLocation

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageLocation.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageLocation.scala
@@ -3,8 +3,7 @@ package uk.ac.wellcome.platform.archive.common.storage.models
 import uk.ac.wellcome.platform.archive.common.ingests.models.StorageProvider
 import uk.ac.wellcome.storage.ObjectLocation
 
-// replaces StorageLocation
-sealed trait BetterStorageLocation {
+sealed trait StorageLocation {
   val provider: StorageProvider
   val location: ObjectLocation
 }
@@ -12,9 +11,9 @@ sealed trait BetterStorageLocation {
 case class PrimaryStorageLocation(
   provider: StorageProvider,
   location: ObjectLocation
-) extends BetterStorageLocation
+) extends StorageLocation
 
 case class SecondaryStorageLocation(
   provider: StorageProvider,
   location: ObjectLocation
-) extends BetterStorageLocation
+) extends StorageLocation

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageManifest.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageManifest.scala
@@ -30,8 +30,8 @@ case class StorageManifest(
   version: BagVersion,
   manifest: FileManifest,
   tagManifest: FileManifest,
-  location: BetterStorageLocation,
-  replicaLocations: Seq[BetterStorageLocation],
+  location: StorageLocation,
+  replicaLocations: Seq[StorageLocation],
   createdDate: Instant
 ) {
   val id = BagId(space, info.externalIdentifier)

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageManifest.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageManifest.scala
@@ -31,8 +31,20 @@ case class StorageManifest(
   version: BagVersion,
   manifest: FileManifest,
   tagManifest: FileManifest,
-  locations: Seq[StorageLocation],
+  location: BetterStorageLocation,
+  replicaLocations: Seq[BetterStorageLocation],
   createdDate: Instant
 ) {
   val id = BagId(space, info.externalIdentifier)
+
+  // TODO: Remove this converter when we modify the bags API and notifier
+  // to send the correct format.
+  private def toOldLocation(location: BetterStorageLocation): StorageLocation =
+    StorageLocation(
+      provider = location.provider,
+      location = location.location
+    )
+
+  def locations: Seq[StorageLocation] =
+    (Seq(location) ++ replicaLocations).map { toOldLocation }
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageManifest.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageManifest.scala
@@ -7,7 +7,6 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.{
   BagInfo,
   BagVersion
 }
-import uk.ac.wellcome.platform.archive.common.ingests.models.StorageLocation
 import uk.ac.wellcome.platform.archive.common.verify.{
   ChecksumValue,
   HashingAlgorithm
@@ -36,15 +35,4 @@ case class StorageManifest(
   createdDate: Instant
 ) {
   val id = BagId(space, info.externalIdentifier)
-
-  // TODO: Remove this converter when we modify the bags API and notifier
-  // to send the correct format.
-  private def toOldLocation(location: BetterStorageLocation): StorageLocation =
-    StorageLocation(
-      provider = location.provider,
-      location = location.location
-    )
-
-  def locations: Seq[StorageLocation] =
-    (Seq(location) ++ replicaLocations).map { toOldLocation }
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
@@ -15,12 +15,7 @@ import uk.ac.wellcome.platform.archive.common.ingests.models.{
   InfrequentAccessStorageProvider,
   StorageLocation
 }
-import uk.ac.wellcome.platform.archive.common.storage.models.{
-  FileManifest,
-  StorageManifest,
-  StorageManifestFile,
-  StorageSpace
-}
+import uk.ac.wellcome.platform.archive.common.storage.models._
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 
 import scala.util.{Failure, Success, Try}
@@ -73,13 +68,11 @@ class StorageManifestService(sizeFinder: SizeFinder) extends Logging {
           checksumAlgorithm = bag.tagManifest.checksumAlgorithm,
           files = tagManifestFiles
         ),
-        locations = Seq(
-          // TODO: Support adding more locations!
-          StorageLocation(
-            provider = InfrequentAccessStorageProvider,
-            location = bagRoot.asLocation()
-          )
+        location = PrimaryStorageLocation(
+          provider = InfrequentAccessStorageProvider,
+          location = bagRoot.asLocation()
         ),
+        replicaLocations = Seq.empty,
         createdDate = Instant.now
       )
     } yield storageManifest

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
@@ -11,10 +11,7 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.{
   MatchedLocation
 }
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagMatcher
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  InfrequentAccessStorageProvider,
-  StorageLocation
-}
+import uk.ac.wellcome.platform.archive.common.ingests.models.InfrequentAccessStorageProvider
 import uk.ac.wellcome.platform.archive.common.storage.models._
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/SourceLocationPayloadTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/SourceLocationPayloadTest.scala
@@ -28,7 +28,7 @@ class SourceLocationPayloadTest
     val ingest = Ingest(
       id = ingestId,
       ingestType = ingestType,
-      sourceLocation = StorageLocation(
+      sourceLocation = SourceLocation(
         provider = StandardStorageProvider,
         location = sourceLocation
       ),

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
@@ -3,7 +3,10 @@ package uk.ac.wellcome.platform.archive.common.generators
 import java.net.URI
 import java.time.Instant
 
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagVersion,
+  ExternalIdentifier
+}
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest.Status
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/IngestGenerators.scala
@@ -3,26 +3,21 @@ package uk.ac.wellcome.platform.archive.common.generators
 import java.net.URI
 import java.time.Instant
 
-import uk.ac.wellcome.platform.archive.common.bagit.models.{
-  BagVersion,
-  ExternalIdentifier
-}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{BagVersion, ExternalIdentifier}
 import uk.ac.wellcome.platform.archive.common.ingests.models.Ingest.Status
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
 
 import scala.util.Random
 
-trait IngestGenerators extends BagIdGenerators {
+trait IngestGenerators extends BagIdGenerators with ObjectLocationGenerators {
 
-  val storageLocation = StorageLocation(
-    StandardStorageProvider,
-    ObjectLocation(
-      randomAlphanumericWithLength(),
-      randomAlphanumericWithLength()
+  def createSourceLocation: SourceLocation =
+    SourceLocation(
+      provider = StandardStorageProvider,
+      location = createObjectLocation
     )
-  )
 
   def createIngest: Ingest = createIngestWith()
 
@@ -39,7 +34,7 @@ trait IngestGenerators extends BagIdGenerators {
   def createIngestWith(
     id: IngestID = createIngestID,
     ingestType: IngestType = CreateIngestType,
-    sourceLocation: StorageLocation = storageLocation,
+    sourceLocation: SourceLocation = createSourceLocation,
     callback: Option[Callback] = Some(createCallback()),
     space: StorageSpace = createStorageSpace,
     status: Status = Ingest.Accepted,

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
@@ -6,7 +6,6 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.{BagInfo, BagVersion}
 import uk.ac.wellcome.platform.archive.common.ingests.models.StandardStorageProvider
 import uk.ac.wellcome.platform.archive.common.storage.models._
 import uk.ac.wellcome.platform.archive.common.verify.{HashingAlgorithm, SHA256}
-import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
 
 import scala.util.Random

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
@@ -58,15 +58,13 @@ trait StorageManifestGenerators
         provider = StandardStorageProvider,
         location = createObjectLocation
       ),
-      replicaLocations =
-        (1 to randomInt(0, 5))
-          .map { _ =>
-            SecondaryStorageLocation(
-              provider = StandardStorageProvider,
-              location = createObjectLocation
-            )
-          }
-      ,
+      replicaLocations = (1 to randomInt(0, 5))
+        .map { _ =>
+          SecondaryStorageLocation(
+            provider = StandardStorageProvider,
+            location = createObjectLocation
+          )
+        },
       createdDate = Instant.now
     )
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
@@ -3,12 +3,9 @@ package uk.ac.wellcome.platform.archive.common.generators
 import java.time.Instant
 
 import uk.ac.wellcome.platform.archive.common.bagit.models.{BagInfo, BagVersion}
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  StandardStorageProvider,
-  StorageLocation
-}
+import uk.ac.wellcome.platform.archive.common.ingests.models.StandardStorageProvider
 import uk.ac.wellcome.platform.archive.common.storage.models._
-import uk.ac.wellcome.platform.archive.common.verify.SHA256
+import uk.ac.wellcome.platform.archive.common.verify.{HashingAlgorithm, SHA256}
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
 
@@ -20,7 +17,7 @@ trait StorageManifestGenerators
     with StorageSpaceGenerators
     with ObjectLocationGenerators {
 
-  val checksumAlgorithm = SHA256
+  val checksumAlgorithm: HashingAlgorithm = SHA256
 
   private def createStorageManifestFile: StorageManifestFile = {
     val bagFile = createBagFile

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
@@ -29,12 +29,10 @@ trait StorageManifestGenerators
     )
   }
 
-  // TODO: Change the interface of this method.
   def createStorageManifestWith(
     space: StorageSpace = createStorageSpace,
     bagInfo: BagInfo = createBagInfo,
-    version: BagVersion = BagVersion(Random.nextInt),
-    locations: List[ObjectLocation] = List(createObjectLocation)
+    version: BagVersion = BagVersion(Random.nextInt)
   ): StorageManifest =
     StorageManifest(
       space = space,
@@ -58,11 +56,17 @@ trait StorageManifestGenerators
       ),
       location = PrimaryStorageLocation(
         provider = StandardStorageProvider,
-        location = locations.head
+        location = createObjectLocation
       ),
-      replicaLocations = locations.tail.map {
-        SecondaryStorageLocation(StandardStorageProvider, _)
-      },
+      replicaLocations =
+        (1 to randomInt(0, 5))
+          .map { _ =>
+            SecondaryStorageLocation(
+              provider = StandardStorageProvider,
+              location = createObjectLocation
+            )
+          }
+      ,
       createdDate = Instant.now
     )
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
@@ -7,12 +7,7 @@ import uk.ac.wellcome.platform.archive.common.ingests.models.{
   StandardStorageProvider,
   StorageLocation
 }
-import uk.ac.wellcome.platform.archive.common.storage.models.{
-  FileManifest,
-  StorageManifest,
-  StorageManifestFile,
-  StorageSpace
-}
+import uk.ac.wellcome.platform.archive.common.storage.models._
 import uk.ac.wellcome.platform.archive.common.verify.SHA256
 import uk.ac.wellcome.storage.ObjectLocation
 import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
@@ -37,6 +32,7 @@ trait StorageManifestGenerators
     )
   }
 
+  // TODO: Change the interface of this method.
   def createStorageManifestWith(
     space: StorageSpace = createStorageSpace,
     bagInfo: BagInfo = createBagInfo,
@@ -63,7 +59,13 @@ trait StorageManifestGenerators
           createStorageManifestFile
         )
       ),
-      locations = locations.map { StorageLocation(StandardStorageProvider, _) },
+      location = PrimaryStorageLocation(
+        provider = StandardStorageProvider,
+        location = locations.head
+      ),
+      replicaLocations = locations.tail.map {
+        SecondaryStorageLocation(StandardStorageProvider, _)
+      },
       createdDate = Instant.now
     )
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
@@ -15,11 +15,9 @@ import uk.ac.wellcome.platform.archive.common.generators.{
   StorageSpaceGenerators
 }
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.TimeTestFixture
-import uk.ac.wellcome.platform.archive.common.ingests.models.{
-  InfrequentAccessStorageProvider,
-  StorageLocation
-}
+import uk.ac.wellcome.platform.archive.common.ingests.models.InfrequentAccessStorageProvider
 import uk.ac.wellcome.platform.archive.common.storage.models.{
+  PrimaryStorageLocation,
   StorageManifest,
   StorageSpace
 }
@@ -69,12 +67,12 @@ class StorageManifestServiceTest
       version = version
     )
 
-    storageManifest.locations shouldBe Seq(
-      StorageLocation(
-        provider = InfrequentAccessStorageProvider,
-        location = bagRoot
-      )
+    storageManifest.location shouldBe PrimaryStorageLocation(
+      provider = InfrequentAccessStorageProvider,
+      location = bagRoot
     )
+
+    storageManifest.replicaLocations shouldBe empty
   }
 
   describe("constructs the paths correctly") {

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayIngest.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayIngest.scala
@@ -22,7 +22,7 @@ case class RequestDisplayIngest(
     Ingest(
       id = IngestID.random,
       ingestType = IngestType.create(ingestType.id),
-      sourceLocation = sourceLocation.toStorageLocation,
+      sourceLocation = sourceLocation.toSourceLocation,
       callback = Callback(
         callback.map(displayCallback => URI.create(displayCallback.url))
       ),

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayLocation.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayLocation.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.archive.display
 
 import io.circe.generic.extras.JsonKey
 import uk.ac.wellcome.platform.archive.common.ingests.models.SourceLocation
-import uk.ac.wellcome.platform.archive.common.storage.models.BetterStorageLocation
+import uk.ac.wellcome.platform.archive.common.storage.models.StorageLocation
 import uk.ac.wellcome.storage.ObjectLocation
 
 case class DisplayLocation(
@@ -26,7 +26,7 @@ object DisplayLocation {
       path = location.location.path
     )
 
-  def apply(location: BetterStorageLocation): DisplayLocation =
+  def apply(location: StorageLocation): DisplayLocation =
     DisplayLocation(
       provider = DisplayProvider(location.provider),
       bucket = location.location.namespace,

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayLocation.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayLocation.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.platform.archive.display
 import io.circe.generic.extras.JsonKey
 import uk.ac.wellcome.platform.archive.common.ingests.models
 import uk.ac.wellcome.platform.archive.common.ingests.models.StorageLocation
+import uk.ac.wellcome.platform.archive.common.storage.models.BetterStorageLocation
 import uk.ac.wellcome.storage.ObjectLocation
 
 case class DisplayLocation(
@@ -17,8 +18,16 @@ case class DisplayLocation(
       ObjectLocation(bucket, path)
     )
 }
+
 object DisplayLocation {
   def apply(location: StorageLocation): DisplayLocation =
+    DisplayLocation(
+      provider = DisplayProvider(location.provider),
+      bucket = location.location.namespace,
+      path = location.location.path
+    )
+
+  def apply(location: BetterStorageLocation): DisplayLocation =
     DisplayLocation(
       provider = DisplayProvider(location.provider),
       bucket = location.location.namespace,

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayLocation.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayLocation.scala
@@ -1,8 +1,7 @@
 package uk.ac.wellcome.platform.archive.display
 
 import io.circe.generic.extras.JsonKey
-import uk.ac.wellcome.platform.archive.common.ingests.models
-import uk.ac.wellcome.platform.archive.common.ingests.models.StorageLocation
+import uk.ac.wellcome.platform.archive.common.ingests.models.SourceLocation
 import uk.ac.wellcome.platform.archive.common.storage.models.BetterStorageLocation
 import uk.ac.wellcome.storage.ObjectLocation
 
@@ -12,15 +11,15 @@ case class DisplayLocation(
   path: String,
   @JsonKey("type") ontologyType: String = "Location"
 ) {
-  def toStorageLocation: StorageLocation =
-    models.StorageLocation(
-      provider.toStorageProvider,
-      ObjectLocation(bucket, path)
+  def toSourceLocation: SourceLocation =
+    SourceLocation(
+      provider = provider.toStorageProvider,
+      location = ObjectLocation(bucket, path)
     )
 }
 
 object DisplayLocation {
-  def apply(location: StorageLocation): DisplayLocation =
+  def apply(location: SourceLocation): DisplayLocation =
     DisplayLocation(
       provider = DisplayProvider(location.provider),
       bucket = location.location.namespace,

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayIngestTest.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayIngestTest.scala
@@ -38,7 +38,7 @@ class DisplayIngestTest
       val ingest: Ingest = Ingest(
         id = id,
         ingestType = CreateIngestType,
-        sourceLocation = StorageLocation(
+        sourceLocation = SourceLocation(
           provider = StandardStorageProvider,
           location = ObjectLocation("bukkit", "key.txt")
         ),
@@ -140,9 +140,9 @@ class DisplayIngestTest
       val ingest = ingestCreateRequest.toIngest
 
       ingest.id shouldBe a[IngestID]
-      ingest.sourceLocation shouldBe StorageLocation(
-        InfrequentAccessStorageProvider,
-        ObjectLocation(bucket, path)
+      ingest.sourceLocation shouldBe SourceLocation(
+        provider = InfrequentAccessStorageProvider,
+        location = ObjectLocation(bucket, path)
       )
       ingest.callback shouldBe Some(
         Callback(URI.create(ingestCreateRequest.callback.get.url))

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/fixtures/DisplayJsonHelpers.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/fixtures/DisplayJsonHelpers.scala
@@ -4,7 +4,7 @@ import java.time.format.DateTimeFormatter
 
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagInfo
 import uk.ac.wellcome.platform.archive.common.storage.models.{
-  BetterStorageLocation,
+  StorageLocation,
   FileManifest,
   StorageManifestFile
 }
@@ -47,7 +47,7 @@ trait DisplayJsonHelpers {
        |}
      """.stripMargin
 
-  def location(loc: BetterStorageLocation): String =
+  def location(loc: StorageLocation): String =
     s"""
        |{
        |  "provider": {

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/fixtures/DisplayJsonHelpers.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/fixtures/DisplayJsonHelpers.scala
@@ -3,8 +3,8 @@ package uk.ac.wellcome.platform.archive.display.fixtures
 import java.time.format.DateTimeFormatter
 
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagInfo
-import uk.ac.wellcome.platform.archive.common.ingests.models.StorageLocation
 import uk.ac.wellcome.platform.archive.common.storage.models.{
+  BetterStorageLocation,
   FileManifest,
   StorageManifestFile
 }
@@ -47,7 +47,7 @@ trait DisplayJsonHelpers {
        |}
      """.stripMargin
 
-  def location(loc: StorageLocation): String =
+  def location(loc: BetterStorageLocation): String =
     s"""
        |{
        |  "provider": {

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/fixtures/DisplayJsonHelpers.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/fixtures/DisplayJsonHelpers.scala
@@ -4,8 +4,8 @@ import java.time.format.DateTimeFormatter
 
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagInfo
 import uk.ac.wellcome.platform.archive.common.storage.models.{
-  StorageLocation,
   FileManifest,
+  StorageLocation,
   StorageManifestFile
 }
 

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/ReplicaResult.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/ReplicaResult.scala
@@ -7,6 +7,10 @@ import uk.ac.wellcome.platform.archive.common.ingests.models.{
   InfrequentAccessStorageProvider,
   IngestID
 }
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  BetterStorageLocation,
+  PrimaryStorageLocation
+}
 
 case class ReplicaResult(
   ingestId: IngestID,

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/ReplicaResult.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/ReplicaResult.scala
@@ -8,13 +8,13 @@ import uk.ac.wellcome.platform.archive.common.ingests.models.{
   IngestID
 }
 import uk.ac.wellcome.platform.archive.common.storage.models.{
-  BetterStorageLocation,
+  StorageLocation,
   PrimaryStorageLocation
 }
 
 case class ReplicaResult(
   ingestId: IngestID,
-  storageLocation: BetterStorageLocation,
+  storageLocation: StorageLocation,
   timestamp: Instant
 )
 

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/ReplicaResult.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/ReplicaResult.scala
@@ -8,8 +8,8 @@ import uk.ac.wellcome.platform.archive.common.ingests.models.{
   IngestID
 }
 import uk.ac.wellcome.platform.archive.common.storage.models.{
-  StorageLocation,
-  PrimaryStorageLocation
+  PrimaryStorageLocation,
+  StorageLocation
 }
 
 case class ReplicaResult(

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregator.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregator.scala
@@ -2,6 +2,7 @@ package uk.ac.wellcome.platform.storage.replica_aggregator.services
 
 import java.time.Instant
 
+import uk.ac.wellcome.platform.archive.common.storage.models.SecondaryStorageLocation
 import uk.ac.wellcome.platform.storage.replica_aggregator.models._
 import uk.ac.wellcome.storage.store.VersionedStore
 import uk.ac.wellcome.storage.{Identified, Version}

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/ReplicaAggregatorFeatureTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/ReplicaAggregatorFeatureTest.scala
@@ -10,6 +10,7 @@ import uk.ac.wellcome.platform.archive.common.EnrichedBagInformationPayload
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
 import uk.ac.wellcome.platform.archive.common.ingests.models.InfrequentAccessStorageProvider
+import uk.ac.wellcome.platform.archive.common.storage.models.PrimaryStorageLocation
 import uk.ac.wellcome.platform.storage.replica_aggregator.fixtures.ReplicaAggregatorFixtures
 import uk.ac.wellcome.platform.storage.replica_aggregator.models.{
   ReplicaPath,

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/ReplicaAggregatorFeatureTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/ReplicaAggregatorFeatureTest.scala
@@ -12,7 +12,6 @@ import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAsser
 import uk.ac.wellcome.platform.archive.common.ingests.models.InfrequentAccessStorageProvider
 import uk.ac.wellcome.platform.storage.replica_aggregator.fixtures.ReplicaAggregatorFixtures
 import uk.ac.wellcome.platform.storage.replica_aggregator.models.{
-  PrimaryStorageLocation,
   ReplicaPath,
   ReplicaResult
 }

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorTest.scala
@@ -7,9 +7,9 @@ import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
 import uk.ac.wellcome.platform.archive.common.ingests.models.InfrequentAccessStorageProvider
 import uk.ac.wellcome.platform.archive.common.storage.models.{
-  StorageLocation,
   PrimaryStorageLocation,
-  SecondaryStorageLocation
+  SecondaryStorageLocation,
+  StorageLocation
 }
 import uk.ac.wellcome.platform.storage.replica_aggregator.models._
 import uk.ac.wellcome.storage.{UpdateWriteError, Version}

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorTest.scala
@@ -7,7 +7,7 @@ import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
 import uk.ac.wellcome.platform.archive.common.ingests.models.InfrequentAccessStorageProvider
 import uk.ac.wellcome.platform.archive.common.storage.models.{
-  BetterStorageLocation,
+  StorageLocation,
   PrimaryStorageLocation,
   SecondaryStorageLocation
 }
@@ -29,7 +29,7 @@ class ReplicaAggregatorTest
     with StorageRandomThings {
 
   def createReplicaResultWith(
-    storageLocation: BetterStorageLocation = PrimaryStorageLocation(
+    storageLocation: StorageLocation = PrimaryStorageLocation(
       provider = InfrequentAccessStorageProvider,
       location = createObjectLocation
     )

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorTest.scala
@@ -6,6 +6,11 @@ import org.scalatest.{EitherValues, FunSpec, Matchers, TryValues}
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
 import uk.ac.wellcome.platform.archive.common.ingests.models.InfrequentAccessStorageProvider
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  BetterStorageLocation,
+  PrimaryStorageLocation,
+  SecondaryStorageLocation
+}
 import uk.ac.wellcome.platform.storage.replica_aggregator.models._
 import uk.ac.wellcome.storage.{UpdateWriteError, Version}
 import uk.ac.wellcome.storage.generators.ObjectLocationGenerators


### PR DESCRIPTION
Closes https://github.com/wellcometrust/platform/issues/3833 by changing the API output to the new format.

Additionally:

* Some refactoring so that StorageManifest supports multiple locations (this will break all the existing manifests)
* Create a new type `SourceLocation` which replaces the old `StorageLocation`, and rename `BetterStorageLocation` to plain `StorageLocation`