### PR TITLE
Bump the max receive count on the verifier queues

### DIFF
--- a/terraform/modules/queue/variables.tf
+++ b/terraform/modules/queue/variables.tf
@@ -16,7 +16,7 @@ variable "visibility_timeout_seconds" {
 }
 
 variable "max_receive_count" {
-  default = "3"
+  default = 3
 }
 
 variable "queue_high_actions" {

--- a/terraform/modules/stack/replicator_verifier_pair/messaging.tf
+++ b/terraform/modules/stack/replicator_verifier_pair/messaging.tf
@@ -16,8 +16,6 @@ module "bag_replicator_input_queue" {
   # avoid messages appearing to time out and fail.
   visibility_timeout_seconds = "${60 * 60 * 5}"
 
-  max_receive_count = 1
-
   queue_high_actions = [
     "${module.bag_replicator.scale_up_arn}",
   ]
@@ -54,8 +52,6 @@ module "bag_verifier_queue" {
   # We keep a high visibility timeout to
   # avoid messages appearing to time out and fail.
   visibility_timeout_seconds = "${60 * 60 * 5}"
-
-  max_receive_count = 1
 
   queue_high_actions = [
     "${module.bag_verifier.scale_up_arn}",


### PR DESCRIPTION
This means we won't lose messages if a task gets scaled away midway through processing a message.