### PR TITLE
Aggregator: are these enough replicas?

### DIFF
--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/Main.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/Main.scala
@@ -7,11 +7,26 @@ import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.typesafe.config.Config
 import org.scanamo.auto._
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.typesafe.{AlpakkaSqsWorkerConfigBuilder, CloudwatchMonitoringClientBuilder, SQSBuilder}
+import uk.ac.wellcome.messaging.typesafe.{
+  AlpakkaSqsWorkerConfigBuilder,
+  CloudwatchMonitoringClientBuilder,
+  SQSBuilder
+}
 import uk.ac.wellcome.messaging.worker.monitoring.CloudwatchMonitoringClient
-import uk.ac.wellcome.platform.archive.common.config.builders.{IngestUpdaterBuilder, OperationNameBuilder, OutgoingPublisherBuilder}
-import uk.ac.wellcome.platform.storage.replica_aggregator.models.{AggregatorInternalRecord, ReplicaPath}
-import uk.ac.wellcome.platform.storage.replica_aggregator.services.{ReplicaAggregator, ReplicaAggregatorWorker, ReplicaCounter}
+import uk.ac.wellcome.platform.archive.common.config.builders.{
+  IngestUpdaterBuilder,
+  OperationNameBuilder,
+  OutgoingPublisherBuilder
+}
+import uk.ac.wellcome.platform.storage.replica_aggregator.models.{
+  AggregatorInternalRecord,
+  ReplicaPath
+}
+import uk.ac.wellcome.platform.storage.replica_aggregator.services.{
+  ReplicaAggregator,
+  ReplicaAggregatorWorker,
+  ReplicaCounter
+}
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 import uk.ac.wellcome.storage.typesafe.DynamoBuilder
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
@@ -53,10 +68,8 @@ object Main extends WellcomeTypesafeApp {
     new ReplicaAggregatorWorker(
       config = AlpakkaSqsWorkerConfigBuilder.build(config),
       replicaAggregator = new ReplicaAggregator(dynamoVersionedStore),
-
       // TODO: Make this configurable
       replicaCounter = new ReplicaCounter(expectedReplicaCount = 1),
-
       ingestUpdater = IngestUpdaterBuilder.build(config, operationName),
       outgoingPublisher = OutgoingPublisherBuilder.build(config, operationName)
     )

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/Main.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/Main.scala
@@ -7,25 +7,11 @@ import com.amazonaws.services.sqs.AmazonSQSAsync
 import com.typesafe.config.Config
 import org.scanamo.auto._
 import uk.ac.wellcome.json.JsonUtil._
-import uk.ac.wellcome.messaging.typesafe.{
-  AlpakkaSqsWorkerConfigBuilder,
-  CloudwatchMonitoringClientBuilder,
-  SQSBuilder
-}
+import uk.ac.wellcome.messaging.typesafe.{AlpakkaSqsWorkerConfigBuilder, CloudwatchMonitoringClientBuilder, SQSBuilder}
 import uk.ac.wellcome.messaging.worker.monitoring.CloudwatchMonitoringClient
-import uk.ac.wellcome.platform.archive.common.config.builders.{
-  IngestUpdaterBuilder,
-  OperationNameBuilder,
-  OutgoingPublisherBuilder
-}
-import uk.ac.wellcome.platform.storage.replica_aggregator.models.{
-  AggregatorInternalRecord,
-  ReplicaPath
-}
-import uk.ac.wellcome.platform.storage.replica_aggregator.services.{
-  ReplicaAggregator,
-  ReplicaAggregatorWorker
-}
+import uk.ac.wellcome.platform.archive.common.config.builders.{IngestUpdaterBuilder, OperationNameBuilder, OutgoingPublisherBuilder}
+import uk.ac.wellcome.platform.storage.replica_aggregator.models.{AggregatorInternalRecord, ReplicaPath}
+import uk.ac.wellcome.platform.storage.replica_aggregator.services.{ReplicaAggregator, ReplicaAggregatorWorker, ReplicaCounter}
 import uk.ac.wellcome.storage.dynamo.DynamoConfig
 import uk.ac.wellcome.storage.typesafe.DynamoBuilder
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
@@ -67,6 +53,10 @@ object Main extends WellcomeTypesafeApp {
     new ReplicaAggregatorWorker(
       config = AlpakkaSqsWorkerConfigBuilder.build(config),
       replicaAggregator = new ReplicaAggregator(dynamoVersionedStore),
+
+      // TODO: Make this configurable
+      replicaCounter = new ReplicaCounter(expectedReplicaCount = 1),
+
       ingestUpdater = IngestUpdaterBuilder.build(config, operationName),
       outgoingPublisher = OutgoingPublisherBuilder.build(config, operationName)
     )

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/AggregatorInternalRecord.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/AggregatorInternalRecord.scala
@@ -78,7 +78,7 @@ object AggregatorInternalRecord {
       case Some(location) if location == primaryLocation => record
       case Some(location) =>
         throw new Exception(
-          s"Record already has a different PrimaryStorageLocation: ${location} (existing) != ${primaryLocation}"
+          s"Record already has a different PrimaryStorageLocation: $location (existing) != $primaryLocation"
         )
     }
   }

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/KnownReplicas.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/KnownReplicas.scala
@@ -1,0 +1,15 @@
+package uk.ac.wellcome.platform.storage.replica_aggregator.models
+
+import uk.ac.wellcome.platform.archive.common.storage.models.{PrimaryStorageLocation, SecondaryStorageLocation}
+
+/** This records a complete set of replicas which can be passed around
+  * between services.
+  *
+  * This is very similar to AggregatorInternalRecord, but it ensures that
+  * we do have a primary replica.
+  *
+  */
+case class KnownReplicas(
+  location: PrimaryStorageLocation,
+  replicas: List[SecondaryStorageLocation]
+)

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/KnownReplicas.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/KnownReplicas.scala
@@ -1,6 +1,9 @@
 package uk.ac.wellcome.platform.storage.replica_aggregator.models
 
-import uk.ac.wellcome.platform.archive.common.storage.models.{PrimaryStorageLocation, SecondaryStorageLocation}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  PrimaryStorageLocation,
+  SecondaryStorageLocation
+}
 
 /** This records a complete set of replicas which can be passed around
   * between services.

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/ReplicaResult.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/ReplicaResult.scala
@@ -24,5 +24,3 @@ case object ReplicaResult {
       timestamp = Instant.now()
     )
 }
-
-

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/ReplicaResult.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/ReplicaResult.scala
@@ -6,7 +6,6 @@ import uk.ac.wellcome.platform.archive.common.EnrichedBagInformationPayload
 import uk.ac.wellcome.platform.archive.common.ingests.models.InfrequentAccessStorageProvider
 import uk.ac.wellcome.platform.archive.common.storage.models.{
   PrimaryStorageLocation,
-  SecondaryStorageLocation,
   StorageLocation
 }
 
@@ -26,8 +25,4 @@ case object ReplicaResult {
     )
 }
 
-// TODO: This needs moving somewhere!
-case class KnownReplicas(
-  location: PrimaryStorageLocation,
-  replicas: List[SecondaryStorageLocation]
-)
+

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/ReplicationAggregationSummary.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/ReplicationAggregationSummary.scala
@@ -3,6 +3,7 @@ package uk.ac.wellcome.platform.storage.replica_aggregator.models
 import java.time.Instant
 
 import uk.ac.wellcome.platform.archive.common.operation.models.Summary
+import uk.ac.wellcome.platform.storage.replica_aggregator.services.ReplicaCounterError
 
 sealed trait ReplicationAggregationSummary extends Summary {
   val replicaPath: ReplicaPath
@@ -37,7 +38,7 @@ sealed trait ReplicationAggregationSummary extends Summary {
 
 case class ReplicationAggregationComplete(
   replicaPath: ReplicaPath,
-  aggregatorRecord: AggregatorInternalRecord,
+  knownReplicas: KnownReplicas,
   startTime: Instant,
   endTime: Instant
 ) extends ReplicationAggregationSummary
@@ -45,6 +46,7 @@ case class ReplicationAggregationComplete(
 case class ReplicationAggregationIncomplete(
   replicaPath: ReplicaPath,
   aggregatorRecord: AggregatorInternalRecord,
+  counterError: ReplicaCounterError,
   startTime: Instant,
   endTime: Instant
 ) extends ReplicationAggregationSummary

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregator.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregator.scala
@@ -1,69 +1,32 @@
 package uk.ac.wellcome.platform.storage.replica_aggregator.services
 
-import java.time.Instant
-
-import uk.ac.wellcome.platform.archive.common.storage.models.SecondaryStorageLocation
 import uk.ac.wellcome.platform.storage.replica_aggregator.models._
 import uk.ac.wellcome.storage.Identified
 import uk.ac.wellcome.storage.store.VersionedStore
 
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
 class ReplicaAggregator(
   versionedStore: VersionedStore[ReplicaPath, Int, AggregatorInternalRecord]
 ) {
-  def aggregate(result: ReplicaResult): Try[ReplicationAggregationSummary] =
-    Try {
+  def aggregate(result: ReplicaResult): Try[AggregatorInternalRecord] = {
+    val replicaPath =
+      ReplicaPath(result.storageLocation.prefix.path)
 
-      // When we add support for secondary storage locations, we need to tweak
-      // the logic for deciding if a replica is "complete" -- we'll need to
-      // check we have:
-      //
-      //    * at least one primary replica
-      //    * at least N secondary replicas, where N is configurable
-      //
-      // For the initial, simpler case, we just handle primary replicas, so
-      // error out if passed a secondary replica.
-      //
-      result.storageLocation match {
-        case _: SecondaryStorageLocation =>
-          throw new Throwable(
-            s"Not yet supported! Cannot aggregate secondary replica result: $result"
-          )
+    val initialRecord =
+      AggregatorInternalRecord(result.storageLocation)
 
-        case _ => ()
-      }
+    versionedStore.upsert(replicaPath)(initialRecord) { existingRecord =>
+      // TODO: This .get is caused by poor handling of error states in the storage library.
+      // See: https://github.com/wellcometrust/platform/issues/3840
 
-      val startTime = Instant.now()
+      existingRecord.addLocation(result.storageLocation).get
+    } match {
+      case Right(Identified(_, aggregatorRecord)) =>
+        Success(aggregatorRecord)
 
-      val replicaPath =
-        ReplicaPath(result.storageLocation.prefix.path)
-
-      val initialRecord =
-        AggregatorInternalRecord(result.storageLocation)
-
-      versionedStore.upsert(replicaPath)(initialRecord) { existingRecord =>
-        // TODO: This .get is caused by poor handling of error states in the storage library.
-        // See: https://github.com/wellcometrust/platform/issues/3840
-
-        existingRecord.addLocation(result.storageLocation).get
-      } match {
-        // Only a single result is enough for now.
-        case Right(Identified(_, aggregatorRecord)) =>
-          ReplicationAggregationComplete(
-            replicaPath = replicaPath,
-            aggregatorRecord = aggregatorRecord,
-            startTime = startTime,
-            endTime = Instant.now()
-          )
-
-        case Left(updateError) =>
-          ReplicationAggregationFailed(
-            e = updateError.e,
-            replicaPath = replicaPath,
-            startTime = startTime,
-            endTime = Instant.now()
-          )
-      }
+      case Left(updateError) =>
+        Failure(updateError.e)
     }
+  }
 }

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorker.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorker.scala
@@ -10,7 +10,12 @@ import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
 import uk.ac.wellcome.platform.archive.common.EnrichedBagInformationPayload
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services.OutgoingPublisher
-import uk.ac.wellcome.platform.archive.common.storage.models.{IngestFailed, IngestStepResult, IngestStepSucceeded, IngestStepWorker}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  IngestFailed,
+  IngestStepResult,
+  IngestStepSucceeded,
+  IngestStepWorker
+}
 import uk.ac.wellcome.platform.storage.replica_aggregator.models._
 
 import scala.util.{Failure, Success, Try}
@@ -68,13 +73,12 @@ class ReplicaAggregatorWorker[IngestDestination, OutgoingDestination](
 
       case Failure(err) =>
         IngestFailed(
-          summary =
-            ReplicationAggregationFailed(
-              e = err,
-              replicaPath = replicaPath,
-              startTime = startTime,
-              endTime = Instant.now()
-            ),
+          summary = ReplicationAggregationFailed(
+            e = err,
+            replicaPath = replicaPath,
+            startTime = startTime,
+            endTime = Instant.now()
+          ),
           e = err
         )
     }
@@ -87,7 +91,8 @@ class ReplicaAggregatorWorker[IngestDestination, OutgoingDestination](
 
   private def sendOutgoing(
     ingestStep: IngestStepResult[ReplicationAggregationSummary],
-    payload: EnrichedBagInformationPayload): Try[Unit] =
+    payload: EnrichedBagInformationPayload
+  ): Try[Unit] =
     ingestStep match {
       case IngestStepSucceeded(_: ReplicationAggregationComplete, _) =>
         outgoingPublisher.sendIfSuccessful(ingestStep, payload)

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorker.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorker.scala
@@ -1,5 +1,7 @@
 package uk.ac.wellcome.platform.storage.replica_aggregator.services
 
+import java.time.Instant
+
 import akka.actor.ActorSystem
 import com.amazonaws.services.sqs.AmazonSQSAsync
 import io.circe.Decoder
@@ -8,19 +10,15 @@ import uk.ac.wellcome.messaging.worker.monitoring.MonitoringClient
 import uk.ac.wellcome.platform.archive.common.EnrichedBagInformationPayload
 import uk.ac.wellcome.platform.archive.common.ingests.services.IngestUpdater
 import uk.ac.wellcome.platform.archive.common.operation.services.OutgoingPublisher
-import uk.ac.wellcome.platform.archive.common.storage.models.{
-  IngestFailed,
-  IngestStepResult,
-  IngestStepSucceeded,
-  IngestStepWorker
-}
+import uk.ac.wellcome.platform.archive.common.storage.models.{IngestFailed, IngestStepResult, IngestStepSucceeded, IngestStepWorker}
 import uk.ac.wellcome.platform.storage.replica_aggregator.models._
 
-import scala.util.{Success, Try}
+import scala.util.{Failure, Success, Try}
 
 class ReplicaAggregatorWorker[IngestDestination, OutgoingDestination](
   val config: AlpakkaSQSWorkerConfig,
   replicaAggregator: ReplicaAggregator,
+  replicaCounter: ReplicaCounter,
   ingestUpdater: IngestUpdater[IngestDestination],
   outgoingPublisher: OutgoingPublisher[OutgoingDestination]
 )(
@@ -35,24 +33,66 @@ class ReplicaAggregatorWorker[IngestDestination, OutgoingDestination](
 
   override def processMessage(
     payload: EnrichedBagInformationPayload
-  ): Try[IngestStepResult[ReplicationAggregationSummary]] =
+  ): Try[IngestStepResult[ReplicationAggregationSummary]] = {
+    val replicaPath = ReplicaPath(payload.bagRootLocation.path)
+
+    val startTime = Instant.now()
+
+    val trySummary =
+      for {
+        aggregatorRecord <- replicaAggregator.aggregate(ReplicaResult(payload))
+
+        summary = replicaCounter.countReplicas(aggregatorRecord) match {
+          case Right(knownReplicas) =>
+            ReplicationAggregationComplete(
+              replicaPath = replicaPath,
+              knownReplicas = knownReplicas,
+              startTime = startTime,
+              endTime = Instant.now()
+            )
+
+          case Left(counterError) =>
+            ReplicationAggregationIncomplete(
+              replicaPath = replicaPath,
+              aggregatorRecord = aggregatorRecord,
+              counterError = counterError,
+              startTime = startTime,
+              endTime = Instant.now()
+            )
+        }
+      } yield summary
+
+    val ingestStep = trySummary match {
+      case Success(replicaSummary) =>
+        IngestStepSucceeded(replicaSummary)
+
+      case Failure(err) =>
+        IngestFailed(
+          summary =
+            ReplicationAggregationFailed(
+              e = err,
+              replicaPath = replicaPath,
+              startTime = startTime,
+              endTime = Instant.now()
+            ),
+          e = err
+        )
+    }
+
     for {
-      aggregation <- replicaAggregator.aggregate(ReplicaResult(payload))
-
-      // TODO: Need to distinguish result to determine outgoing message:
-      // ReplicationAggregationIncomplete/ReplicationAggregationComplete
-      // How does that map to IngestStepSucceeded & then sendIfSuccessful?
-
-      ingestStep <- Success(aggregation match {
-        case failed: ReplicationAggregationFailed =>
-          IngestFailed(failed, failed.e)
-        case default =>
-          IngestStepSucceeded(default)
-      })
-
       _ <- ingestUpdater.send(payload.ingestId, ingestStep)
-
-      _ <- outgoingPublisher.sendIfSuccessful(ingestStep, payload)
+      _ <- sendOutgoing(ingestStep, payload)
     } yield ingestStep
+  }
 
+  private def sendOutgoing(
+    ingestStep: IngestStepResult[ReplicationAggregationSummary],
+    payload: EnrichedBagInformationPayload): Try[Unit] =
+    ingestStep match {
+      case IngestStepSucceeded(_: ReplicationAggregationComplete, _) =>
+        outgoingPublisher.sendIfSuccessful(ingestStep, payload)
+
+      case _ =>
+        Success(())
+    }
 }

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaCounter.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaCounter.scala
@@ -1,0 +1,46 @@
+package uk.ac.wellcome.platform.storage.replica_aggregator.services
+import uk.ac.wellcome.platform.storage.replica_aggregator.models.{AggregatorInternalRecord, KnownReplicas}
+
+sealed trait ReplicaCounterError
+
+case class NoPrimaryReplica() extends ReplicaCounterError
+
+case class NotEnoughReplicas(
+  expected: Int,
+  actual: Int
+) extends ReplicaCounterError
+
+/** Check whether we have enough replicas to mark an ingest as "complete".
+  *
+  * It checks that:
+  *
+  *   - there's a primary replica
+  *   - there are at least `expectedReplicas` overall
+  *
+  */
+class ReplicaCounter(expectedReplicaCount: Int) {
+  def countReplicas(record: AggregatorInternalRecord): Either[ReplicaCounterError, KnownReplicas] =
+    record.location match {
+      case None => Left(NoPrimaryReplica())
+
+      case Some(primaryLocation) =>
+        // All the secondary replicas + 1 for the primary
+        val actualReplicaCount = record.replicas.size + 1
+
+        if (actualReplicaCount >= expectedReplicaCount) {
+          Right(
+            KnownReplicas(
+              location = primaryLocation,
+              replicas = record.replicas
+            )
+          )
+        } else {
+          Left(
+            NotEnoughReplicas(
+              expected = expectedReplicaCount,
+              actual = actualReplicaCount
+            )
+          )
+        }
+    }
+}

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaCounter.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaCounter.scala
@@ -1,5 +1,8 @@
 package uk.ac.wellcome.platform.storage.replica_aggregator.services
