### PR TITLE
Split rejection/exception handlers, clarify http app flow

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/http/WellcomeExceptionHandler.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/http/WellcomeExceptionHandler.scala
@@ -1,0 +1,31 @@
+package uk.ac.wellcome.platform.archive.common.http
+
+import java.net.URL
+
+import akka.http.scaladsl.model.StatusCodes.InternalServerError
+import akka.http.scaladsl.server.ExceptionHandler
+import grizzled.slf4j.Logging
+import uk.ac.wellcome.platform.archive.common.http.models.InternalServerErrorResponse
+
+trait WellcomeExceptionHandler extends Logging {
+  import akka.http.scaladsl.server.Directives._
+  import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
+  import uk.ac.wellcome.json.JsonUtil._
+
+  val httpMetrics: HttpMetrics
+  val contextURL: URL
+
+  implicit val exceptionHandler: ExceptionHandler = buildExceptionHandler()
+
+  private def buildExceptionHandler(): ExceptionHandler =
+    ExceptionHandler {
+      case err: Exception =>
+        logger.error(s"Unexpected exception $err")
+        val error = InternalServerErrorResponse(
+          context = contextURL,
+          statusCode = InternalServerError
+        )
+        httpMetrics.sendMetricForStatus(InternalServerError)
+        complete(InternalServerError -> error)
+    }
+}

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/http/WellcomeHttpApp.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/http/WellcomeHttpApp.scala
@@ -19,9 +19,9 @@ class WellcomeHttpApp(
   val contextURL: URL
 )(
   implicit
-    val as: ActorSystem,
-    val ec: ExecutionContext,
-    mt: ActorMaterializer
+  val as: ActorSystem,
+  val ec: ExecutionContext,
+  mt: ActorMaterializer
 ) extends Runnable
     with WellcomeExceptionHandler
     with WellcomeRejectionHandler
@@ -49,7 +49,9 @@ class WellcomeHttpApp(
       server <- binding
       _ = info(s"Listening: ${httpServerConfig.host}:${httpServerConfig.port}")
       _ <- server.whenTerminated
-      _ = info(s"Terminating: ${httpServerConfig.host}:${httpServerConfig.port}")
+      _ = info(
+        s"Terminating: ${httpServerConfig.host}:${httpServerConfig.port}"
+      )
     } yield server
   }
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/http/WellcomeHttpApp.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/http/WellcomeHttpApp.scala
@@ -4,164 +4,52 @@ import java.net.URL
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.marshalling.Marshal
-import akka.http.scaladsl.model.StatusCodes.{BadRequest, InternalServerError}
-import akka.http.scaladsl.model._
 import akka.http.scaladsl.server._
 import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.Flow
-import akka.util.ByteString
 import grizzled.slf4j.Logging
-import io.circe.CursorOp
 import uk.ac.wellcome.platform.archive.common.config.models.HTTPServerConfig
-import uk.ac.wellcome.platform.archive.common.http.models.{
-  InternalServerErrorResponse,
-  UserErrorResponse
-}
 import uk.ac.wellcome.typesafe.Runnable
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class WellcomeHttpApp(
   routes: Route,
-  httpMetrics: HttpMetrics,
   httpServerConfig: HTTPServerConfig,
-  contextURL: URL
+  val httpMetrics: HttpMetrics,
+  val contextURL: URL
 )(
-  implicit val
-  as: ActorSystem,
-  mt: ActorMaterializer,
-  ec: ExecutionContext
+  implicit
+    val as: ActorSystem,
+    val ec: ExecutionContext,
+    mt: ActorMaterializer
 ) extends Runnable
