### PR TITLE
In the stat reporting script, show failure reasons

### DIFF
--- a/scripts/ss_report_stats.py
+++ b/scripts/ss_report_stats.py
@@ -77,7 +77,10 @@ for page in paginator.paginate(TableName="storage-ingests"):
         ingest_id = item["id"]
 
         if status == "Failed":
-            failed[ingest_id] = last_event
+            failed[ingest_id] = {
+                "date": last_event,
+                "description": item["payload"]["events"][-1]["description"]
+            }
         if status == "Processing":
             processing[ingest_id] = last_event
 
@@ -95,11 +98,11 @@ if failed:
     print("== failed ==")
 
     lines = [
-        "%s ~> %s" % (ingest_id, to_s(date))
-        for (ingest_id, date) in sorted(failed.items(), key=lambda t: t[1])
+        "%s ~> %s" % (ingest_id, data["description"])
+        for (ingest_id, data) in sorted(failed.items(), key=lambda t: t[1]["date"])
     ]
 
-    print(termcolor.colored("\n".join(lines[-5:]), "red"))
+    print(termcolor.colored("\n".join(lines), "red"))
     print("== failed ==\n")
 
 if processing:

--- a/scripts/ss_report_stats.py
+++ b/scripts/ss_report_stats.py
@@ -80,7 +80,7 @@ for page in paginator.paginate(TableName="storage-ingests"):
         if status == "Failed":
             failed[ingest_id] = {
                 "date": last_event,
-                "description": item["payload"]["events"][-1]["description"]
+                "description": item["payload"]["events"][-1]["description"],
             }
         if status == "Processing":
             processing[ingest_id] = last_event
@@ -97,12 +97,18 @@ def to_s(last_event):
 
 if failed:
     for ingest_id, ingest_data in failed.items():
-        if ingest_data["description"].startswith("Unpacking failed - There is no archive at"):
-            ingest_data["description"] = "Unpacking failed - There is no archive at <src>"
-        if ingest_data["description"].startswith((
-            "Verification (Amazon Glacier) failed -",
-        )):
-            ingest_data["description"] = ingest_data["description"].split("-")[0].strip()
+        if ingest_data["description"].startswith(
+            "Unpacking failed - There is no archive at"
+        ):
+            ingest_data[
+                "description"
+            ] = "Unpacking failed - There is no archive at <src>"
+        if ingest_data["description"].startswith(
+            ("Verification (Amazon Glacier) failed -",)
+        ):
+            ingest_data["description"] = (
+                ingest_data["description"].split("-")[0].strip()
+            )
 
     failed_by_reason = collections.defaultdict(list)
 


### PR DESCRIPTION
New output makes it much easier to see why bags are failing, like so:

```
== failed ==
Unpacking failed - There is no archive at <src>:
  77be0aab-9cc2-47b2-bdbb-1e7baa5cbce6
  f455046b-0a11-439e-bfe5-0bbab73630c1
  0d5c93b3-39c4-45f3-89f1-6298f3620c60
  da919ccc-0120-46eb-a7c3-622caa2e68cc
  26ead225-853a-4339-8555-2994a9fe9277
  ad2ddfb4-e059-4875-ad48-04f53b6db4ec
  1cf8f2ab-e52f-4e26-93bc-63a78dac3602
  c7b20c40-d9d8-478f-b940-654abe57625d
  2cff5cc4-77df-4b29-a5d9-b8b45a35d6fd
  24285a29-4912-4faf-a1d0-29bcfa27d79f
  353102f4-998b-4abc-bf85-9285404c860a
  c35d9510-ea0b-4b83-b287-0e1bbfc322a1
  10b86287-bc28-45a4-abee-e81a4d2fff68
  42aae2aa-43c9-4950-8066-34cba0553fe3
  09eb09a6-a03b-4010-b48f-ec38134c54a0
  a23bc9db-3de1-4681-a607-e5274c229961
  6823398e-a8c0-4ccc-b108-9a65bb5bbc75
  6d386ca8-c416-4e8d-8f95-80609020eecd
  c355522d-5726-4df9-b7c7-88da803ba5db
  9035a64c-6b75-4c0a-b8bd-82a3af169652
  89d73161-064f-4c5a-92d2-0f47b5bfc567
  67e57df4-51ac-46c6-aa11-2141480f3ae4
  43af19b8-37f2-43e1-bbaf-3bd136cbb578
  5035ee7d-4255-4a41-b3b5-1d88fc4f8981
  a8a5bd03-217e-4d8d-a90a-e74a39d9e268
  65bb3fc3-f100-473a-940c-56efb1ecbc7f
  1a569558-eaaa-42a4-8f6d-ba5da1294774
  62e63c83-fd17-42a9-9940-a8efd131c31f
  ba0318de-4d86-4023-af2f-bec4abbff9da
  0a401e93-8a4c-4602-b70a-1811dadd3969
  d39fda03-c59e-4076-911e-884ac2f6cb59
  d88554c5-234d-43b3-90ec-58a82a24f486
  4c891513-3f94-4213-9946-6f6a6c7f0047
  5860a182-a5e3-40cf-804f-1d4bcdf9dfad
  63aaf7bc-b039-4b81-ba0b-548c8b1deb35
  8446b5a4-4227-4bb0-9405-4f6885d0dc92
  1408744f-47bf-40ea-9262-464299b31291
  f1d37073-82c5-460f-aa1d-524a6098e8ab
  2b1dc7e4-288f-4c93-9994-fade9fad2d8f
  53d116dd-fe8b-4fe2-a95b-17a2c8c180be
  709518a4-165e-4838-a89b-24f5928f6382
  9b4309d7-3862-4429-a23d-1ade686361ee
  80091906-5517-4283-85b3-d44e89fdf7f3
  48d4d2f9-e1b0-4359-9cc2-4cfa611a004a
  c00a0fd8-4fb4-44f1-bf07-2a16f6b35ea6
  6ddb2ba5-3d93-4530-bb54-38a71ec53c33
  55fcad8a-14bd-4cb5-8cbe-87dac3db6c34
  c1513816-bb78-4bea-a0dc-4b7d23c2f65b
  2894a534-f16b-4e32-9664-c25b723be08a
  b2a5e548-3453-4a2a-98ca-136c76321455
  07397d21-7232-4d42-91cf-de8da8daf984

Verification (Amazon Glacier) failed:
  83c0a5bd-e813-4c80-bfb6-7c94bc094418

Aggregating replicas succeeded - 1 of 2 replicas complete:
  2c9ecfcd-5072-41dc-8359-e6cd29255d6a

Aggregating replicas failed:
  c7e53f4d-e6d7-4854-87b8-6e577e288d4b
  f38674e9-5148-4a87-adb5-ac2d1f7d2ff1
  58408609-1a19-4536-894a-45e8ec9713f8
== failed ==
```

Ingests are grouped by the reason they failed, so we have some idea what the most common failures are and where we need to start looking for error messages. I used this to find https://github.com/wellcometrust/platform/issues/3896, and we can trace down others too.