-import uk.ac.wellcome.platform.storage.replica_aggregator.models.{AggregatorInternalRecord, KnownReplicas}
+import uk.ac.wellcome.platform.storage.replica_aggregator.models.{
+  AggregatorInternalRecord,
+  KnownReplicas
+}
 
 sealed trait ReplicaCounterError
 
@@ -19,7 +22,9 @@ case class NotEnoughReplicas(
   *
   */
 class ReplicaCounter(expectedReplicaCount: Int) {
-  def countReplicas(record: AggregatorInternalRecord): Either[ReplicaCounterError, KnownReplicas] =
+  def countReplicas(
+    record: AggregatorInternalRecord
+  ): Either[ReplicaCounterError, KnownReplicas] =
     record.location match {
       case None => Left(NoPrimaryReplica())
 

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/fixtures/ReplicaAggregatorFixtures.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/fixtures/ReplicaAggregatorFixtures.scala
@@ -10,6 +10,7 @@ import uk.ac.wellcome.platform.archive.common.fixtures.{MonitoringClientFixture,
 import uk.ac.wellcome.platform.storage.replica_aggregator.models.{AggregatorInternalRecord, ReplicaPath}
 import uk.ac.wellcome.platform.storage.replica_aggregator.services.{ReplicaAggregator, ReplicaAggregatorWorker, ReplicaCounter}
 import uk.ac.wellcome.storage.store.VersionedStore
+import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
 
 trait ReplicaAggregatorFixtures
     extends OperationFixtures
@@ -24,7 +25,10 @@ trait ReplicaAggregatorFixtures
 
   def withReplicaAggregatorWorker[R](
     queue: Queue = defaultQueue,
-    versionedStore: VersionedStore[ReplicaPath, Int, AggregatorInternalRecord],
+    versionedStore: VersionedStore[ReplicaPath, Int, AggregatorInternalRecord] =
+      MemoryVersionedStore[ReplicaPath, AggregatorInternalRecord](
+        initialEntries = Map.empty
+      ),
     ingests: MemoryMessageSender,
     outgoing: MemoryMessageSender,
     stepName: String = randomAlphanumericWithLength(),

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/fixtures/ReplicaAggregatorFixtures.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/fixtures/ReplicaAggregatorFixtures.scala
@@ -6,9 +6,19 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.messaging.fixtures.SQS.Queue
 import uk.ac.wellcome.messaging.fixtures.worker.AlpakkaSQSWorkerFixtures
 import uk.ac.wellcome.messaging.memory.MemoryMessageSender
-import uk.ac.wellcome.platform.archive.common.fixtures.{MonitoringClientFixture, OperationFixtures}
-import uk.ac.wellcome.platform.storage.replica_aggregator.models.{AggregatorInternalRecord, ReplicaPath}
-import uk.ac.wellcome.platform.storage.replica_aggregator.services.{ReplicaAggregator, ReplicaAggregatorWorker, ReplicaCounter}
+import uk.ac.wellcome.platform.archive.common.fixtures.{
+  MonitoringClientFixture,
+  OperationFixtures
+}
+import uk.ac.wellcome.platform.storage.replica_aggregator.models.{
+  AggregatorInternalRecord,
+  ReplicaPath
+}
+import uk.ac.wellcome.platform.storage.replica_aggregator.services.{
+  ReplicaAggregator,
+  ReplicaAggregatorWorker,
+  ReplicaCounter
+}
 import uk.ac.wellcome.storage.store.VersionedStore
 import uk.ac.wellcome.storage.store.memory.MemoryVersionedStore
 
@@ -42,7 +52,8 @@ trait ReplicaAggregatorFixtures
         val worker = new ReplicaAggregatorWorker(
           config = createAlpakkaSQSWorkerConfig(queue),
           replicaAggregator = new ReplicaAggregator(versionedStore),
-          replicaCounter = new ReplicaCounter(expectedReplicaCount = expectedReplicaCount),
+          replicaCounter =
+            new ReplicaCounter(expectedReplicaCount = expectedReplicaCount),
           ingestUpdater = ingestUpdater,
           outgoingPublisher = outgoingPublisher
         )

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/generators/StorageLocationGenerators.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/generators/StorageLocationGenerators.scala
@@ -2,16 +2,25 @@ package uk.ac.wellcome.platform.storage.replica_aggregator.generators
 
 import uk.ac.wellcome.platform.archive.common.ingests.models.InfrequentAccessStorageProvider
 import uk.ac.wellcome.platform.archive.common.storage.models.{PrimaryStorageLocation, SecondaryStorageLocation}
+import uk.ac.wellcome.storage.ObjectLocationPrefix
 import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
 
 trait StorageLocationGenerators extends ObjectLocationGenerators {
-  def createPrimaryLocation = PrimaryStorageLocation(
-    provider = InfrequentAccessStorageProvider,
-    prefix = createObjectLocationPrefix
-  )
+  def createPrimaryLocation: PrimaryStorageLocation =
+    createPrimaryLocationWith()
 
-  def createSecondaryLocation = SecondaryStorageLocation(
-    provider = InfrequentAccessStorageProvider,
-    prefix = createObjectLocationPrefix
-  )
+  def createPrimaryLocationWith(prefix: ObjectLocationPrefix = createObjectLocationPrefix) =
+    PrimaryStorageLocation(
+      provider = InfrequentAccessStorageProvider,
+      prefix = prefix
+    )
+
+  def createSecondaryLocation: SecondaryStorageLocation =
+    createSecondaryLocationWith()
+
+  def createSecondaryLocationWith(prefix: ObjectLocationPrefix = createObjectLocationPrefix) =
+    SecondaryStorageLocation(
+      provider = InfrequentAccessStorageProvider,
+      prefix = prefix
+    )
 }

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/generators/StorageLocationGenerators.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/generators/StorageLocationGenerators.scala
@@ -1,0 +1,17 @@
+package uk.ac.wellcome.platform.storage.replica_aggregator.generators
+
+import uk.ac.wellcome.platform.archive.common.ingests.models.InfrequentAccessStorageProvider
+import uk.ac.wellcome.platform.archive.common.storage.models.{PrimaryStorageLocation, SecondaryStorageLocation}
+import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
+
+trait StorageLocationGenerators extends ObjectLocationGenerators {
+  def createPrimaryLocation = PrimaryStorageLocation(
+    provider = InfrequentAccessStorageProvider,
+    prefix = createObjectLocationPrefix
+  )
+
+  def createSecondaryLocation = SecondaryStorageLocation(
+    provider = InfrequentAccessStorageProvider,
+    prefix = createObjectLocationPrefix
+  )
+}

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/generators/StorageLocationGenerators.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/generators/StorageLocationGenerators.scala
@@ -1,7 +1,10 @@
 package uk.ac.wellcome.platform.storage.replica_aggregator.generators
 
 import uk.ac.wellcome.platform.archive.common.ingests.models.InfrequentAccessStorageProvider
-import uk.ac.wellcome.platform.archive.common.storage.models.{PrimaryStorageLocation, SecondaryStorageLocation}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  PrimaryStorageLocation,
+  SecondaryStorageLocation
+}
 import uk.ac.wellcome.storage.ObjectLocationPrefix
 import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
 
@@ -9,7 +12,9 @@ trait StorageLocationGenerators extends ObjectLocationGenerators {
   def createPrimaryLocation: PrimaryStorageLocation =
     createPrimaryLocationWith()
 
-  def createPrimaryLocationWith(prefix: ObjectLocationPrefix = createObjectLocationPrefix) =
+  def createPrimaryLocationWith(
+    prefix: ObjectLocationPrefix = createObjectLocationPrefix
+  ) =
     PrimaryStorageLocation(
       provider = InfrequentAccessStorageProvider,
       prefix = prefix
@@ -18,7 +23,9 @@ trait StorageLocationGenerators extends ObjectLocationGenerators {
   def createSecondaryLocation: SecondaryStorageLocation =
     createSecondaryLocationWith()
 
-  def createSecondaryLocationWith(prefix: ObjectLocationPrefix = createObjectLocationPrefix) =
+  def createSecondaryLocationWith(
+    prefix: ObjectLocationPrefix = createObjectLocationPrefix
+  ) =
     SecondaryStorageLocation(
       provider = InfrequentAccessStorageProvider,
       prefix = prefix

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/AggregatorInternalRecordTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/AggregatorInternalRecordTest.scala
@@ -1,32 +1,16 @@
 package uk.ac.wellcome.platform.storage.replica_aggregator.models
 
 import org.scalatest.{FunSpec, Matchers, TryValues}
-import uk.ac.wellcome.platform.archive.common.ingests.models.InfrequentAccessStorageProvider
-import uk.ac.wellcome.platform.archive.common.storage.models.{
-  PrimaryStorageLocation,
-  SecondaryStorageLocation
-}
-import uk.ac.wellcome.storage.generators.{
-  ObjectLocationGenerators,
-  RandomThings
-}
+import uk.ac.wellcome.platform.archive.common.storage.models.SecondaryStorageLocation
+import uk.ac.wellcome.platform.storage.replica_aggregator.generators.StorageLocationGenerators
+import uk.ac.wellcome.storage.generators.RandomThings
 
 class AggregatorInternalRecordTest
     extends FunSpec
     with Matchers
     with TryValues
-    with ObjectLocationGenerators
+    with StorageLocationGenerators
     with RandomThings {
-
-  def createPrimaryLocation = PrimaryStorageLocation(
-    provider = InfrequentAccessStorageProvider,
-    prefix = createObjectLocationPrefix
-  )
-
-  def createSecondaryLocation = SecondaryStorageLocation(
-    provider = InfrequentAccessStorageProvider,
-    prefix = createObjectLocationPrefix
-  )
 
   def createReplicas(min: Int = 0): List[SecondaryStorageLocation] =
     (1 to randomInt(min, 10))

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorTest.scala
@@ -6,7 +6,10 @@ import org.scalatest.{EitherValues, FunSpec, Matchers, TryValues}
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
 import uk.ac.wellcome.platform.archive.common.ingests.models.InfrequentAccessStorageProvider
-import uk.ac.wellcome.platform.archive.common.storage.models.{PrimaryStorageLocation, StorageLocation}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  PrimaryStorageLocation,
+  StorageLocation
+}
 import uk.ac.wellcome.platform.storage.replica_aggregator.generators.StorageLocationGenerators
 import uk.ac.wellcome.platform.storage.replica_aggregator.models._
 import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
@@ -148,8 +151,12 @@ class ReplicaAggregatorTest
     val results: Seq[AggregatorInternalRecord] =
       withAggregator(versionedStore) { aggregator =>
         locations
-          .map { storageLocation => createReplicaResultWith(storageLocation = storageLocation) }
-          .map { replicaResult => aggregator.aggregate(replicaResult) }
+          .map { storageLocation =>
+            createReplicaResultWith(storageLocation = storageLocation)
+          }
+          .map { replicaResult =>
+            aggregator.aggregate(replicaResult)
+          }
           .map { _.success.value }
       }
 
@@ -166,7 +173,7 @@ class ReplicaAggregatorTest
         AggregatorInternalRecord(
           location = Some(location2),
           replicas = List(location1, location3)
-        ),
+        )
       )
     }
 
@@ -207,7 +214,10 @@ class ReplicaAggregatorTest
     }
 
     versionedStore.store
-      .asInstanceOf[MemoryStore[Version[ReplicaPath, Int], AggregatorInternalRecord]]
+      .asInstanceOf[MemoryStore[
+        Version[ReplicaPath, Int],
+        AggregatorInternalRecord
+      ]]
       .entries should have size 2
   }
 
@@ -252,7 +262,10 @@ class ReplicaAggregatorTest
 
     withAggregator() { aggregator =>
       (1 to 5).map { _ =>
-        aggregator.aggregate(replicaResult).success.value shouldBe expectedRecord
+        aggregator
+          .aggregate(replicaResult)
+          .success
+          .value shouldBe expectedRecord
       }
     }
   }
@@ -275,7 +288,9 @@ class ReplicaAggregatorTest
       aggregator.aggregate(replicaResult1) shouldBe a[Success[_]]
 
       val err = aggregator.aggregate(replicaResult2).failed.get
-      err.getMessage should startWith("Record already has a different PrimaryStorageLocation")
+      err.getMessage should startWith(
+        "Record already has a different PrimaryStorageLocation"
+      )
     }
   }
 
