### PR TITLE
Add IngestId to StorageManifest

### DIFF
--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/Register.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/Register.scala
@@ -29,6 +29,7 @@ class Register(
     version: BagVersion,
     space: StorageSpace
   ): Try[IngestStepResult[RegistrationSummary]] = {
+
     val registration = RegistrationSummary(
       ingestId = ingestId,
       startTime = Instant.now(),
@@ -44,6 +45,7 @@ class Register(
       }
 
       storageManifest <- storageManifestService.createManifest(
+        ingestId = ingestId,
         bag = bag,
         location = location,
         replicas = replicas,

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageManifest.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageManifest.scala
@@ -2,15 +2,9 @@ package uk.ac.wellcome.platform.archive.common.storage.models
 
 import java.time.Instant
 
-import uk.ac.wellcome.platform.archive.common.bagit.models.{
-  BagId,
-  BagInfo,
-  BagVersion
-}
-import uk.ac.wellcome.platform.archive.common.verify.{
-  ChecksumValue,
-  HashingAlgorithm
-}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, BagInfo, BagVersion}
+import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
+import uk.ac.wellcome.platform.archive.common.verify.{ChecksumValue, HashingAlgorithm}
 
 case class StorageManifestFile(
   checksum: ChecksumValue,
@@ -32,7 +26,8 @@ case class StorageManifest(
   tagManifest: FileManifest,
   location: StorageLocation,
   replicaLocations: Seq[StorageLocation],
-  createdDate: Instant
+  createdDate: Instant,
+  ingestId: IngestID
 ) {
   val id = BagId(space, info.externalIdentifier)
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageManifest.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageManifest.scala
@@ -2,9 +2,16 @@ package uk.ac.wellcome.platform.archive.common.storage.models
 
 import java.time.Instant
 
-import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, BagInfo, BagVersion}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  BagId,
+  BagInfo,
+  BagVersion
+}
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
-import uk.ac.wellcome.platform.archive.common.verify.{ChecksumValue, HashingAlgorithm}
+import uk.ac.wellcome.platform.archive.common.verify.{
+  ChecksumValue,
+  HashingAlgorithm
+}
 
 case class StorageManifestFile(
   checksum: ChecksumValue,

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
@@ -3,14 +3,9 @@ package uk.ac.wellcome.platform.archive.common.storage.services
 import java.time.Instant
 
 import grizzled.slf4j.Logging
-import uk.ac.wellcome.platform.archive.common.bagit.models.{
-  Bag,
-  BagManifest,
-  BagPath,
-  BagVersion,
-  MatchedLocation
-}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{Bag, BagManifest, BagPath, BagVersion, MatchedLocation}
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagMatcher
+import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
 import uk.ac.wellcome.platform.archive.common.storage.models._
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 
@@ -24,6 +19,7 @@ class BadFetchLocationException(message: String)
 
 class StorageManifestService(sizeFinder: SizeFinder) extends Logging {
   def createManifest(
+    ingestId: IngestID,
     bag: Bag,
     location: PrimaryStorageLocation,
     replicas: Seq[SecondaryStorageLocation],
@@ -72,7 +68,8 @@ class StorageManifestService(sizeFinder: SizeFinder) extends Logging {
           prefix = bagRoot
         ),
         replicaLocations = replicaLocations,
-        createdDate = Instant.now
+        createdDate = Instant.now,
+        ingestId = ingestId
       )
     } yield storageManifest
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
@@ -3,7 +3,13 @@ package uk.ac.wellcome.platform.archive.common.storage.services
 import java.time.Instant
 
 import grizzled.slf4j.Logging
-import uk.ac.wellcome.platform.archive.common.bagit.models.{Bag, BagManifest, BagPath, BagVersion, MatchedLocation}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  Bag,
+  BagManifest,
+  BagPath,
+  BagVersion,
+  MatchedLocation
+}
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagMatcher
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
 import uk.ac.wellcome.platform.archive.common.storage.models._

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
@@ -3,7 +3,7 @@ package uk.ac.wellcome.platform.archive.common.generators
 import java.time.Instant
 
 import uk.ac.wellcome.platform.archive.common.bagit.models.{BagInfo, BagVersion}
-import uk.ac.wellcome.platform.archive.common.ingests.models.StandardStorageProvider
+import uk.ac.wellcome.platform.archive.common.ingests.models.{IngestID, StandardStorageProvider}
 import uk.ac.wellcome.platform.archive.common.storage.models._
 import uk.ac.wellcome.platform.archive.common.verify.{HashingAlgorithm, SHA256}
 import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
@@ -29,6 +29,7 @@ trait StorageManifestGenerators
   }
 
   def createStorageManifestWith(
+    ingestId: IngestID = createIngestID,
     space: StorageSpace = createStorageSpace,
     bagInfo: BagInfo = createBagInfo,
     version: BagVersion = BagVersion(Random.nextInt)
@@ -64,7 +65,8 @@ trait StorageManifestGenerators
             prefix = createObjectLocationPrefix
           )
         },
-      createdDate = Instant.now
+      createdDate = Instant.now,
+      ingestId = ingestId
     )
 
   def createStorageManifest: StorageManifest =

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/generators/StorageManifestGenerators.scala
@@ -3,7 +3,10 @@ package uk.ac.wellcome.platform.archive.common.generators
 import java.time.Instant
 
 import uk.ac.wellcome.platform.archive.common.bagit.models.{BagInfo, BagVersion}
