### PR TITLE
Comment out two tasks in the Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,8 +21,9 @@ jobs:
     - env: SBT_PROJECT=replica_aggregator
 
     - env: SBT_PROJECT=notifier
-    - env: TASK=bagger-publish
-    - env: TASK=python_client-test
+
+    # - env: TASK=bagger-publish
+    # - env: TASK=python_client-test
 
 script:
   - ./.travis/run_job.py


### PR DESCRIPTION
There is such build contention in Travis, let's save ten minutes of build time a pop on two tasks that almost never change.