@@ -289,12 +304,12 @@ class ReplicaAggregatorTest
         }
       }
 
-    val uniqResults = results
-      .map { _.success.value }
-      .toSet
+    val uniqResults = results.map { _.success.value }.toSet
 
     uniqResults should have size 1
 
-    uniqResults.head shouldBe AggregatorInternalRecord(replicaResult.storageLocation)
+    uniqResults.head shouldBe AggregatorInternalRecord(
+      replicaResult.storageLocation
+    )
   }
 }

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorTest.scala
@@ -6,14 +6,14 @@ import org.scalatest.{EitherValues, FunSpec, Matchers, TryValues}
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
 import uk.ac.wellcome.platform.archive.common.ingests.models.InfrequentAccessStorageProvider
-import uk.ac.wellcome.platform.archive.common.storage.models.{PrimaryStorageLocation, SecondaryStorageLocation, StorageLocation}
+import uk.ac.wellcome.platform.archive.common.storage.models.{PrimaryStorageLocation, StorageLocation}
 import uk.ac.wellcome.platform.storage.replica_aggregator.generators.StorageLocationGenerators
 import uk.ac.wellcome.platform.storage.replica_aggregator.models._
 import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
 import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryVersionedStore}
 import uk.ac.wellcome.storage.{UpdateWriteError, Version}
 
