### PR TITLE
Check the ingestType when assigning the version

### DIFF
--- a/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/VersionPicker.scala
+++ b/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/VersionPicker.scala
@@ -9,8 +9,10 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.{
   ExternalIdentifier
 }
 import uk.ac.wellcome.platform.archive.common.ingests.models.{
+  CreateIngestType,
   IngestID,
-  IngestType
+  IngestType,
+  UpdateIngestType
 }
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 import uk.ac.wellcome.platform.archive.common.versioning.dynamo.DynamoID
@@ -69,16 +71,13 @@ class VersionPicker(
     ingestType: IngestType,
     assignedVersion: BagVersion
   ): Either[VersionPickerError, BagVersion] =
-    // TODO: This is stubbed out for the purposes of the migration,
-    // but we should restore it later.
-    Right(assignedVersion)
-//    if (ingestType == CreateIngestType && assignedVersion > 1) {
-//      Left(IngestTypeCreateForExistingBag())
-//    } else if (ingestType == UpdateIngestType && assignedVersion == 1) {
-//      Left(IngestTypeUpdateForNewBag())
-//    } else {
-//      Right(assignedVersion)
-//    }
+    if (ingestType == CreateIngestType && assignedVersion.underlying > 1) {
+      Left(IngestTypeCreateForExistingBag())
+    } else if (ingestType == UpdateIngestType && assignedVersion.underlying == 1) {
+      Left(IngestTypeUpdateForNewBag())
+    } else {
+      Right(assignedVersion)
+    }
 
   // Annoyingly, cats doesn't provide an Implicit for MonadError[Id, Throwable],
   // so we have to implement one ourselves.

--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/services/BagVersionerTest.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/services/BagVersionerTest.scala
@@ -52,7 +52,7 @@ class BagVersionerTest
     }
   }
 
-  ignore("fails if you ask for ingestType 'update' on a new bag") {
+  it("fails if you ask for ingestType 'update' on a new bag") {
     val externalIdentifier = createExternalIdentifier
     val storageSpace = createStorageSpace
 
@@ -75,7 +75,7 @@ class BagVersionerTest
     }
   }
 
-  ignore("fails if you ask for ingestType 'create' on an existing bag") {
+  it("fails if you ask for ingestType 'create' on an existing bag") {
     val externalIdentifier = createExternalIdentifier
     val storageSpace = createStorageSpace
 

--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/VersionPickerTest.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/VersionPickerTest.scala
@@ -287,7 +287,7 @@ class VersionPickerTest
   }
 
   describe("checking the ingest type") {
-    ignore("only allows ingest type 'create' once") {
+    it("only allows ingest type 'create' once") {
       val externalIdentifier = createExternalIdentifier
       val storageSpace = createStorageSpace
 
@@ -312,7 +312,7 @@ class VersionPickerTest
       }
     }
 
-    ignore("only allows ingest type 'update' on an already-existing bag") {
+    it("only allows ingest type 'update' on an already-existing bag") {
       val externalIdentifier = createExternalIdentifier
       val storageSpace = createStorageSpace
 


### PR DESCRIPTION
Restores the checks that were removed in https://github.com/wellcometrust/platform/issues/3732