### PR TITLE
Adds LargeResponses trait

### DIFF
--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/LargeResponses.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/LargeResponses.scala
@@ -1,0 +1,79 @@
+package uk.ac.wellcome.platform.archive.common.storage
+
+import java.net.URL
+
+import akka.http.scaladsl.model.headers.{ETag, Location}
+import akka.http.scaladsl.model.{HttpResponse, StatusCodes}
+import akka.http.scaladsl.server.Directives.mapResponse
+import akka.http.scaladsl.server.Route
+import akka.stream.ActorMaterializer
+import grizzled.slf4j.Logging
+import uk.ac.wellcome.platform.archive.common.storage.services.S3Uploader
+import uk.ac.wellcome.storage.ObjectLocationPrefix
+import uk.ac.wellcome.storage.streaming.InputStreamWithLengthAndMetadata
+
+import scala.concurrent.duration.Duration
+
+trait LargeResponses extends Logging {
+
+  import java.util.UUID
+
+  import akka.stream.scaladsl.StreamConverters
+
+  val s3Uploader: S3Uploader
+  val maximumResponseByteLength: Long
+  val prefix: ObjectLocationPrefix
+  val cacheDuration: Duration
+
+  private val converter = StreamConverters.asInputStream()
+
+  implicit val materializer: ActorMaterializer
+
+  def wrapLargeResponses(route: Route): Route =
+    mapResponse(storeAndRedirect)(route)
+
+  private def storeAndRedirect(response: HttpResponse): HttpResponse = {
+    response.entity.contentLengthOption match {
+      case Some(length) if length > maximumResponseByteLength => {
+
+        val storageKey = response
+          .header[ETag]
+          .map(_.toString)
+          .getOrElse(UUID.randomUUID().toString)
+
+        val objectLocation = prefix.asLocation(storageKey)
+
+        val inputStream = response.entity
+          .getDataBytes()
+          .runWith(converter, materializer)
+
+        val content = new InputStreamWithLengthAndMetadata(
+          inputStream = inputStream,
+          length = length,
+          metadata = Map.empty
+        )
+
+        val uploaded = s3Uploader.uploadAndGetURL(
+          location = objectLocation,
+          content = content,
+          expiryLength = cacheDuration
+        )
+
+        uploaded match {
+          case Right(url: URL) =>
+            HttpResponse(
+              status = StatusCodes.TemporaryRedirect,
+              headers = Location(url.toExternalForm) :: Nil
+            )
+          case Left(err) =>
+            error(err)
+            HttpResponse(
+              status = StatusCodes.InternalServerError
+            )
+        }
+      }
+
+      case _ => response
+    }
+  }
+}

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/LargeResponses.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/LargeResponses.scala
@@ -38,7 +38,7 @@ trait LargeResponses extends Logging {
 
         val storageKey = response
           .header[ETag]
-          .map(_.value.replace("\"",""))
+          .map(_.value.replace("\"", ""))
           .getOrElse(UUID.randomUUID().toString)
 
         val objectLocation = prefix.asLocation(storageKey)

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/LargeResponses.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/LargeResponses.scala
@@ -38,7 +38,7 @@ trait LargeResponses extends Logging {
 
         val storageKey = response
           .header[ETag]
-          .map(_.toString)
+          .map(_.value.replace("\"",""))
           .getOrElse(UUID.randomUUID().toString)
 
         val objectLocation = prefix.asLocation(storageKey)

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/LargeResponsesTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/LargeResponsesTest.scala
@@ -1,0 +1,137 @@
+package uk.ac.wellcome.platform.archive.common.storage
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.headers.Location
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse, StatusCodes}
+import akka.http.scaladsl.server.Directives.{complete, get}
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.StreamConverters
+import org.apache.commons.io.IOUtils
+import org.scalatest.FunSpec
+import uk.ac.wellcome.akka.fixtures.Akka
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.platform.archive.common.storage.services.S3Uploader
+import uk.ac.wellcome.storage.ObjectLocationPrefix
+import uk.ac.wellcome.storage.fixtures.S3Fixtures
+import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket
+import uk.ac.wellcome.storage.generators.RandomThings
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import scala.concurrent.{Await, Future}
+
+class LargeResponsesTest
+    extends FunSpec
+    with S3Fixtures
+    with RandomThings
+    with Akka {
+
+  private val converter = StreamConverters.asInputStream()
+
+  describe("LargeResponsesTest") {
+
+    it("does not redirect a < max-length response") {
+      withLocalS3Bucket { bucket =>
+        withActorSystem { implicit actorSystem =>
+          withMaterializer(actorSystem) { implicit mat =>
+            val maxBytes = 100
+            val expectedByteArray = randomBytes(maxBytes - 10)
+
+            withLargeResponderResult(bucket, maxBytes, expectedByteArray) {
+              response: HttpResponse =>
+                val inputStream = response.entity
+                  .getDataBytes()
+                  .runWith(converter, mat)
+
+                val actualByteArray = IOUtils.toByteArray(inputStream)
+
+                response.status shouldBe StatusCodes.OK
+                actualByteArray shouldBe expectedByteArray
+
+            }
+          }
+        }
+      }
+    }
+
+    it("redirects a > max-length response") {
+      withLocalS3Bucket { bucket =>
+        withActorSystem { implicit actorSystem =>
+          withMaterializer(actorSystem) { implicit mat =>
+            val maxBytes = 100
+            val expectedByteArray = randomBytes(maxBytes + 10)
+
+            withLargeResponderResult(bucket, maxBytes, expectedByteArray) {
+              response: HttpResponse =>
+                response.status shouldBe StatusCodes.TemporaryRedirect
+
+                val redirectLocation = response.header[Location].get
+
+                val madeRequest = Http()
+                  .singleRequest(HttpRequest(uri = redirectLocation.uri))
+
+                val madeRequestResult: HttpResponse = Await.result(madeRequest, 10.seconds)
+
+                madeRequestResult.status shouldBe StatusCodes.OK
+                val inputStream = madeRequestResult.entity
+                  .getDataBytes()
+                  .runWith(converter, mat)
+
+                val actualByteArray = IOUtils.toByteArray(inputStream)
+
+                actualByteArray shouldBe expectedByteArray
+            }
+          }
+        }
+      }
+    }
+  }
+
+  private def withLargeResponderResult[R](
+    bucket: Bucket,
+    maxBytes: Int,
+    testBytes: Array[Byte]
+  )(testWith: TestWith[HttpResponse, R])(
+    implicit mat: ActorMaterializer,
+    as: ActorSystem
+  ) = {
+
+    val uploader = new S3Uploader()
+
+    val objectLocationPrefix =
+      ObjectLocationPrefix(bucket.name, randomAlphanumeric)
+    val duration = 30 seconds
+
+    val largeResponder = new LargeResponses {
+      override val s3Uploader: S3Uploader = uploader
+      override val maximumResponseByteLength: Long = maxBytes
+      override val prefix: ObjectLocationPrefix = objectLocationPrefix
+      override val cacheDuration: Duration = duration
+      override implicit val materializer: ActorMaterializer = mat
+    }
+
+    val routes = largeResponder.wrapLargeResponses(get {
+      complete(testBytes)
+    })
+
+    val binding: Future[Http.ServerBinding] =
+      Http().bindAndHandle(routes, "127.0.0.1", 8080)
+
+    val madeRequest = Http()
+      .singleRequest(HttpRequest(uri = "http://127.0.0.1:8080"))
+
+    val madeRequestResult: HttpResponse = Await.result(madeRequest, 1.seconds)
+
+    val result = testWith(madeRequestResult)
+
+    Await
+      .result(binding, 1.seconds)
+      .terminate(hardDeadline = 1.seconds)
+      .flatMap { _ =>
+        as.terminate()
+      }
+
+    result
+  }
+}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/LargeResponsesTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/LargeResponsesTest.scala
@@ -71,7 +71,8 @@ class LargeResponsesTest
                 val madeRequest = Http()
                   .singleRequest(HttpRequest(uri = redirectLocation.uri))
 
-                val madeRequestResult: HttpResponse = Await.result(madeRequest, 10.seconds)
+                val madeRequestResult: HttpResponse =
+                  Await.result(madeRequest, 10.seconds)
 
                 madeRequestResult.status shouldBe StatusCodes.OK
                 val inputStream = madeRequestResult.entity


### PR DESCRIPTION
Allows routes providing responses in excess of a given byte length to store those responses in S3 and provide redirection to a signed S3 URL.

For wellcometrust/platform#3937