-import scala.util.Try
+import scala.util.{Success, Try}
 
 class ReplicaAggregatorTest
     extends FunSpec
@@ -49,32 +49,11 @@ class ReplicaAggregatorTest
       new ReplicaAggregator(versionedStore)
     )
 
-  it("completes after a single primary replica") {
+  describe("handling a primary replica") {
     val primaryLocation = createPrimaryLocation
 
     val replicaResult = createReplicaResultWith(
       storageLocation = primaryLocation
-    )
-
-    val result: Try[AggregatorInternalRecord] =
-      withAggregator() {
-        _.aggregate(replicaResult)
-      }
-
-    result.success.value shouldBe AggregatorInternalRecord(
-      location = Some(primaryLocation),
-      replicas = List.empty
-    )
-  }
-
-  it("stores a single primary replica") {
-    val storageLocation = PrimaryStorageLocation(
-      provider = InfrequentAccessStorageProvider,
-      prefix = createObjectLocationPrefix
-    )
-
-    val replicaResult = createReplicaResultWith(
-      storageLocation = storageLocation
     )
 
     val versionedStore =
@@ -82,37 +61,154 @@ class ReplicaAggregatorTest
         initialEntries = Map.empty
       )
 
-    withAggregator(versionedStore) {
-      _.aggregate(replicaResult)
-    }
-
-    val path = ReplicaPath(replicaResult.storageLocation.prefix.path)
-
-    versionedStore
-      .getLatest(path)
-      .right
-      .value
-      .identifiedT shouldBe AggregatorInternalRecord(
-      location = Some(storageLocation),
-      replicas = List.empty
-    )
-  }
-
-  it("errors if asked to aggregate a secondary replica") {
-    val replicaResult = createReplicaResultWith(
-      storageLocation = SecondaryStorageLocation(
-        provider = InfrequentAccessStorageProvider,
-        prefix = createObjectLocationPrefix
-      )
-    )
-
     val result =
-      withAggregator() {
+      withAggregator(versionedStore) {
         _.aggregate(replicaResult)
       }
 
-    val err = result.failed.get
-    err.getMessage shouldBe s"Not yet supported! Cannot aggregate secondary replica result: $replicaResult"
+    val expectedRecord =
+      AggregatorInternalRecord(
+        location = Some(primaryLocation),
+        replicas = List.empty
+      )
+
+    it("returns the correct record") {
+      result.success.value shouldBe expectedRecord
+    }
+
+    it("stores the replica in the underlying store") {
+      val path = ReplicaPath(replicaResult.storageLocation.prefix.path)
+
+      versionedStore
+        .getLatest(path)
+        .right
+        .value
+        .identifiedT shouldBe expectedRecord
+    }
+  }
+
+  describe("handling a secondary replica") {
+    val secondaryLocation = createSecondaryLocation
+
+    val replicaResult = createReplicaResultWith(
+      storageLocation = secondaryLocation
+    )
+
+    val versionedStore =
+      MemoryVersionedStore[ReplicaPath, AggregatorInternalRecord](
+        initialEntries = Map.empty
+      )
+
+    val result =
+      withAggregator(versionedStore) {
+        _.aggregate(replicaResult)
+      }
+
+    val expectedRecord =
+      AggregatorInternalRecord(
+        location = None,
+        replicas = List(secondaryLocation)
+      )
+
+    it("returns the correct record") {
+      result.success.value shouldBe expectedRecord
+    }
+
+    it("stores the replica in the underlying store") {
+      val path = ReplicaPath(replicaResult.storageLocation.prefix.path)
+
+      versionedStore
+        .getLatest(path)
+        .right
+        .value
+        .identifiedT shouldBe expectedRecord
+    }
+  }
+
+  describe("handling multiple updates to the same replica") {
+    val prefix = createObjectLocationPrefix
+
+    val location1 = createSecondaryLocationWith(
+      prefix = prefix.copy(namespace = randomAlphanumeric)
+    )
+    val location2 = createPrimaryLocationWith(
+      prefix = prefix.copy(namespace = randomAlphanumeric)
+    )
+    val location3 = createSecondaryLocationWith(
+      prefix = prefix.copy(namespace = randomAlphanumeric)
+    )
+
+    val locations = Seq(location1, location2, location3)
+
+    val versionedStore =
+      MemoryVersionedStore[ReplicaPath, AggregatorInternalRecord](
+        initialEntries = Map.empty
+      )
+
+    val results: Seq[AggregatorInternalRecord] =
+      withAggregator(versionedStore) { aggregator =>
+        locations
+          .map { storageLocation => createReplicaResultWith(storageLocation = storageLocation) }
+          .map { replicaResult => aggregator.aggregate(replicaResult) }
+          .map { _.success.value }
+      }
+
+    it("returns the correct records") {
+      results shouldBe Seq(
+        AggregatorInternalRecord(
+          location = None,
+          replicas = List(location1)
+        ),
+        AggregatorInternalRecord(
+          location = Some(location2),
+          replicas = List(location1)
+        ),
+        AggregatorInternalRecord(
+          location = Some(location2),
+          replicas = List(location1, location3)
+        ),
+      )
+    }
+
+    it("stores the replica in the underlying store") {
+      val path = ReplicaPath(prefix.path)
+
+      val expectedRecord =
+        AggregatorInternalRecord(
+          location = Some(location2),
+          replicas = List(location1, location3)
+        )
+
+      versionedStore
+        .getLatest(path)
+        .right
+        .value
+        .identifiedT shouldBe expectedRecord
+    }
+  }
+
+  it("stores different replicas under different paths") {
+    val primaryLocation1 = createPrimaryLocation
+    val primaryLocation2 = createPrimaryLocation
+
+    val versionedStore =
+      MemoryVersionedStore[ReplicaPath, AggregatorInternalRecord](
+        initialEntries = Map.empty
+      )
+
+    withAggregator(versionedStore) { aggregator =>
+      Seq(primaryLocation1, primaryLocation2)
+        .map { storageLocation =>
+          createReplicaResultWith(storageLocation = storageLocation)
+        }
+        .foreach { replicaResult =>
+          aggregator.aggregate(replicaResult)
+        }
+    }
+
+    versionedStore.store
+      .asInstanceOf[MemoryStore[Version[ReplicaPath, Int], AggregatorInternalRecord]]
+      .entries should have size 2
   }
 
   it("handles an error from the underlying versioned store") {
@@ -138,11 +234,49 @@ class ReplicaAggregatorTest
         _.aggregate(createReplicaResult)
       }
 
-    val summary = result.success.value
+    result.failed.get shouldBe throwable
+  }
 