+    with WellcomeExceptionHandler
+    with WellcomeRejectionHandler
     with Logging {
 
   import akka.http.scaladsl.server.Directives._
-  import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
-  import uk.ac.wellcome.json.JsonUtil._
 
-  def run(): Future[Http.HttpTerminated] = {
-    implicit val rejectionHandler: RejectionHandler = buildRejectionHandler()
-    implicit val exceptionHandler: ExceptionHandler = buildExceptionHandler()
+  def run(): Future[_] = {
+    val handler = mapResponse { response =>
+      httpMetrics.sendMetric(response)
 
-    val bindingFuture: Future[Http.ServerBinding] = Http()
+      response
+    }(routes)
+
+    val binding = Http()
       .bindAndHandle(
-        handler = sendCloudWatchMetrics { routes },
+        handler = handler,
         interface = httpServerConfig.host,
         port = httpServerConfig.port
       )
 
-    bindingFuture
-      .map(b => {
-        info(s"Listening on ${httpServerConfig.host}:${httpServerConfig.port}")
-        b
-      })
-      .flatMap { _.whenTerminated }
-  }
+    info(s"Starting: ${httpServerConfig.host}:${httpServerConfig.port}")
 
-  val sendCloudWatchMetrics: Directive0 = mapResponse { resp: HttpResponse =>
-    httpMetrics.sendMetric(resp)
-    resp
-  }
-
-  private def handleDecodingFailures(
-    causes: DecodingFailures
-  ): StandardRoute = {
-    val message = causes.failures.map { cause =>
-      val path = CursorOp.opsToPath(cause.history)
-
-      // Error messages returned by Circe are somewhat inconsistent and we also return our
-      // own error messages when decoding enums (DisplayIngestType and DisplayStorageProvider).
-      val reason = cause.message match {
-        // "Attempt to decode value on failed cursor" seems to mean in circeworld
-        // that a required field was not present.
-        case s if s.contains("Attempt to decode value on failed cursor") =>
-          "required property not supplied."
-        // These are errors returned by our custom decoders for enum.
-        case s if s.contains("valid values") => s
-        // If a field exists in the JSON but it's of the wrong format
-        // (for example the schema says it should be a String but an object has
-        // been supplied instead), the error message returned by Circe only
-        // contains the expected type.
-        case s => s"should be a $s."
-      }
-
-      s"Invalid value at $path: $reason"
-    }
-
-    complete(
-      BadRequest -> UserErrorResponse(
-        context = contextURL,
-        statusCode = BadRequest,
-        description = message.toList.mkString("\n")
-      )
-    )
-  }
-
-  private def buildRejectionHandler(): RejectionHandler =
-    RejectionHandler
-      .newBuilder()
-      .handle {
-        case MalformedRequestContentRejection(_, causes: DecodingFailures) =>
-          handleDecodingFailures(causes)
-      }
-      .result()
-      .seal
-      .mapRejectionResponse {
-        case res @ HttpResponse(
-              statusCode,
-              _,
-              HttpEntity.Strict(contentType, _),
-              _
-            ) if contentType != ContentTypes.`application/json` =>
-          transformToJsonErrorResponse(statusCode, res)
-        case x => x
-      }
-      .mapRejectionResponse { resp: HttpResponse =>
-        httpMetrics.sendMetric(resp)
-        resp
-      }
-
-  private def buildExceptionHandler(): ExceptionHandler =
-    ExceptionHandler {
-      case err: Exception =>
-        logger.error(s"Unexpected exception $err")
-        val error = InternalServerErrorResponse(
-          context = contextURL,
-          statusCode = InternalServerError
-        )
-        httpMetrics.sendMetricForStatus(InternalServerError)
-        complete(InternalServerError -> error)
-    }
-
-  private def transformToJsonErrorResponse(
-    statusCode: StatusCode,
-    response: HttpResponse
-  ): HttpResponse = {
-
-    val errorResponseMarshallingFlow = Flow[ByteString]
-      .mapAsync(parallelism = 1)(data => {
-        val description = data.utf8String
-        if (statusCode.intValue() >= 500) {
-          val response = InternalServerErrorResponse(
-            context = contextURL,
-            statusCode = statusCode
-          )
-          Marshal(response).to[MessageEntity]
-        } else {
-          val response = UserErrorResponse(
-            context = contextURL,
-            statusCode = statusCode,
-            description = description
-          )
-          Marshal(response).to[MessageEntity]
-        }
-      })
-      .flatMapConcat(_.dataBytes)
-
-    response
-      .transformEntityDataBytes(errorResponseMarshallingFlow)
-      .mapEntity(
-        entity => entity.withContentType(ContentTypes.`application/json`)
-      )
+    for {
+      server <- binding
+      _ = info(s"Listening: ${httpServerConfig.host}:${httpServerConfig.port}")
+      _ <- server.whenTerminated
+      _ = info(s"Terminating: ${httpServerConfig.host}:${httpServerConfig.port}")
+    } yield server
   }
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/http/WellcomeRejectionHandler.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/http/WellcomeRejectionHandler.scala
@@ -1,0 +1,117 @@
+package uk.ac.wellcome.platform.archive.common.http
+
+import java.net.URL
+
+import akka.http.scaladsl.marshalling.Marshal
+import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse, MessageEntity, StatusCode}
+import akka.http.scaladsl.model.StatusCodes.BadRequest
+import akka.http.scaladsl.server.{MalformedRequestContentRejection, RejectionHandler, StandardRoute}
+import akka.stream.scaladsl.Flow
+import akka.util.ByteString
+import io.circe.CursorOp
+import uk.ac.wellcome.platform.archive.common.http.models.{InternalServerErrorResponse, UserErrorResponse}
+
+import scala.concurrent.ExecutionContext
+
+trait WellcomeRejectionHandler {
+  import akka.http.scaladsl.server.Directives._
+  import de.heikoseeberger.akkahttpcirce.ErrorAccumulatingCirceSupport._
+  import uk.ac.wellcome.json.JsonUtil._
+
+  val httpMetrics: HttpMetrics
+  val contextURL: URL
+
+  implicit val ec: ExecutionContext
+
+  implicit val rejectionHandler: RejectionHandler = buildRejectionHandler()
+
+  private def buildRejectionHandler(): RejectionHandler =
+    RejectionHandler
+      .newBuilder()
+      .handle {
+        case MalformedRequestContentRejection(_, causes: DecodingFailures) =>
+          handleDecodingFailures(causes)
+      }
+      .result()
+      .seal
+      .mapRejectionResponse {
+        case res @ HttpResponse(
+        statusCode,
+        _,
+        HttpEntity.Strict(contentType, _),
+        _
+        ) if contentType != ContentTypes.`application/json` =>
+          transformToJsonErrorResponse(statusCode, res)
+        case x => x
+      }
+      .mapRejectionResponse { resp: HttpResponse =>
+        httpMetrics.sendMetric(resp)
+        resp
+      }
+
+  private def handleDecodingFailures(
+                                      causes: DecodingFailures
+                                    ): StandardRoute = {
+    val message = causes.failures.map { cause =>
+      val path = CursorOp.opsToPath(cause.history)
+
+      // Error messages returned by Circe are somewhat inconsistent and we also return our
+      // own error messages when decoding enums (DisplayIngestType and DisplayStorageProvider).
+      val reason = cause.message match {
+        // "Attempt to decode value on failed cursor" seems to mean in circeworld
+        // that a required field was not present.
+        case s if s.contains("Attempt to decode value on failed cursor") =>
+          "required property not supplied."
+        // These are errors returned by our custom decoders for enum.
+        case s if s.contains("valid values") => s
+        // If a field exists in the JSON but it's of the wrong format
+        // (for example the schema says it should be a String but an object has
+        // been supplied instead), the error message returned by Circe only
+        // contains the expected type.
+        case s => s"should be a $s."
+      }
+
+      s"Invalid value at $path: $reason"
+    }
+
+    complete(
+      BadRequest -> UserErrorResponse(
+        context = contextURL,
+        statusCode = BadRequest,
+        description = message.toList.mkString("\n")
+      )
+    )
+  }
+
+  private def transformToJsonErrorResponse(
+                                            statusCode: StatusCode,
+                                            response: HttpResponse
+                                          ): HttpResponse = {
+
+    val errorResponseMarshallingFlow = Flow[ByteString]
+      .mapAsync(parallelism = 1)(data => {
+        val description = data.utf8String
+        if (statusCode.intValue() >= 500) {
+          val response = InternalServerErrorResponse(
+            context = contextURL,
+            statusCode = statusCode
+          )
+          Marshal(response).to[MessageEntity]
+        } else {
+          val response = UserErrorResponse(
+            context = contextURL,
+            statusCode = statusCode,
+            description = description
+          )
+          Marshal(response).to[MessageEntity]
+        }
+      })
+      .flatMapConcat(_.dataBytes)
+
+    response
+      .transformEntityDataBytes(errorResponseMarshallingFlow)
+      .mapEntity(
+        entity => entity.withContentType(ContentTypes.`application/json`)
+      )
+  }
+}

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/http/WellcomeRejectionHandler.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/http/WellcomeRejectionHandler.scala
@@ -3,13 +3,26 @@ package uk.ac.wellcome.platform.archive.common.http
 import java.net.URL
 
 import akka.http.scaladsl.marshalling.Marshal
-import akka.http.scaladsl.model.{ContentTypes, HttpEntity, HttpResponse, MessageEntity, StatusCode}
+import akka.http.scaladsl.model.{
+  ContentTypes,
+  HttpEntity,
+  HttpResponse,
+  MessageEntity,
+  StatusCode
+}
 import akka.http.scaladsl.model.StatusCodes.BadRequest
-import akka.http.scaladsl.server.{MalformedRequestContentRejection, RejectionHandler, StandardRoute}
+import akka.http.scaladsl.server.{
+  MalformedRequestContentRejection,
+  RejectionHandler,
+  StandardRoute
+}
 import akka.stream.scaladsl.Flow
 import akka.util.ByteString
 import io.circe.CursorOp
-import uk.ac.wellcome.platform.archive.common.http.models.{InternalServerErrorResponse, UserErrorResponse}
+import uk.ac.wellcome.platform.archive.common.http.models.{
+  InternalServerErrorResponse,
+  UserErrorResponse
+}
 
 import scala.concurrent.ExecutionContext
 
@@ -36,11 +49,11 @@ trait WellcomeRejectionHandler {
       .seal
       .mapRejectionResponse {
         case res @ HttpResponse(
-        statusCode,
-        _,
-        HttpEntity.Strict(contentType, _),
-        _
-        ) if contentType != ContentTypes.`application/json` =>
+              statusCode,
+              _,
+              HttpEntity.Strict(contentType, _),
+              _
+            ) if contentType != ContentTypes.`application/json` =>
           transformToJsonErrorResponse(statusCode, res)
         case x => x
       }
@@ -50,8 +63,8 @@ trait WellcomeRejectionHandler {
       }
 
   private def handleDecodingFailures(
-                                      causes: DecodingFailures
-                                    ): StandardRoute = {
+    causes: DecodingFailures
+  ): StandardRoute = {
     val message = causes.failures.map { cause =>
       val path = CursorOp.opsToPath(cause.history)
 
@@ -84,9 +97,9 @@ trait WellcomeRejectionHandler {
   }
 
   private def transformToJsonErrorResponse(
-                                            statusCode: StatusCode,
-                                            response: HttpResponse
-                                          ): HttpResponse = {
+    statusCode: StatusCode,
+    response: HttpResponse
+  ): HttpResponse = {
 
     val errorResponseMarshallingFlow = Flow[ByteString]
       .mapAsync(parallelism = 1)(data => {


### PR DESCRIPTION
Make the `WellcomeHttpApp` code a bit clearer, by some simple refactoring and extraction of exception/rejection handling.