-import uk.ac.wellcome.platform.archive.common.ingests.models.{IngestID, StandardStorageProvider}
+import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  IngestID,
+  StandardStorageProvider
+}
 import uk.ac.wellcome.platform.archive.common.storage.models._
 import uk.ac.wellcome.platform.archive.common.verify.{HashingAlgorithm, SHA256}
 import uk.ac.wellcome.storage.generators.ObjectLocationGenerators

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
@@ -3,25 +3,11 @@ package uk.ac.wellcome.platform.archive.common.storage.services
 import java.net.URI
 
 import org.scalatest.{Assertion, FunSpec, Matchers, TryValues}
-import uk.ac.wellcome.platform.archive.common.bagit.models.{
-  Bag,
-  BagFetchEntry,
-  BagPath,
-  BagVersion
-}
-import uk.ac.wellcome.platform.archive.common.generators.{
-  BagFileGenerators,
-  BagGenerators,
-  StorageLocationGenerators,
-  StorageSpaceGenerators
-}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{Bag, BagFetchEntry, BagPath, BagVersion}
+import uk.ac.wellcome.platform.archive.common.generators.{BagFileGenerators, BagGenerators, StorageLocationGenerators, StorageSpaceGenerators}
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.TimeTestFixture
-import uk.ac.wellcome.platform.archive.common.storage.models.{
-  PrimaryStorageLocation,
-  SecondaryStorageLocation,
-  StorageManifest,
-  StorageSpace
-}
+import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
+import uk.ac.wellcome.platform.archive.common.storage.models.{PrimaryStorageLocation, SecondaryStorageLocation, StorageManifest, StorageSpace}
 import uk.ac.wellcome.platform.archive.common.verify.{MD5, SHA256}
 import uk.ac.wellcome.storage.ObjectLocation
 
@@ -540,6 +526,7 @@ class StorageManifestServiceTest
       val service = new StorageManifestService(brokenSizeFinder)
 
       val result = service.createManifest(
+        ingestId = createIngestID,
         bag = bag,
         location = location,
         replicas = Seq.empty,
@@ -661,6 +648,7 @@ class StorageManifestServiceTest
   }
 
   private def createManifest(
+    ingestId: IngestID = createIngestID,
     bag: Bag = createBag,
     location: PrimaryStorageLocation = createPrimaryLocationWith(
       version = BagVersion(1)
@@ -674,6 +662,7 @@ class StorageManifestServiceTest
     val service = new StorageManifestService(sizeFinder)
 
     val result = service.createManifest(
+      ingestId = ingestId,
       bag = bag,
       location = location,
       replicas = replicas,
@@ -710,6 +699,7 @@ class StorageManifestServiceTest
     )
 
   private def assertIsError(
+    ingestId: IngestID = createIngestID,
     bag: Bag = createBag,
     location: PrimaryStorageLocation = createPrimaryLocationWith(
       version = BagVersion(1)
@@ -724,6 +714,7 @@ class StorageManifestServiceTest
     val service = new StorageManifestService(sizeFinder)
 
     val result = service.createManifest(
+      ingestId = ingestId,
       bag = bag,
       location = location,
       replicas = replicas,

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
@@ -3,11 +3,26 @@ package uk.ac.wellcome.platform.archive.common.storage.services
 import java.net.URI
 
 import org.scalatest.{Assertion, FunSpec, Matchers, TryValues}
-import uk.ac.wellcome.platform.archive.common.bagit.models.{Bag, BagFetchEntry, BagPath, BagVersion}
-import uk.ac.wellcome.platform.archive.common.generators.{BagFileGenerators, BagGenerators, StorageLocationGenerators, StorageSpaceGenerators}
+import uk.ac.wellcome.platform.archive.common.bagit.models.{
+  Bag,
+  BagFetchEntry,
+  BagPath,
+  BagVersion
+}
+import uk.ac.wellcome.platform.archive.common.generators.{
+  BagFileGenerators,
+  BagGenerators,
+  StorageLocationGenerators,
+  StorageSpaceGenerators
+}
 import uk.ac.wellcome.platform.archive.common.ingests.fixtures.TimeTestFixture
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
-import uk.ac.wellcome.platform.archive.common.storage.models.{PrimaryStorageLocation, SecondaryStorageLocation, StorageManifest, StorageSpace}
+import uk.ac.wellcome.platform.archive.common.storage.models.{
+  PrimaryStorageLocation,
+  SecondaryStorageLocation,
+  StorageManifest,
+  StorageSpace
+}
 import uk.ac.wellcome.platform.archive.common.verify.{MD5, SHA256}
 import uk.ac.wellcome.storage.ObjectLocation
 

--- a/scripts/ss_report_stats.py
+++ b/scripts/ss_report_stats.py
@@ -69,7 +69,7 @@ for page in paginator.paginate(TableName="storage-ingests"):
             last_event = max(
                 event["createdDate"] for event in item["payload"]["events"]
             )
-        except KeyError:
+        except (KeyError, TypeError):
             last_event = item["payload"]["createdDate"]
 
         last_event = NOW - dt.datetime.fromtimestamp(int(last_event) / 1000)


### PR DESCRIPTION
So we can identify to which ingest a manifest relates.

More specifically this will allow us to identify duplicate messages received by the register.

**Note:** This will require us to truncate what the storage service knows about already as it changes the internal model.