-    summary shouldBe a[ReplicationAggregationFailed]
-    val failure = summary.asInstanceOf[ReplicationAggregationFailed]
-    failure.e shouldBe throwable
+  it("accepts adding the same primary location to a record twice") {
+    val primaryLocation = createPrimaryLocation
+
+    val replicaResult = createReplicaResultWith(
+      storageLocation = primaryLocation
+    )
+
+    val expectedRecord =
+      AggregatorInternalRecord(
+        location = Some(primaryLocation),
+        replicas = List.empty
+      )
+
+    withAggregator() { aggregator =>
+      (1 to 5).map { _ =>
+        aggregator.aggregate(replicaResult).success.value shouldBe expectedRecord
+      }
+    }
+  }
+
+  it("fails if you add different primary locations for the same replica path") {
+    val prefix = createObjectLocationPrefix
+
+    val primaryLocation1 = createPrimaryLocationWith(
+      prefix = prefix.copy(namespace = randomAlphanumeric)
+    )
+
+    val primaryLocation2 = createPrimaryLocationWith(
+      prefix = prefix.copy(namespace = randomAlphanumeric)
+    )
+
+    val replicaResult1 = createReplicaResultWith(primaryLocation1)
+    val replicaResult2 = createReplicaResultWith(primaryLocation2)
+
+    withAggregator() { aggregator =>
+      aggregator.aggregate(replicaResult1) shouldBe a[Success[_]]
+
+      val err = aggregator.aggregate(replicaResult2).failed.get
+      err.getMessage should startWith("Record already has a different PrimaryStorageLocation")
+    }
   }
 
   it("only stores unique replica results") {
@@ -163,13 +297,4 @@ class ReplicaAggregatorTest
 
     uniqResults.head shouldBe AggregatorInternalRecord(replicaResult.storageLocation)
   }
