### PR TITLE
Ensure API logs are written for requests

### DIFF
--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Main.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/Main.scala
@@ -38,14 +38,17 @@ object Main extends WellcomeTypesafeApp {
         StorageManifestDaoBuilder.build(config)
     }
 
+    val appName = "BagsApi"
+
     new WellcomeHttpApp(
       routes = router.bags,
       httpMetrics = new HttpMetrics(
-        name = "BagsApi",
+        name = appName,
         metrics = MetricsBuilder.buildMetricsSender(config)
       ),
       httpServerConfig = HTTPServerBuilder.buildHTTPServerConfig(config),
-      contextURL = contextURLMain
+      contextURL = contextURLMain,
+      appName = appName
     )
   }
 }

--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
@@ -49,6 +49,7 @@ trait BagsApiFixture
   )(testWith: TestWith[WellcomeHttpApp, R]): R =
     withActorSystem { implicit actorSystem =>
       withMaterializer(actorSystem) { implicit materializer =>
+
         val httpMetrics = new HttpMetrics(
           name = metricsName,
           metrics = metrics
@@ -65,7 +66,8 @@ trait BagsApiFixture
           routes = router.bags,
           httpMetrics = httpMetrics,
           httpServerConfig = httpServerConfigTest,
-          contextURL = contextURLTest
+          contextURL = contextURLTest,
+          appName = metricsName
         )
 
         app.run()

--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/fixtures/BagsApiFixture.scala
@@ -49,7 +49,6 @@ trait BagsApiFixture
   )(testWith: TestWith[WellcomeHttpApp, R]): R =
     withActorSystem { implicit actorSystem =>
       withMaterializer(actorSystem) { implicit materializer =>
-
         val httpMetrics = new HttpMetrics(
           name = metricsName,
           metrics = metrics

--- a/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/Main.scala
+++ b/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/Main.scala
@@ -33,11 +33,6 @@ object Main extends WellcomeTypesafeApp {
     implicit val materializer: ActorMaterializer =
       AkkaBuilder.buildActorMaterializer()
 
-    val httpMetrics = new HttpMetrics(
-      name = "IngestsApi",
-      metrics = MetricsBuilder.buildMetricsSender(config)
-    )
-
     implicit val dynamoClient: AmazonDynamoDB =
       DynamoBuilder.buildDynamoClient(config)
 
@@ -66,11 +61,19 @@ object Main extends WellcomeTypesafeApp {
       override val contextURL: URL = contextURLMain
     }
 
+    val appName = "IngestsApi"
+
+    val httpMetrics = new HttpMetrics(
+      name = appName,
+      metrics = MetricsBuilder.buildMetricsSender(config)
+    )
+
     new WellcomeHttpApp(
       routes = router.ingests,
       httpMetrics = httpMetrics,
       httpServerConfig = httpServerConfigMain,
-      contextURL = contextURLMain
+      contextURL = contextURLMain,
+      appName = appName
     )
   }
 }

--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/fixtures/IngestsApiFixture.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/fixtures/IngestsApiFixture.scala
@@ -70,7 +70,8 @@ trait IngestsApiFixture
               routes = ingestsApi.ingests,
               httpMetrics = httpMetrics,
               httpServerConfig = httpServerConfigTest,
-              contextURL = contextURLTest
+              contextURL = contextURLTest,
+              appName = metricsName
             )
 
             app.run()

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/http/WellcomeHttpApp.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/http/WellcomeHttpApp.scala
@@ -52,14 +52,18 @@ class WellcomeHttpApp(
       .bindAndHandle(
         handler = loggedHandler,
         interface = httpServerConfig.host,
-        port = httpServerConfig.port,
+        port = httpServerConfig.port
       )
 
-    info(s"$appTag - Starting: ${httpServerConfig.host}:${httpServerConfig.port}")
+    info(
+      s"$appTag - Starting: ${httpServerConfig.host}:${httpServerConfig.port}"
+    )
 
     for {
       server <- binding
-      _ = info(s"$appTag - Listening: ${httpServerConfig.host}:${httpServerConfig.port}")
+      _ = info(
+        s"$appTag - Listening: ${httpServerConfig.host}:${httpServerConfig.port}"
+      )
       _ <- server.whenTerminated
       _ = info(
         s"$appTag - Terminating: ${httpServerConfig.host}:${httpServerConfig.port}"


### PR DESCRIPTION
Log request/response cycle in API apps.

**Note:** this is not an access log and does not follow the [Common Log Format](https://en.wikipedia.org/wiki/Common_Log_Format), it instead uses the Akka HTTP `logRequestResult` default which is much more verbose, e.g.

```
[INFO] [08/23/2019 10:23:41.525] [default-akka.actor.default-dispatcher-3] [akka.actor.ActorSystemImpl(default)] BagsApiFixture/8204df7a-b0f2-49fa-8c67-536fd4d47da4: Response for
  Request : HttpRequest(HttpMethod(GET),http://localhost:1234/bags/FSb2L4jQ/O84bmz6a?version=v2,List(Host: localhost:1234, User-Agent: akka-http/10.1.5, Timeout-Access: <function1>),HttpEntity.Strict(none/none,ByteString()),HttpProtocol(HTTP/1.1))
  Response: Complete(HttpResponse(200 OK,List(),HttpEntity.Strict(application/json,{"@context":"http://api.wellcomecollection.org/storage/v1/context.json","id":"FSb2L4jQ/O84bmz6a","space":{"id":"FSb2L4jQ","type":"Space"},"info":{"externalIdentifier":"O84bmz6a","payloadOxum":"9139598493143876916.1786","baggingDate":"+1023813-02-16","sourceOrganization":"ySa3Cay2","externalDescription":"CHbptNsK","internalSenderIdentifier":"fc2Ue06n","internalSenderDescription":"YJ17mzPF","type":"BagInfo"},"manifest":{"checksumAlgorithm":"SHA-256","files":[{"checksum":"XNC2oPA3","name":"My9kdQhk","path":"My9kdQhk","size":6517536422375075416,"type":"File"},{"checksum":"HXkZL4W7","name":"19BF5U9E","path":"19BF5U9E","size":6611211372559748024,"type":"File"},{"checksum":"mpaYQrkz","name":"irQc1NT7","path":"irQc1NT7","size":3957129920248191884,"type":"File"}],"type":"BagManifest"},"tagManifest":{"checksumAlgorithm":"SHA-256","files":[{"checksum":"tlreP2VT","name":"V9VX8862","path":"V9VX8862","size":6698213871935505504,"type":"File"},{"checksum":"EXtV50ui","name":"bbnaDKzB","path":"bbnaDKzB","size":2493156778322182950,"type":"File"},{"checksum":"D9v93RnX","name":"kdfOSOM3","path":"kdfOSOM3","size":5516240721948523990,"type":"File"}],"type":"BagManifest"},"location":{"provider":{"id":"aws-s3-standard","type":"Provider"},"bucket":"tM1rG6MD","path":"v7IG5ftZ","type":"Location"},"replicaLocations":[{"provider":{"id":"aws-s3-standard","type":"Provider"},"bucket":"LCSIAIaJ","path":"rhL2coIn","type":"Location"},{"provider":{"id":"aws-s3-standard","type":"Provider"},"bucket":"XO0Qjkok","path":"aHP4BYnK","type":"Location"},{"provider":{"id":"aws-s3-standard","type":"Provider"},"bucket":"EMatCybu","path":"jwjbbQZp","type":"Location"},{"provider":{"id":"aws-s3-standard","type":"Provider"},"bucket":"8ctF4GME","path":"AtfJMcgQ","type":"Location"},{"provider":{"id":"aws-s3-standard","type":"Provider"},"bucket":"fOugu8DH","path":"BYkA7aOS","type":"Location"}],"createdDate":"2019-08-23T09:23:38.581587Z","version":"v2","type":"Bag"}),HttpProtocol(HTTP/1.1)))
```

`WellcomeHttpApp` logs now have a process specific identifier, e.g. `BagsApi/8204df7a-b0f2-49fa-8c67-536fd4d47da4` the UUID is unique to an instance of `WellcomeHttpApp` in order to follow application threads with greater ease.

_Proper access logs (if necessary) can be handled outside the application._
