### PR TITLE
Always have at least 3 retries on every queue

### DIFF
--- a/terraform/modules/stack/messaging.tf
+++ b/terraform/modules/stack/messaging.tf
@@ -121,8 +121,6 @@ module "bag_unpacker_queue" {
   # avoid messages appearing to time out and fail.
   visibility_timeout_seconds = "${60 * 60 * 5}"
 
-  max_receive_count = 1
-
   queue_high_actions = [
     "${module.bag_unpacker.scale_up_arn}",
   ]
@@ -192,8 +190,6 @@ module "bag_verifier_pre_replicate_queue" {
   # We keep a high visibility timeout to
   # avoid messages appearing to time out and fail.
   visibility_timeout_seconds = "${60 * 60 * 5}"
-
-  max_receive_count = 1
 
   queue_high_actions = [
     "${module.bag_verifier_pre_replication.scale_up_arn}",


### PR DESCRIPTION
If we deploy a new version of a service, ECS stops any instances of the old service.  This means we lose any work that was in-flight.

If the SQS queue has retries >1, the message will eventually be retried (albeit after a delay, from the queue visibility timeout).  If we don't have retries, the message will get dropped and not retried, and the ingest will be eternally processing.