-
-  // TODO (separate patch):
-  //
-  // *  It deduplicates replicas to the same location, even if they have
-  //    different timestamps
-  // *  It returns an "incomplete" summary if we don't have a primary replica
-  //    and/or we don't have enough secondary replicas
-  // *  It errors if it gets multiple primary replicas
-  //
 }

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
@@ -1,0 +1,46 @@
+package uk.ac.wellcome.platform.storage.replica_aggregator.services
+import org.scalatest.{FunSpec, Matchers}
+
+class ReplicaAggregatorWorkerTest extends FunSpec with Matchers {
+  describe("if there are enough replicas") {
+    it("returns a ReplicationAggregationComplete") {
+      true shouldBe false
+    }
+
+    it("sends an outgoing message") {
+      true shouldBe false
+    }
+
+    it("updates the ingests monitor") {
+      true shouldBe false
+    }
+  }
+
+  describe("if there are not enough replicas") {
+    it("returns a ReplicationAggregationIncomplete") {
+      true shouldBe false
+    }
+
+    it("does not send an outgoing message") {
+      true shouldBe false
+    }
+
+    it("updates the ingests monitor") {
+      true shouldBe false
+    }
+  }
+
+  describe("if there's an error in the replica aggregator") {
+    it("returns a ReplicationAggregationFailed") {
+      true shouldBe false
+    }
+
+    it("does not send an outgoing message") {
+      true shouldBe false
+    }
+
+    it("sends an IngestFailed to the monitor") {
+      true shouldBe false
+    }
+  }
+}

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
@@ -1,46 +1,178 @@
 package uk.ac.wellcome.platform.storage.replica_aggregator.services
-import org.scalatest.{FunSpec, Matchers}
 
