### PR TITLE
Include more context in the aggregator messages

### DIFF
--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/AggregatorInternalRecord.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/models/AggregatorInternalRecord.scala
@@ -24,6 +24,9 @@ case class AggregatorInternalRecord(
       record = this,
       storageLocation = storageLocation
     )
+
+  def count: Int =
+    (Seq(location).flatten ++ replicas).size
 }
 
 object AggregatorInternalRecord {

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorker.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorker.scala
@@ -88,6 +88,9 @@ class ReplicaAggregatorWorker[IngestDestination, OutgoingDestination](
             counterError = err,
             startTime = startTime,
             endTime = Instant.now()
+          ),
+          maybeUserFacingMessage = Some(
+            s"${aggregatorRecord.count} of ${replicaCounter.expectedReplicaCount} replicas complete"
           )
         )
 
@@ -98,7 +101,8 @@ class ReplicaAggregatorWorker[IngestDestination, OutgoingDestination](
             knownReplicas = knownReplicas,
             startTime = startTime,
             endTime = Instant.now()
-          )
+          ),
+          maybeUserFacingMessage = Some("all replicas complete")
         )
     }
 

--- a/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaCounter.scala
+++ b/replica_aggregator/src/main/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaCounter.scala
@@ -19,7 +19,7 @@ case class NotEnoughReplicas(
   *   - there are at least `expectedReplicas` overall
   *
   */
-class ReplicaCounter(expectedReplicaCount: Int) {
+class ReplicaCounter(val expectedReplicaCount: Int) {
   def countReplicas(
     record: AggregatorInternalRecord
   ): Either[ReplicaCounterError, KnownReplicas] =

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/ReplicaAggregatorFeatureTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/ReplicaAggregatorFeatureTest.scala
@@ -52,7 +52,7 @@ class ReplicaAggregatorFeatureTest
             ingestId = payload.ingestId,
             ingests = ingests,
             expectedDescriptions = Seq(
-              "Aggregating replicas succeeded"
+              "Aggregating replicas succeeded - all replicas complete"
             )
           )
 

--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
@@ -65,6 +65,10 @@ class ReplicaAggregatorWorkerTest
       completeAggregation.knownReplicas shouldBe expectedKnownReplicas
     }
 
+    it("includes a user-facing message") {
+      result.maybeUserFacingMessage shouldBe Some("all replicas complete")
+    }
+
     it("sends an outgoing message") {
       val expectedPayload = KnownReplicasPayload(
         context = payload.context,
@@ -80,7 +84,7 @@ class ReplicaAggregatorWorkerTest
         ingestId = payload.ingestId,
         ingests = ingests,
         expectedDescriptions = Seq(
-          "Aggregating replicas succeeded"
+          "Aggregating replicas succeeded - all replicas complete"
         )
       )
     }
@@ -127,6 +131,10 @@ class ReplicaAggregatorWorkerTest
       )
     }
 
+    it("includes a user-facing message") {
+      result.maybeUserFacingMessage shouldBe Some("1 of 3 replicas complete")
+    }
+
     it("does not send an outgoing message") {
       outgoing.getMessages[VersionedBagRootPayload] shouldBe empty
     }
@@ -136,7 +144,7 @@ class ReplicaAggregatorWorkerTest
         ingestId = payload.ingestId,
         ingests = ingests,
         expectedDescriptions = Seq(
-          "Aggregating replicas succeeded"
+          "Aggregating replicas succeeded - 1 of 3 replicas complete"
         )
       )
     }


### PR DESCRIPTION
Because the aggregator runs multiple times, it now includes a bit of context in the ingests monitor message, e.g.

> Aggregating replicas succeeded - 1 of 3 replicas complete

or

> Aggregating replicas succeeded - all replicas complete

Spun out as a separate piece from https://github.com/wellcometrust/storage-service/pull/352