### PR TITLE
StorageManifestService can store replicas correctly

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
@@ -273,7 +273,7 @@ class StorageManifestService(sizeFinder: SizeFinder) extends Logging {
     if (failures.isEmpty) {
       Success(successes)
     } else {
-      Failure(new Throwable(s"Malformed bag root in the replicas: $failures"))
+      Failure(new StorageManifestException(s"Malformed bag root in the replicas: $failures"))
     }
   }
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
@@ -251,29 +251,35 @@ class StorageManifestService(sizeFinder: SizeFinder) extends Logging {
 
   private def getReplicaLocations(
     replicas: Seq[SecondaryStorageLocation],
-    version: BagVersion): Try[Seq[SecondaryStorageLocation]] = {
+    version: BagVersion
+  ): Try[Seq[SecondaryStorageLocation]] = {
     val rootReplicas =
       replicas
         .map { loc =>
           getBagRoot(replicaRoot = loc.prefix, version = version) match {
-            case Success(prefix) => Success(
-              SecondaryStorageLocation(
-                provider = loc.provider,
-                prefix = prefix
+            case Success(prefix) =>
+              Success(
+                SecondaryStorageLocation(
+                  provider = loc.provider,
+                  prefix = prefix
+                )
               )
-            )
 
             case Failure(err) => Failure(err)
           }
         }
 
     val successes = rootReplicas.collect { case Success(loc) => loc }
-    val failures = rootReplicas.collect { case Failure(err) => err }
+    val failures = rootReplicas.collect { case Failure(err)  => err }
 
     if (failures.isEmpty) {
       Success(successes)
     } else {
-      Failure(new StorageManifestException(s"Malformed bag root in the replicas: $failures"))
+      Failure(
+        new StorageManifestException(
+          s"Malformed bag root in the replicas: $failures"
+        )
+      )
     }
   }
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
@@ -31,21 +31,8 @@ class StorageManifestService(sizeFinder: SizeFinder) extends Logging {
     space: StorageSpace,
     version: BagVersion
   ): Try[StorageManifest] =
-    createManifest(
-      bag = bag,
-      replicaRoot = location.prefix,
-      space = space,
-      version = version
-    )
-
-  def createManifest(
-    bag: Bag,
-    replicaRoot: ObjectLocationPrefix,
-    space: StorageSpace,
-    version: BagVersion
-  ): Try[StorageManifest] = {
     for {
-      bagRoot <- getBagRoot(replicaRoot, version)
+      bagRoot <- getBagRoot(location.prefix, version)
 
       matchedLocations <- resolveFetchLocations(bag)
 
@@ -80,14 +67,30 @@ class StorageManifestService(sizeFinder: SizeFinder) extends Logging {
           files = tagManifestFiles
         ),
         location = PrimaryStorageLocation(
-          provider = InfrequentAccessStorageProvider,
+          provider = location.provider,
           prefix = bagRoot
         ),
         replicaLocations = Seq.empty,
         createdDate = Instant.now
       )
     } yield storageManifest
-  }
+
+  def createManifest(
+    bag: Bag,
+    replicaRoot: ObjectLocationPrefix,
+    space: StorageSpace,
+    version: BagVersion
+  ): Try[StorageManifest] =
+    createManifest(
+      bag = bag,
+      location = PrimaryStorageLocation(
+        provider = InfrequentAccessStorageProvider,
+        prefix = replicaRoot
+      ),
+      replicas = Seq.empty,
+      space = space,
+      version = version
+    )
 
   /** The replicator writes bags inside a bucket to paths of the form
     *

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
@@ -26,6 +26,20 @@ class BadFetchLocationException(message: String)
 class StorageManifestService(sizeFinder: SizeFinder) extends Logging {
   def createManifest(
     bag: Bag,
+    location: PrimaryStorageLocation,
+    replicas: Seq[SecondaryStorageLocation],
+    space: StorageSpace,
+    version: BagVersion
+  ): Try[StorageManifest] =
+    createManifest(
+      bag = bag,
+      replicaRoot = location.prefix,
+      space = space,
+      version = version
+    )
+
+  def createManifest(
+    bag: Bag,
     replicaRoot: ObjectLocationPrefix,
     space: StorageSpace,
     version: BagVersion

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageRandomThings.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageRandomThings.scala
@@ -19,7 +19,9 @@ trait StorageRandomThings extends RandomThings {
     Instant.now().plusSeconds(Random.nextInt())
 
   def atMost[T](max: Int)(f: => T): Seq[T] =
-    (1 to randomInt(from = 0, to = max)).map { _ => f }
+    (1 to randomInt(from = 0, to = max)).map { _ =>
+      f
+    }
 
   def randomPaths(maxDepth: Int = 4, dirs: Int = 4): List[String] = {
     (1 to dirs).map { _ =>

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageRandomThings.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageRandomThings.scala
@@ -18,6 +18,9 @@ trait StorageRandomThings extends RandomThings {
   def randomInstant: Instant =
     Instant.now().plusSeconds(Random.nextInt())
 
+  def atMost[T](max: Int)(f: => T): Seq[T] =
+    (1 to randomInt(from = 0, to = max)).map { _ => f }
+
   def randomPaths(maxDepth: Int = 4, dirs: Int = 4): List[String] = {
     (1 to dirs).map { _ =>
       val depth = Random.nextInt(maxDepth)

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageLocationGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageLocationGenerators.scala
@@ -1,6 +1,10 @@
-package uk.ac.wellcome.platform.storage.replica_aggregator.generators
+package uk.ac.wellcome.platform.archive.common.generators
 
-import uk.ac.wellcome.platform.archive.common.ingests.models.InfrequentAccessStorageProvider
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  InfrequentAccessStorageProvider,
+  StandardStorageProvider,
+  StorageProvider
+}
 import uk.ac.wellcome.platform.archive.common.storage.models.{
   PrimaryStorageLocation,
   SecondaryStorageLocation
@@ -8,15 +12,27 @@ import uk.ac.wellcome.platform.archive.common.storage.models.{
 import uk.ac.wellcome.storage.ObjectLocationPrefix
 import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
 
+import scala.util.Random
+
 trait StorageLocationGenerators extends ObjectLocationGenerators {
+  def createProvider: StorageProvider = {
+    val providers = Seq(
+      StandardStorageProvider,
+      InfrequentAccessStorageProvider
+    )
+
+    providers(Random.nextInt(providers.size))
+  }
+
   def createPrimaryLocation: PrimaryStorageLocation =
     createPrimaryLocationWith()
 
   def createPrimaryLocationWith(
+    provider: StorageProvider = createProvider,
     prefix: ObjectLocationPrefix = createObjectLocationPrefix
   ) =
     PrimaryStorageLocation(
-      provider = InfrequentAccessStorageProvider,
+      provider = provider,
       prefix = prefix
     )
 
@@ -24,10 +40,11 @@ trait StorageLocationGenerators extends ObjectLocationGenerators {
     createSecondaryLocationWith()
 
   def createSecondaryLocationWith(
+    provider: StorageProvider = createProvider,
     prefix: ObjectLocationPrefix = createObjectLocationPrefix
   ) =
     SecondaryStorageLocation(
-      provider = InfrequentAccessStorageProvider,
+      provider = provider,
       prefix = prefix
     )
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
@@ -62,7 +62,7 @@ class StorageManifestServiceTest
     val bagRoot = createObjectLocationPrefix
     val replicaRoot = bagRoot.asLocation(version.toString)
 
-    val sizeFinder: SizeFinder = (location: ObjectLocation) => Success(1L)
+    val sizeFinder: SizeFinder = (_: ObjectLocation) => Success(1L)
 
     val service = new StorageManifestService(sizeFinder)
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
@@ -84,7 +84,11 @@ class StorageManifestServiceTest
           createSecondaryLocationWith(BagVersion(3))
         )
 
-        assertIsError(location = location, replicas = replicas, version = version) { err =>
+        assertIsError(
+          location = location,
+          replicas = replicas,
+          version = version
+        ) { err =>
           err shouldBe a[StorageManifestException]
           err.getMessage should startWith("Malformed bag root in the replicas:")
         }
@@ -129,9 +133,11 @@ class StorageManifestServiceTest
     it("uses the correct roots on the replica locations") {
       val expectedPrefixes = replicas
         .map { _.prefix }
-        .map { prefix => prefix.copy(
-          path = prefix.path.stripSuffix(s"/$version")
-        )}
+        .map { prefix =>
+          prefix.copy(
+            path = prefix.path.stripSuffix(s"/$version")
+          )
+        }
 
       val actualPrefixes = storageManifest.replicaLocations.map { _.prefix }
 
@@ -466,10 +472,9 @@ class StorageManifestServiceTest
         fetchEntries = fetchEntries
       )
 
-      assertIsError(bag = bag, location = location, version = version) {
-        err =>
-          err shouldBe a[BadFetchLocationException]
-          err.getMessage shouldBe "Fetch entry for data/file1.txt refers to a file in the wrong path: /file1.txt"
+      assertIsError(bag = bag, location = location, version = version) { err =>
+        err shouldBe a[BadFetchLocationException]
+        err.getMessage shouldBe "Fetch entry for data/file1.txt refers to a file in the wrong path: /file1.txt"
       }
     }
   }
@@ -657,12 +662,14 @@ class StorageManifestServiceTest
 
   private def createManifest(
     bag: Bag = createBag,
-    location: PrimaryStorageLocation = createPrimaryLocationWith(version = BagVersion(1)),
+    location: PrimaryStorageLocation = createPrimaryLocationWith(
+      version = BagVersion(1)
+    ),
     replicas: Seq[SecondaryStorageLocation] = Seq.empty,
     space: StorageSpace = createStorageSpace,
     version: BagVersion = BagVersion(1),
-    sizeFinder: SizeFinder =
-      (location: ObjectLocation) => Success(Random.nextLong().abs)
+    sizeFinder: SizeFinder = (location: ObjectLocation) =>
+      Success(Random.nextLong().abs)
   ): StorageManifest = {
     val service = new StorageManifestService(sizeFinder)
 
@@ -689,19 +696,24 @@ class StorageManifestServiceTest
 
   def createPrimaryLocationWith(
     bagRoot: ObjectLocation,
-    version: BagVersion): PrimaryStorageLocation =
+    version: BagVersion
+  ): PrimaryStorageLocation =
     createPrimaryLocationWith(
       prefix = bagRoot.join(version.toString).asPrefix
     )
 
-  def createSecondaryLocationWith(version: BagVersion): SecondaryStorageLocation =
+  def createSecondaryLocationWith(
+    version: BagVersion
+  ): SecondaryStorageLocation =
     createSecondaryLocationWith(
       prefix = createObjectLocation.join(version.toString).asPrefix
     )
 
   private def assertIsError(
     bag: Bag = createBag,
-    location: PrimaryStorageLocation = createPrimaryLocationWith(version = BagVersion(1)),
+    location: PrimaryStorageLocation = createPrimaryLocationWith(
+      version = BagVersion(1)
+    ),
     replicas: Seq[SecondaryStorageLocation] = Seq.empty,
     version: BagVersion = BagVersion(1)
   )(assertError: Throwable => Assertion): Assertion = {

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/AggregatorInternalRecordTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/AggregatorInternalRecordTest.scala
@@ -1,8 +1,8 @@
 package uk.ac.wellcome.platform.storage.replica_aggregator.models
 
 import org.scalatest.{FunSpec, Matchers, TryValues}
+import uk.ac.wellcome.platform.archive.common.generators.StorageLocationGenerators
 import uk.ac.wellcome.platform.archive.common.storage.models.SecondaryStorageLocation
-import uk.ac.wellcome.platform.storage.replica_aggregator.generators.StorageLocationGenerators
 import uk.ac.wellcome.storage.generators.RandomThings
 
 class AggregatorInternalRecordTest

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorTest.scala
@@ -5,12 +5,12 @@ import java.time.Instant
 import org.scalatest.{EitherValues, FunSpec, Matchers, TryValues}
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.common.fixtures.StorageRandomThings
+import uk.ac.wellcome.platform.archive.common.generators.StorageLocationGenerators
 import uk.ac.wellcome.platform.archive.common.ingests.models.InfrequentAccessStorageProvider
 import uk.ac.wellcome.platform.archive.common.storage.models.{
   PrimaryStorageLocation,
   StorageLocation
 }
-import uk.ac.wellcome.platform.storage.replica_aggregator.generators.StorageLocationGenerators
 import uk.ac.wellcome.platform.storage.replica_aggregator.models._
 import uk.ac.wellcome.storage.maxima.memory.MemoryMaxima
 import uk.ac.wellcome.storage.store.memory.{MemoryStore, MemoryVersionedStore}

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaCounterTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaCounterTest.scala
@@ -2,7 +2,7 @@ package uk.ac.wellcome.platform.storage.replica_aggregator.services
 
 import org.scalatest.{EitherValues, FunSpec, Matchers}
 import uk.ac.wellcome.platform.archive.common.storage.models.KnownReplicas
-import uk.ac.wellcome.platform.storage.replica_aggregator.generators.StorageLocationGenerators
+import uk.ac.wellcome.platform.archive.common.generators.StorageLocationGenerators
 import uk.ac.wellcome.platform.storage.replica_aggregator.models.AggregatorInternalRecord
 
 class ReplicaCounterTest


### PR DESCRIPTION
The API for StorageManifestService is now:

```scala
def createManifest(
  bag: Bag,
  location: PrimaryStorageLocation,
  replicas: Seq[SecondaryStorageLocation],
  space: StorageSpace,
  version: BagVersion
): Try[StorageManifest]
```

and if you pass any replicas, their path is correctly checked and updated to the non-versioned value (e.g. if the path is `digitised/b1234/v1`, the *bag path* is `digitised/b1234`, so all file paths including fetch entries can be relative to this path).

Plus EVEN MOAR TESTS.

Part of https://github.com/wellcometrust/platform/issues/3845

I haven’t applied this to the register yet, because this was fiddly enough on its own – the old API still exists and has the same behaviour, and I’ll swap it out in a separate patch (plus bag register tests!).