-class ReplicaAggregatorWorkerTest extends FunSpec with Matchers {
+import org.scalatest.{FunSpec, Matchers, TryValues}
+import uk.ac.wellcome.json.JsonUtil._
+import uk.ac.wellcome.messaging.memory.MemoryMessageSender
+import uk.ac.wellcome.platform.archive.common.EnrichedBagInformationPayload
+import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
+import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
+import uk.ac.wellcome.platform.archive.common.ingests.models.{InfrequentAccessStorageProvider, Ingest}
+import uk.ac.wellcome.platform.archive.common.storage.models.{IngestFailed, IngestStepSucceeded, PrimaryStorageLocation}
+import uk.ac.wellcome.platform.storage.replica_aggregator.fixtures.ReplicaAggregatorFixtures
+import uk.ac.wellcome.platform.storage.replica_aggregator.models._
+import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
+import uk.ac.wellcome.storage.{UpdateWriteError, Version}
+import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryVersionedStore}
+
+class ReplicaAggregatorWorkerTest
+  extends FunSpec
+    with Matchers
+    with PayloadGenerators
+    with IngestUpdateAssertions
+    with ReplicaAggregatorFixtures
+    with TryValues {
+
   describe("if there are enough replicas") {
+    val ingests = new MemoryMessageSender()
+    val outgoing = new MemoryMessageSender()
+
+    val payload = createEnrichedBagInformationPayload
+
+    val result =
+      withReplicaAggregatorWorker(
+        ingests = ingests,
+        outgoing = outgoing,
+        stepName = "aggregating replicas"
+      ) {
+        _.processMessage(payload).success.value
+      }
+
     it("returns a ReplicationAggregationComplete") {
-      true shouldBe false
+      result shouldBe a[IngestStepSucceeded[_]]
+
+      result.summary shouldBe a[ReplicationAggregationComplete]
+
+      val completeAggregation = result.summary.asInstanceOf[ReplicationAggregationComplete]
+      completeAggregation.replicaPath shouldBe ReplicaPath(payload.bagRootLocation.path)
+      completeAggregation.knownReplicas shouldBe KnownReplicas(
+        location = PrimaryStorageLocation(
+          provider = InfrequentAccessStorageProvider,
+          prefix = payload.bagRootLocation.asPrefix
+        ),
+        replicas = List.empty
+      )
     }
 
     it("sends an outgoing message") {
-      true shouldBe false
+      outgoing.getMessages[EnrichedBagInformationPayload] shouldBe Seq(payload)
     }
 
     it("updates the ingests monitor") {
-      true shouldBe false
+      assertTopicReceivesIngestEvents(
+        ingestId = payload.ingestId,
+        ingests = ingests,
+        expectedDescriptions = Seq(
+          "Aggregating replicas succeeded"
+        )
+      )
     }
   }
 
   describe("if there are not enough replicas") {
+    val ingests = new MemoryMessageSender()
+    val outgoing = new MemoryMessageSender()
+
+    val payload = createEnrichedBagInformationPayload
+
+    val result =
+      withReplicaAggregatorWorker(
+        ingests = ingests,
+        outgoing = outgoing,
+        stepName = "aggregating replicas",
+        expectedReplicaCount = 3
+      ) {
+        _.processMessage(payload).success.value
+      }
+
     it("returns a ReplicationAggregationIncomplete") {
-      true shouldBe false
+      result shouldBe a[IngestStepSucceeded[_]]
+
+      result.summary shouldBe a[ReplicationAggregationIncomplete]
+
+      val incompleteAggregation = result.summary.asInstanceOf[ReplicationAggregationIncomplete]
+      incompleteAggregation.replicaPath shouldBe ReplicaPath(payload.bagRootLocation.path)
+      incompleteAggregation.aggregatorRecord shouldBe AggregatorInternalRecord(
+        location = Some(
+          PrimaryStorageLocation(
+            provider = InfrequentAccessStorageProvider,
+            prefix = payload.bagRootLocation.asPrefix
+          )
+        ),
+        replicas = List.empty
+      )
+      incompleteAggregation.counterError shouldBe NotEnoughReplicas(expected = 3, actual = 1)
     }
 
     it("does not send an outgoing message") {
-      true shouldBe false
+      outgoing.getMessages[EnrichedBagInformationPayload] shouldBe empty
     }
 
     it("updates the ingests monitor") {
-      true shouldBe false
+      assertTopicReceivesIngestEvents(
+        ingestId = payload.ingestId,
+        ingests = ingests,
+        expectedDescriptions = Seq(
+          "Aggregating replicas succeeded"
+        )
+      )
     }
   }
 
   describe("if there's an error in the replica aggregator") {
+    val throwable = new Throwable("BOOM!")
+
+    val brokenStore =
+      new MemoryVersionedStore[ReplicaPath, AggregatorInternalRecord](
+        store =
+          new MemoryStore[Version[ReplicaPath, Int], AggregatorInternalRecord](
+            initialEntries = Map.empty
+          ) with MemoryMaxima[ReplicaPath, AggregatorInternalRecord]
+      ) {
+        override def upsert(id: ReplicaPath)(
+          t: AggregatorInternalRecord
+        )(
+          f: AggregatorInternalRecord => AggregatorInternalRecord
+        ): UpdateEither =
+          Left(UpdateWriteError(throwable))
+      }
+
+    val ingests = new MemoryMessageSender()
+    val outgoing = new MemoryMessageSender()
+
+    val payload = createEnrichedBagInformationPayload
+
+    val result =
+      withReplicaAggregatorWorker(
+        ingests = ingests,
+        outgoing = outgoing,
+        versionedStore = brokenStore,
+        stepName = "aggregating replicas"
+      ) {
+        _.processMessage(payload).success.value
+      }
+
     it("returns a ReplicationAggregationFailed") {
-      true shouldBe false
+      result shouldBe a[IngestFailed[_]]
+
+      result.summary shouldBe a[ReplicationAggregationFailed]
+
+      val failure = result.summary.asInstanceOf[ReplicationAggregationFailed]
+      failure.replicaPath shouldBe ReplicaPath(payload.bagRootLocation.path)
+      failure.e shouldBe throwable
     }
 
     it("does not send an outgoing message") {
-      true shouldBe false
+      outgoing.getMessages[EnrichedBagInformationPayload] shouldBe empty
     }
 
     it("sends an IngestFailed to the monitor") {
-      true shouldBe false
+      assertTopicReceivesIngestStatus(
+        ingestId = payload.ingestId,
+        ingests = ingests,
+        status = Ingest.Failed
+      ) {
+        _.map { _.description } shouldBe Seq("Aggregating replicas failed")
+      }
     }
   }
 }

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
@@ -6,8 +6,15 @@ import uk.ac.wellcome.messaging.memory.MemoryMessageSender
 import uk.ac.wellcome.platform.archive.common.EnrichedBagInformationPayload
 import uk.ac.wellcome.platform.archive.common.generators.PayloadGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.IngestUpdateAssertions
-import uk.ac.wellcome.platform.archive.common.ingests.models.{InfrequentAccessStorageProvider, Ingest}
-import uk.ac.wellcome.platform.archive.common.storage.models.{IngestFailed, IngestStepSucceeded, PrimaryStorageLocation}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  InfrequentAccessStorageProvider,
+  Ingest
+}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  IngestFailed,
+  IngestStepSucceeded,
+  PrimaryStorageLocation
+}
 import uk.ac.wellcome.platform.storage.replica_aggregator.fixtures.ReplicaAggregatorFixtures
 import uk.ac.wellcome.platform.storage.replica_aggregator.models._
 import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
@@ -15,7 +22,7 @@ import uk.ac.wellcome.storage.{UpdateWriteError, Version}
 import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryVersionedStore}
 
 class ReplicaAggregatorWorkerTest
-  extends FunSpec
+    extends FunSpec
     with Matchers
     with PayloadGenerators
     with IngestUpdateAssertions
@@ -42,8 +49,11 @@ class ReplicaAggregatorWorkerTest
 
       result.summary shouldBe a[ReplicationAggregationComplete]
 
