### PR TITLE
Lock the replicator around the destination, not the ingest ID

### DIFF
--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorker.scala
@@ -102,7 +102,7 @@ class BagReplicatorWorker[
       )
 
       result <- lockingService
-        .withLock(payload.ingestId.toString) {
+        .withLock(dstPrefix.toString) {
           replicate(replicationRequest)
         }
         .map(lockFailed(replicationRequest).apply(_))

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/BagReplicatorWorkerTest.scala
@@ -207,7 +207,9 @@ class BagReplicatorWorkerTest
     }
   }
 
-  it("allows multiple workers for the same ingest to write to different locations") {
+  it(
+    "allows multiple workers for the same ingest to write to different locations"
+  ) {
     withLocalS3Bucket { srcBucket =>
       // We have to create enough files in the bag to keep the first
       // replicator busy, otherwise it completes and unlocks, and the
@@ -231,13 +233,21 @@ class BagReplicatorWorkerTest
 
       withLocalS3Bucket { dstBucket1 =>
         withLocalS3Bucket { dstBucket2 =>
-          withBagReplicatorWorker(bucket = dstBucket1, lockServiceDao = lockServiceDao) { worker1 =>
-            withBagReplicatorWorker(bucket = dstBucket2, lockServiceDao = lockServiceDao) { worker2 =>
+          withBagReplicatorWorker(
+            bucket = dstBucket1,
+            lockServiceDao = lockServiceDao
+          ) { worker1 =>
+            withBagReplicatorWorker(
+              bucket = dstBucket2,
+              lockServiceDao = lockServiceDao
+            ) { worker2 =>
               val futures =
-                Future.sequence(Seq(
-                  worker1.processPayload(payload),
-                  worker2.processPayload(payload)
-                ))
+                Future.sequence(
+                  Seq(
+                    worker1.processPayload(payload),
+                    worker2.processPayload(payload)
+                  )
+                )
 
               whenReady(futures) { result =>
                 result.count { _.isInstanceOf[IngestStepSucceeded[_]] } shouldBe 2


### PR DESCRIPTION
If you lock around the ingest ID, the Glacier and IA replications can't run simultaneously, and there's a 5-hour timeout on the queue. >.<

If you're writing to different destinations, it's fine to run replications concurrently. Desirable, even!

Discovered in #352.