### PR TITLE
Add ETag to Bag API responses

### DIFF
--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApi.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApi.scala
@@ -129,14 +129,19 @@ trait BagsApi extends Logging {
             )
 
           case Right(manifests) =>
-            complete(
-              DisplayResultList(
-                context = contextURL.toString,
-                results = manifests.map {
-                  ResultListEntry(_)
-                }
+            val etagValue = manifests.map(_.idWithVersion).mkString("&")
+            val etag = ETag(etagValue)
+
+            respondWithHeaders(etag) {
+              complete(
+                DisplayResultList(
+                  context = contextURL.toString,
+                  results = manifests.map {
+                    ResultListEntry(_)
+                  }
+                )
               )
-            )
+            }
 
           case Left(err) =>
             error(s"Error while trying to look up versions of $bagId", err.e)

--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApi.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApi.scala
@@ -4,6 +4,7 @@ import java.net.URL
 
 import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.model.StatusCodes._
+import akka.http.scaladsl.model.headers.ETag
 import akka.http.scaladsl.server.Route
 import grizzled.slf4j.Logging
 import io.circe.Printer
@@ -68,12 +69,17 @@ trait BagsApi extends Logging {
 
           result match {
             case Right(storageManifest) =>
-              complete(
-                ResponseDisplayBag(
-                  storageManifest = storageManifest,
-                  contextUrl = contextURL
+              val etag = ETag(storageManifest.idWithVersion)
+              
+              respondWithHeaders(etag) {
+                complete(
+                  ResponseDisplayBag(
+                    storageManifest = storageManifest,
+                    contextUrl = contextURL
+                  )
                 )
-              )
+              }
+
             case Left(_: NoVersionExistsError) =>
               val errorMessage = maybeVersion match {
                 case Some(version) =>

--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApi.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApi.scala
@@ -70,7 +70,7 @@ trait BagsApi extends Logging {
           result match {
             case Right(storageManifest) =>
               val etag = ETag(storageManifest.idWithVersion)
-              
+
               respondWithHeaders(etag) {
                 complete(
                   ResponseDisplayBag(

--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
@@ -10,7 +10,11 @@ import org.scalatest.concurrent.IntegrationPatience
 import org.scalatest.{FunSpec, Matchers}
 import uk.ac.wellcome.json.utils.JsonAssertions
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion
-import uk.ac.wellcome.platform.archive.common.generators.{BagIdGenerators, BagInfoGenerators, StorageManifestGenerators}
+import uk.ac.wellcome.platform.archive.common.generators.{
+  BagIdGenerators,
+  BagInfoGenerators,
+  StorageManifestGenerators
+}
 import uk.ac.wellcome.platform.archive.common.http.HttpMetricResults
 import uk.ac.wellcome.platform.archive.display.fixtures.DisplayJsonHelpers
 import uk.ac.wellcome.platform.storage.bags.api.fixtures.BagsApiFixture
@@ -67,7 +71,7 @@ class BagsApiFeatureTest
             }
 
             val header: ETag = response.header[ETag].get
-            val etagValue = header.etag.value.replace("\"","")
+            val etagValue = header.etag.value.replace("\"", "")
 
             etagValue shouldBe storageManifest.idWithVersion
 
@@ -131,7 +135,7 @@ class BagsApiFeatureTest
               }
 
               val header: ETag = response.header[ETag].get
-              val etagValue = header.etag.value.replace("\"","")
+              val etagValue = header.etag.value.replace("\"", "")
 
               etagValue shouldBe storageManifest.idWithVersion
 
@@ -328,10 +332,11 @@ class BagsApiFeatureTest
               assertJsonStringsAreEqual(actualJson, expectedJson)
             }
 
-            val expectedEtagValue = initialManifests.map(_.idWithVersion).mkString("&")
+            val expectedEtagValue =
+              initialManifests.map(_.idWithVersion).mkString("&")
 
             val header: ETag = response.header[ETag].get
-            val etagValue = header.etag.value.replace("\"","")
+            val etagValue = header.etag.value.replace("\"", "")
 
             etagValue shouldBe expectedEtagValue
 
@@ -419,13 +424,12 @@ class BagsApiFeatureTest
               assertJsonStringsAreEqual(actualJson, expectedJson)
             }
 
-            val expectedEtagValue = initialManifests
-              .reverse
+            val expectedEtagValue = initialManifests.reverse
               .map(_.idWithVersion)
               .mkString("&")
 
             val header: ETag = response.header[ETag].get
-            val etagValue = header.etag.value.replace("\"","")
+            val etagValue = header.etag.value.replace("\"", "")
 
             etagValue shouldBe expectedEtagValue
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageManifest.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageManifest.scala
@@ -37,4 +37,5 @@ case class StorageManifest(
   ingestId: IngestID
 ) {
   val id = BagId(space, info.externalIdentifier)
+  val idWithVersion = s"${id}/${version}"
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3Uploader.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3Uploader.scala
@@ -28,6 +28,8 @@ import scala.util.{Failure, Success, Try}
 class S3Uploader(implicit s3Client: AmazonS3) {
   private val s3StreamStore: S3StreamStore = new S3StreamStore()
 
+
+  // TODO: Ensure idempotency in puts by key
   def uploadAndGetURL(
     location: ObjectLocation,
     content: InputStreamWithLengthAndMetadata,

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3Uploader.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3Uploader.scala
@@ -27,7 +27,7 @@ import scala.util.{Failure, Success, Try}
   */
 class S3Uploader(implicit s3Client: AmazonS3) {
   private val s3StreamStore: S3StreamStore = new S3StreamStore()
-  
+
   def uploadAndGetURL(
     location: ObjectLocation,
     content: InputStreamWithLengthAndMetadata,

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3Uploader.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/S3Uploader.scala
@@ -27,9 +27,7 @@ import scala.util.{Failure, Success, Try}
   */
 class S3Uploader(implicit s3Client: AmazonS3) {
   private val s3StreamStore: S3StreamStore = new S3StreamStore()
-
-
-  // TODO: Ensure idempotency in puts by key
+  
   def uploadAndGetURL(
     location: ObjectLocation,
     content: InputStreamWithLengthAndMetadata,


### PR DESCRIPTION
In order to properly respond to requests for storage manifests exceeding the 10MB API Gateway limit we need to utilise the upcoming large response logic (https://github.com/wellcometrust/storage-service/pull/382). 

For that we will need a unique ETag in order to allow proper caching (in S3 of large responses).

For https://github.com/wellcometrust/platform/issues/3937