-      val completeAggregation = result.summary.asInstanceOf[ReplicationAggregationComplete]
-      completeAggregation.replicaPath shouldBe ReplicaPath(payload.bagRootLocation.path)
+      val completeAggregation =
+        result.summary.asInstanceOf[ReplicationAggregationComplete]
+      completeAggregation.replicaPath shouldBe ReplicaPath(
+        payload.bagRootLocation.path
+      )
       completeAggregation.knownReplicas shouldBe KnownReplicas(
         location = PrimaryStorageLocation(
           provider = InfrequentAccessStorageProvider,
@@ -89,8 +99,11 @@ class ReplicaAggregatorWorkerTest
 
       result.summary shouldBe a[ReplicationAggregationIncomplete]
 
-      val incompleteAggregation = result.summary.asInstanceOf[ReplicationAggregationIncomplete]
-      incompleteAggregation.replicaPath shouldBe ReplicaPath(payload.bagRootLocation.path)
+      val incompleteAggregation =
+        result.summary.asInstanceOf[ReplicationAggregationIncomplete]
+      incompleteAggregation.replicaPath shouldBe ReplicaPath(
+        payload.bagRootLocation.path
+      )
       incompleteAggregation.aggregatorRecord shouldBe AggregatorInternalRecord(
         location = Some(
           PrimaryStorageLocation(
@@ -100,7 +113,10 @@ class ReplicaAggregatorWorkerTest
         ),
         replicas = List.empty
       )
-      incompleteAggregation.counterError shouldBe NotEnoughReplicas(expected = 3, actual = 1)
+      incompleteAggregation.counterError shouldBe NotEnoughReplicas(
+        expected = 3,
+        actual = 1
+      )
     }
 
     it("does not send an outgoing message") {

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaCounterTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaCounterTest.scala
@@ -1,0 +1,96 @@
+package uk.ac.wellcome.platform.storage.replica_aggregator.services
+
+import org.scalatest.{EitherValues, FunSpec, Matchers}
+import uk.ac.wellcome.platform.storage.replica_aggregator.generators.StorageLocationGenerators
+import uk.ac.wellcome.platform.storage.replica_aggregator.models.{AggregatorInternalRecord, KnownReplicas}
+
+class ReplicaCounterTest extends FunSpec with Matchers with EitherValues with StorageLocationGenerators {
+  it("rejects a record without a primary location") {
+    val counter = new ReplicaCounter(expectedReplicaCount = 1)
+
+    val record = AggregatorInternalRecord(
+      location = None,
+      replicas = List.empty
+    )
+
+    counter.countReplicas(record).left.value shouldBe NoPrimaryReplica()
+  }
+
+  it("rejects a record without a primary location even if it has enough secondary replicas") {
+    val counter = new ReplicaCounter(expectedReplicaCount = 3)
+
+    val record = AggregatorInternalRecord(
+      location = None,
+      replicas = List(createSecondaryLocation, createSecondaryLocation, createSecondaryLocation)
+    )
+
+    counter.countReplicas(record).left.value shouldBe NoPrimaryReplica()
+  }
+
+  it("if expectedCount = 1, a single primary replica is enough") {
+    val counter = new ReplicaCounter(expectedReplicaCount = 1)
+
+    val location = createPrimaryLocation
+
+    val record = AggregatorInternalRecord(
+      location = Some(location),
+      replicas = List.empty
+    )
+
+    counter.countReplicas(record).right.value shouldBe KnownReplicas(
+      location = location,
+      replicas = List.empty
+    )
+  }
+
+  it("if expectedCount = 3, it expects a primary replica and two secondaries") {
+    val counter = new ReplicaCounter(expectedReplicaCount = 3)
+
+    val location = createPrimaryLocation
+    val replicas = List(createSecondaryLocation, createSecondaryLocation)
+
+    val record = AggregatorInternalRecord(
+      location = Some(location),
+      replicas = replicas
+    )
+
+    counter.countReplicas(record).right.value shouldBe KnownReplicas(
+      location = location,
+      replicas = replicas
+    )
+  }
+
+  it("rejects a record without enough secondary replicas") {
+    val counter = new ReplicaCounter(expectedReplicaCount = 5)
+
+    val location = createPrimaryLocation
+    val replicas = List(createSecondaryLocation, createSecondaryLocation)
+
+    val record = AggregatorInternalRecord(
+      location = Some(location),
+      replicas = replicas
+    )
+
+    counter.countReplicas(record).left.value shouldBe NotEnoughReplicas(
+      expected = 5,
+      actual = 3
+    )
+  }
+
+  it("allows a record with extra replicas") {
+    val counter = new ReplicaCounter(expectedReplicaCount = 3)
+
+    val location = createPrimaryLocation
+    val replicas = (1 to 5).map { _ => createSecondaryLocation }.toList
+
+    val record = AggregatorInternalRecord(
+      location = Some(location),
+      replicas = replicas
+    )
+
+    counter.countReplicas(record).right.value shouldBe KnownReplicas(
+      location = location,
+      replicas = replicas
+    )
+  }
+}

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaCounterTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaCounterTest.scala
@@ -2,9 +2,16 @@ package uk.ac.wellcome.platform.storage.replica_aggregator.services
 
 import org.scalatest.{EitherValues, FunSpec, Matchers}
 import uk.ac.wellcome.platform.storage.replica_aggregator.generators.StorageLocationGenerators
-import uk.ac.wellcome.platform.storage.replica_aggregator.models.{AggregatorInternalRecord, KnownReplicas}
+import uk.ac.wellcome.platform.storage.replica_aggregator.models.{
+  AggregatorInternalRecord,
+  KnownReplicas
+}
 
-class ReplicaCounterTest extends FunSpec with Matchers with EitherValues with StorageLocationGenerators {
+class ReplicaCounterTest
+    extends FunSpec
+    with Matchers
+    with EitherValues
+    with StorageLocationGenerators {
   it("rejects a record without a primary location") {
     val counter = new ReplicaCounter(expectedReplicaCount = 1)
 
@@ -16,12 +23,18 @@ class ReplicaCounterTest extends FunSpec with Matchers with EitherValues with St
     counter.countReplicas(record).left.value shouldBe NoPrimaryReplica()
   }
 
-  it("rejects a record without a primary location even if it has enough secondary replicas") {
+  it(
+    "rejects a record without a primary location even if it has enough secondary replicas"
+  ) {
     val counter = new ReplicaCounter(expectedReplicaCount = 3)
 
     val record = AggregatorInternalRecord(
       location = None,
-      replicas = List(createSecondaryLocation, createSecondaryLocation, createSecondaryLocation)
+      replicas = List(
+        createSecondaryLocation,
+        createSecondaryLocation,
+        createSecondaryLocation
+      )
     )
 
     counter.countReplicas(record).left.value shouldBe NoPrimaryReplica()
@@ -81,7 +94,9 @@ class ReplicaCounterTest extends FunSpec with Matchers with EitherValues with St
     val counter = new ReplicaCounter(expectedReplicaCount = 3)
 
     val location = createPrimaryLocation
-    val replicas = (1 to 5).map { _ => createSecondaryLocation }.toList
+    val replicas = (1 to 5).map { _ =>
+      createSecondaryLocation
+    }.toList
 
     val record = AggregatorInternalRecord(
       location = Some(location),


### PR DESCRIPTION
This patch adds a new class `ReplicaCounter`, which counts the number of replicas to see how many there actually are vs. how many it expects.

If there are enough, it sends a ReplicationCompleteSummary and the payload is forwarded to the register; if not, it marks it as incomplete and just sends an ingests update.

Part of https://github.com/wellcometrust/platform/issues/3836