### PR TITLE
Update scala-storage to 7.24.3

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object WellcomeDependencies {
     val json = "1.1.1"
     val messaging = "5.3.1"
     val monitoring = "2.3.0"
-    val storage = "7.24.1"
+    val storage = "7.24.3"
     val typesafe = "1.0.0"
   }
 


### PR DESCRIPTION
Incorporate RetryableError when VersionAlreadyExistsError to eliminate errors when aggregating replicas in the replica_aggregator.

See https://github.com/wellcometrust/scala-storage/blob/master/CHANGELOG.md