### PR TITLE
Tidy up the bag versioner

### DIFF
--- a/bag_versioner/docker-compose.yml
+++ b/bag_versioner/docker-compose.yml
@@ -1,5 +1,9 @@
 sqs:
-  image: s12v/elasticmq
+  image: "s12v/elasticmq"
   ports:
     - "9324:9324"
     - "4789:9324"
+dynamodb:
+  image: "peopleperhour/dynamodb"
+  ports:
+    - "45678:8000"

--- a/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/Main.scala
+++ b/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/Main.scala
@@ -20,16 +20,18 @@ import uk.ac.wellcome.platform.archive.common.config.builders.{
   OperationNameBuilder,
   OutgoingPublisherBuilder
 }
-import uk.ac.wellcome.platform.archive.common.versioning.IngestVersionManagerError
-import uk.ac.wellcome.platform.archive.common.versioning.dynamo.{
-  DynamoIngestVersionManager,
-  DynamoIngestVersionManagerDao
-}
 import uk.ac.wellcome.platform.storage.bag_versioner.services.{
   BagVersioner,
   BagVersionerWorker
 }
-import uk.ac.wellcome.platform.storage.bag_versioner.versioning.VersionPicker
+import uk.ac.wellcome.platform.storage.bag_versioner.versioning.dynamo.{
+  DynamoIngestVersionManager,
+  DynamoIngestVersionManagerDao
+}
+import uk.ac.wellcome.platform.storage.bag_versioner.versioning.{
+  IngestVersionManagerError,
+  VersionPicker
+}
 import uk.ac.wellcome.storage.locking.dynamo.DynamoLockingService
 import uk.ac.wellcome.storage.typesafe.{DynamoBuilder, DynamoLockDaoBuilder}
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp

--- a/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/services/BagVersioner.scala
+++ b/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/services/BagVersioner.scala
@@ -56,16 +56,16 @@ class BagVersioner(versionPicker: VersionPicker) {
             maybeUserFacingMessage = Some(s"Assigned bag version $version")
           )
 
-        case Left(auditError) =>
+        case Left(error) =>
           IngestFailed(
             BagVersionerFailureSummary(
               ingestId = ingestId,
               startTime = startTime,
               endTime = Instant.now()
             ),
-            e = getUnderlyingThrowable(auditError),
+            e = getUnderlyingThrowable(error),
             maybeUserFacingMessage =
-              UserFacingMessages.createMessage(ingestId, auditError)
+              UserFacingMessages.createMessage(ingestId, error)
           )
       }
     }
@@ -74,6 +74,6 @@ class BagVersioner(versionPicker: VersionPicker) {
     error match {
       case UnableToAssignVersion(internalError: IngestVersionManagerDaoError) =>
         internalError.e
-      case err => new Throwable(s"Unexpected error in the auditor: $err")
+      case err => new Throwable(s"Unexpected error in the bag versioner: $err")
     }
 }

--- a/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/services/BagVersioner.scala
+++ b/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/services/BagVersioner.scala
@@ -13,9 +13,9 @@ import uk.ac.wellcome.platform.archive.common.storage.models.{
   IngestStepSucceeded,
   StorageSpace
 }
-import uk.ac.wellcome.platform.archive.common.versioning.IngestVersionManagerDaoError
 import uk.ac.wellcome.platform.storage.bag_versioner.models._
 import uk.ac.wellcome.platform.storage.bag_versioner.versioning.{
+  IngestVersionManagerDaoError,
   UnableToAssignVersion,
   VersionPicker,
   VersionPickerError

--- a/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/services/UserFacingMessages.scala
+++ b/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/services/UserFacingMessages.scala
@@ -2,16 +2,7 @@ package uk.ac.wellcome.platform.storage.bag_versioner.services
 
 import grizzled.slf4j.Logging
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
-import uk.ac.wellcome.platform.archive.common.versioning.{
-  ExternalIdentifiersMismatch,
-  NewerIngestAlreadyExists
-}
-import uk.ac.wellcome.platform.storage.bag_versioner.versioning.{
-  IngestTypeCreateForExistingBag,
-  IngestTypeUpdateForNewBag,
-  UnableToAssignVersion,
-  VersionPickerError
-}
+import uk.ac.wellcome.platform.storage.bag_versioner.versioning._
 
 object UserFacingMessages extends Logging {
   def createMessage(

--- a/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/IngestVersionManager.scala
+++ b/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/IngestVersionManager.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.versioning
+package uk.ac.wellcome.platform.storage.bag_versioner.versioning
 
 import java.time.Instant
 

--- a/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/IngestVersionManagerDao.scala
+++ b/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/IngestVersionManagerDao.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.versioning
+package uk.ac.wellcome.platform.storage.bag_versioner.versioning
 
 import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID

--- a/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/IngestVersionManagerError.scala
+++ b/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/IngestVersionManagerError.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.versioning
+package uk.ac.wellcome.platform.storage.bag_versioner.versioning
 
 import java.time.Instant
 

--- a/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/VersionPicker.scala
+++ b/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/VersionPicker.scala
@@ -15,11 +15,7 @@ import uk.ac.wellcome.platform.archive.common.ingests.models.{
   UpdateIngestType
 }
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.platform.archive.common.versioning.dynamo.DynamoID
-import uk.ac.wellcome.platform.archive.common.versioning.{
-  IngestVersionManager,
-  IngestVersionManagerError
-}
+import uk.ac.wellcome.platform.archive.common.storage.models.dynamo.DynamoID
 import uk.ac.wellcome.storage.locking.{FailedProcess, LockDao, LockingService}
 
 class VersionPicker(

--- a/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/VersionPickerError.scala
+++ b/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/VersionPickerError.scala
@@ -1,7 +1,5 @@
 package uk.ac.wellcome.platform.storage.bag_versioner.versioning
 
-import uk.ac.wellcome.platform.archive.common.versioning.IngestVersionManagerError
-
 sealed trait VersionPickerError
 
 case class InternalVersionPickerError(e: Throwable) extends VersionPickerError

--- a/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/VersionRecord.scala
+++ b/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/VersionRecord.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.versioning
+package uk.ac.wellcome.platform.storage.bag_versioner.versioning
 
 import java.time.Instant
 

--- a/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/dynamo/DynamoIngestVersionManager.scala
+++ b/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/dynamo/DynamoIngestVersionManager.scala
@@ -1,0 +1,6 @@
+package uk.ac.wellcome.platform.storage.bag_versioner.versioning.dynamo
+
+import uk.ac.wellcome.platform.storage.bag_versioner.versioning.IngestVersionManager
+
+class DynamoIngestVersionManager(val dao: DynamoIngestVersionManagerDao)
+    extends IngestVersionManager

--- a/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/dynamo/DynamoIngestVersionManagerDao.scala
+++ b/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/dynamo/DynamoIngestVersionManagerDao.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.versioning.dynamo
+package uk.ac.wellcome.platform.storage.bag_versioner.versioning.dynamo
 
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB
 import org.scanamo.auto._
@@ -8,7 +8,8 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.platform.archive.common.versioning.{
+import uk.ac.wellcome.platform.archive.common.storage.models.dynamo.DynamoID
+import uk.ac.wellcome.platform.storage.bag_versioner.versioning.{
   IngestVersionManagerDao,
   VersionRecord
 }

--- a/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/dynamo/DynamoVersionRecord.scala
+++ b/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/dynamo/DynamoVersionRecord.scala
@@ -1,10 +1,11 @@
-package uk.ac.wellcome.platform.archive.common.versioning.dynamo
+package uk.ac.wellcome.platform.storage.bag_versioner.versioning.dynamo
 
 import java.time.Instant
 
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
-import uk.ac.wellcome.platform.archive.common.versioning.VersionRecord
+import uk.ac.wellcome.platform.archive.common.storage.models.dynamo.DynamoID
+import uk.ac.wellcome.platform.storage.bag_versioner.versioning.VersionRecord
 import uk.ac.wellcome.storage.dynamo.DynamoHashRangeKeyPair
 
 import scala.util.Try

--- a/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/memory/MemoryIngestVersionManager.scala
+++ b/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/memory/MemoryIngestVersionManager.scala
@@ -1,0 +1,7 @@
+package uk.ac.wellcome.platform.storage.bag_versioner.versioning.memory
+
+import uk.ac.wellcome.platform.storage.bag_versioner.versioning.IngestVersionManager
+
+class MemoryIngestVersionManager(
+  val dao: MemoryIngestVersionManagerDao = new MemoryIngestVersionManagerDao()
+) extends IngestVersionManager

--- a/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/memory/MemoryIngestVersionManagerDao.scala
+++ b/bag_versioner/src/main/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/memory/MemoryIngestVersionManagerDao.scala
@@ -1,9 +1,9 @@
-package uk.ac.wellcome.platform.archive.common.versioning.memory
+package uk.ac.wellcome.platform.storage.bag_versioner.versioning.memory
 
 import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.platform.archive.common.versioning.{
+import uk.ac.wellcome.platform.storage.bag_versioner.versioning.{
   IngestVersionManagerDao,
   VersionRecord
 }

--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/BagVersionerFeatureTest.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/BagVersionerFeatureTest.scala
@@ -35,7 +35,8 @@ class BagVersionerFeatureTest
 
     val payload = createBagRootLocationPayloadWith(
       context = createPipelineContextWith(
-        storageSpace = storageSpace
+        storageSpace = storageSpace,
+        ingestType = CreateIngestType
       ),
       bagRoot = bagRoot
     )
@@ -49,7 +50,7 @@ class BagVersionerFeatureTest
     withLocalSqsQueue { queue =>
       val ingests = new MemoryMessageSender()
       val outgoing = new MemoryMessageSender()
-      withAuditorWorker(queue, ingests, outgoing, stepName = "auditing bag") {
+      withBagVersionerWorker(queue, ingests, outgoing, stepName = "assigning bag version") {
         _ =>
           sendNotificationToSQS(queue, payload)
 
@@ -67,7 +68,7 @@ class BagVersionerFeatureTest
 
                 ingestUpdates(0) shouldBe a[IngestEventUpdate]
                 ingestUpdates(0).events.map { _.description } shouldBe Seq(
-                  "Auditing bag started"
+                  "Assigning bag version started"
                 )
 
                 ingestUpdates(1) shouldBe a[IngestVersionUpdate]
@@ -75,7 +76,7 @@ class BagVersionerFeatureTest
                   .asInstanceOf[IngestVersionUpdate]
                   .version shouldBe BagVersion(1)
                 ingestUpdates(1).events.map { _.description } shouldBe Seq(
-                  "Auditing bag succeeded - assigned bag version v1"
+                  "Assigning bag version succeeded - assigned bag version v1"
                 )
             }
           }
@@ -107,7 +108,7 @@ class BagVersionerFeatureTest
     val outgoing = new MemoryMessageSender()
 
     withLocalSqsQueue { queue =>
-      withAuditorWorker(queue, ingests, outgoing, stepName = "auditing bag") {
+      withBagVersionerWorker(queue, ingests, outgoing, stepName = "assigning bag version") {
         _ =>
           // Send the initial payload with "create" and check it completes
           sendNotificationToSQS(queue, payload1)
@@ -124,7 +125,7 @@ class BagVersionerFeatureTest
 
                 ingestUpdates(0) shouldBe a[IngestEventUpdate]
                 ingestUpdates(0).events.map { _.description } shouldBe Seq(
-                  "Auditing bag started"
+                  "Assigning bag version started"
                 )
 
                 ingestUpdates(1) shouldBe a[IngestVersionUpdate]
@@ -132,7 +133,7 @@ class BagVersionerFeatureTest
                   .asInstanceOf[IngestVersionUpdate]
                   .version shouldBe BagVersion(1)
                 ingestUpdates(1).events.map { _.description } shouldBe Seq(
-                  "Auditing bag succeeded - assigned bag version v1"
+                  "Assigning bag version succeeded - assigned bag version v1"
                 )
             }
           }
@@ -152,7 +153,7 @@ class BagVersionerFeatureTest
 
                 ingestUpdates(0) shouldBe a[IngestEventUpdate]
                 ingestUpdates(0).events.map { _.description } shouldBe Seq(
-                  "Auditing bag started"
+                  "Assigning bag version started"
                 )
 
                 ingestUpdates(1) shouldBe a[IngestVersionUpdate]
@@ -160,12 +161,12 @@ class BagVersionerFeatureTest
                   .asInstanceOf[IngestVersionUpdate]
                   .version shouldBe BagVersion(1)
                 ingestUpdates(1).events.map { _.description } shouldBe Seq(
-                  "Auditing bag succeeded - assigned bag version v1"
+                  "Assigning bag version succeeded - assigned bag version v1"
                 )
 
                 ingestUpdates(2) shouldBe a[IngestEventUpdate]
                 ingestUpdates(2).events.map { _.description } shouldBe Seq(
-                  "Auditing bag started"
+                  "Assigning bag version started"
                 )
 
                 ingestUpdates(3) shouldBe a[IngestVersionUpdate]
@@ -173,7 +174,7 @@ class BagVersionerFeatureTest
                   .asInstanceOf[IngestVersionUpdate]
                   .version shouldBe BagVersion(2)
                 ingestUpdates(3).events.map { _.description } shouldBe Seq(
-                  "Auditing bag succeeded - assigned bag version v2"
+                  "Assigning bag version succeeded - assigned bag version v2"
                 )
             }
           }

--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/BagVersionerFeatureTest.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/BagVersionerFeatureTest.scala
@@ -50,36 +50,40 @@ class BagVersionerFeatureTest
     withLocalSqsQueue { queue =>
       val ingests = new MemoryMessageSender()
       val outgoing = new MemoryMessageSender()
-      withBagVersionerWorker(queue, ingests, outgoing, stepName = "assigning bag version") {
-        _ =>
-          sendNotificationToSQS(queue, payload)
+      withBagVersionerWorker(
+        queue,
+        ingests,
+        outgoing,
+        stepName = "assigning bag version"
+      ) { _ =>
+        sendNotificationToSQS(queue, payload)
 
-          eventually {
-            assertQueueEmpty(queue)
+        eventually {
+          assertQueueEmpty(queue)
 
-            outgoing
-              .getMessages[VersionedBagRootPayload] shouldBe Seq(
-              expectedPayload
-            )
+          outgoing
+            .getMessages[VersionedBagRootPayload] shouldBe Seq(
+            expectedPayload
+          )
 
-            assertTopicReceivesIngestUpdates(payload.ingestId, ingests) {
-              ingestUpdates =>
-                ingestUpdates should have size 2
+          assertTopicReceivesIngestUpdates(payload.ingestId, ingests) {
+            ingestUpdates =>
+              ingestUpdates should have size 2
 
-                ingestUpdates(0) shouldBe a[IngestEventUpdate]
-                ingestUpdates(0).events.map { _.description } shouldBe Seq(
-                  "Assigning bag version started"
-                )
+              ingestUpdates(0) shouldBe a[IngestEventUpdate]
+              ingestUpdates(0).events.map { _.description } shouldBe Seq(
+                "Assigning bag version started"
+              )
 
-                ingestUpdates(1) shouldBe a[IngestVersionUpdate]
-                ingestUpdates(1)
-                  .asInstanceOf[IngestVersionUpdate]
-                  .version shouldBe BagVersion(1)
-                ingestUpdates(1).events.map { _.description } shouldBe Seq(
-                  "Assigning bag version succeeded - assigned bag version v1"
-                )
-            }
+              ingestUpdates(1) shouldBe a[IngestVersionUpdate]
+              ingestUpdates(1)
+                .asInstanceOf[IngestVersionUpdate]
+                .version shouldBe BagVersion(1)
+              ingestUpdates(1).events.map { _.description } shouldBe Seq(
+                "Assigning bag version succeeded - assigned bag version v1"
+              )
           }
+        }
       }
     }
   }
@@ -108,76 +112,80 @@ class BagVersionerFeatureTest
     val outgoing = new MemoryMessageSender()
 
     withLocalSqsQueue { queue =>
-      withBagVersionerWorker(queue, ingests, outgoing, stepName = "assigning bag version") {
-        _ =>
-          // Send the initial payload with "create" and check it completes
-          sendNotificationToSQS(queue, payload1)
+      withBagVersionerWorker(
+        queue,
+        ingests,
+        outgoing,
+        stepName = "assigning bag version"
+      ) { _ =>
+        // Send the initial payload with "create" and check it completes
+        sendNotificationToSQS(queue, payload1)
 
-          eventually {
-            assertQueueEmpty(queue)
+        eventually {
+          assertQueueEmpty(queue)
 
-            outgoing
-              .getMessages[VersionedBagRootPayload] should have size 1
+          outgoing
+            .getMessages[VersionedBagRootPayload] should have size 1
 
-            assertTopicReceivesIngestUpdates(payload1.ingestId, ingests) {
-              ingestUpdates =>
-                ingestUpdates should have size 2
+          assertTopicReceivesIngestUpdates(payload1.ingestId, ingests) {
+            ingestUpdates =>
+              ingestUpdates should have size 2
 
-                ingestUpdates(0) shouldBe a[IngestEventUpdate]
-                ingestUpdates(0).events.map { _.description } shouldBe Seq(
-                  "Assigning bag version started"
-                )
+              ingestUpdates(0) shouldBe a[IngestEventUpdate]
+              ingestUpdates(0).events.map { _.description } shouldBe Seq(
+                "Assigning bag version started"
+              )
 
-                ingestUpdates(1) shouldBe a[IngestVersionUpdate]
-                ingestUpdates(1)
-                  .asInstanceOf[IngestVersionUpdate]
-                  .version shouldBe BagVersion(1)
-                ingestUpdates(1).events.map { _.description } shouldBe Seq(
-                  "Assigning bag version succeeded - assigned bag version v1"
-                )
-            }
+              ingestUpdates(1) shouldBe a[IngestVersionUpdate]
+              ingestUpdates(1)
+                .asInstanceOf[IngestVersionUpdate]
+                .version shouldBe BagVersion(1)
+              ingestUpdates(1).events.map { _.description } shouldBe Seq(
+                "Assigning bag version succeeded - assigned bag version v1"
+              )
           }
+        }
 
-          // Now send the payload with "update"
-          sendNotificationToSQS(queue, payload2)
+        // Now send the payload with "update"
+        sendNotificationToSQS(queue, payload2)
 
-          eventually {
-            assertQueueEmpty(queue)
+        eventually {
+          assertQueueEmpty(queue)
 
-            outgoing
-              .getMessages[VersionedBagRootPayload] should have size 2
+          outgoing
+            .getMessages[VersionedBagRootPayload] should have size 2
 
-            assertTopicReceivesIngestUpdates(payload1.ingestId, ingests) {
-              ingestUpdates =>
-                ingestUpdates should have size 4
+          assertTopicReceivesIngestUpdates(payload1.ingestId, ingests) {
+            ingestUpdates =>
+              ingestUpdates should have size 4
 
-                ingestUpdates(0) shouldBe a[IngestEventUpdate]
-                ingestUpdates(0).events.map { _.description } shouldBe Seq(
-                  "Assigning bag version started"
-                )
+              ingestUpdates(0) shouldBe a[IngestEventUpdate]
+              ingestUpdates(0).events.map { _.description } shouldBe Seq(
+                "Assigning bag version started"
+              )
 
-                ingestUpdates(1) shouldBe a[IngestVersionUpdate]
-                ingestUpdates(1)
-                  .asInstanceOf[IngestVersionUpdate]
-                  .version shouldBe BagVersion(1)
-                ingestUpdates(1).events.map { _.description } shouldBe Seq(
-                  "Assigning bag version succeeded - assigned bag version v1"
-                )
+              ingestUpdates(1) shouldBe a[IngestVersionUpdate]
+              ingestUpdates(1)
+                .asInstanceOf[IngestVersionUpdate]
+                .version shouldBe BagVersion(1)
+              ingestUpdates(1).events.map { _.description } shouldBe Seq(
+                "Assigning bag version succeeded - assigned bag version v1"
+              )
 
-                ingestUpdates(2) shouldBe a[IngestEventUpdate]
-                ingestUpdates(2).events.map { _.description } shouldBe Seq(
-                  "Assigning bag version started"
-                )
+              ingestUpdates(2) shouldBe a[IngestEventUpdate]
+              ingestUpdates(2).events.map { _.description } shouldBe Seq(
+                "Assigning bag version started"
+              )
 
-                ingestUpdates(3) shouldBe a[IngestVersionUpdate]
-                ingestUpdates(3)
-                  .asInstanceOf[IngestVersionUpdate]
-                  .version shouldBe BagVersion(2)
-                ingestUpdates(3).events.map { _.description } shouldBe Seq(
-                  "Assigning bag version succeeded - assigned bag version v2"
-                )
-            }
+              ingestUpdates(3) shouldBe a[IngestVersionUpdate]
+              ingestUpdates(3)
+                .asInstanceOf[IngestVersionUpdate]
+                .version shouldBe BagVersion(2)
+              ingestUpdates(3).events.map { _.description } shouldBe Seq(
+                "Assigning bag version succeeded - assigned bag version v2"
+              )
           }
+        }
       }
     }
   }

--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/fixtures/VersionPickerFixtures.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/fixtures/VersionPickerFixtures.scala
@@ -5,9 +5,11 @@ import java.util.UUID
 import cats.Id
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion
-import uk.ac.wellcome.platform.archive.common.versioning.IngestVersionManagerError
-import uk.ac.wellcome.platform.archive.common.versioning.memory.MemoryIngestVersionManager
-import uk.ac.wellcome.platform.storage.bag_versioner.versioning.VersionPicker
+import uk.ac.wellcome.platform.storage.bag_versioner.versioning.memory.MemoryIngestVersionManager
+import uk.ac.wellcome.platform.storage.bag_versioner.versioning.{
+  IngestVersionManagerError,
+  VersionPicker
+}
 import uk.ac.wellcome.storage.locking.{LockDao, LockingService}
 import uk.ac.wellcome.storage.locking.memory.MemoryLockDao
 

--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/services/BagVersionerTest.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/services/BagVersionerTest.scala
@@ -33,8 +33,8 @@ class BagVersionerTest
     val externalIdentifier = createExternalIdentifier
     val storageSpace = createStorageSpace
 
-    withBagAuditor { bagAuditor =>
-      val maybeAudit = bagAuditor.getSummary(
+    withBagVersioner { bagVersioner =>
+      val maybeVersion = bagVersioner.getSummary(
         ingestId = createIngestID,
         ingestDate = Instant.now,
         ingestType = CreateIngestType,
@@ -42,7 +42,7 @@ class BagVersionerTest
         storageSpace = storageSpace
       )
 
-      val result = maybeAudit.success.get
+      val result = maybeVersion.success.get
       result.maybeUserFacingMessage shouldBe Some("Assigned bag version v1")
 
       val summary = result.summary
@@ -56,8 +56,8 @@ class BagVersionerTest
     val externalIdentifier = createExternalIdentifier
     val storageSpace = createStorageSpace
 
-    withBagAuditor { bagAuditor =>
-      val maybeAudit = bagAuditor.getSummary(
+    withBagVersioner { bagVersioner =>
+      val maybeVersion = bagVersioner.getSummary(
         ingestId = createIngestID,
         ingestDate = Instant.now,
         ingestType = UpdateIngestType,
@@ -65,7 +65,7 @@ class BagVersionerTest
         storageSpace = storageSpace
       )
 
-      val result = maybeAudit.success.get
+      val result = maybeVersion.success.get
       result shouldBe a[IngestFailed[_]]
 
       result.summary shouldBe a[BagVersionerFailureSummary]
@@ -79,8 +79,8 @@ class BagVersionerTest
     val externalIdentifier = createExternalIdentifier
     val storageSpace = createStorageSpace
 
-    withBagAuditor { bagAuditor =>
-      bagAuditor.getSummary(
+    withBagVersioner { bagVersioner =>
+      bagVersioner.getSummary(
         ingestId = createIngestID,
         ingestDate = Instant.ofEpochSecond(1),
         ingestType = CreateIngestType,
@@ -88,7 +88,7 @@ class BagVersionerTest
         storageSpace = storageSpace
       )
 
-      val maybeAudit = bagAuditor.getSummary(
+      val maybeVersion = bagVersioner.getSummary(
         ingestId = createIngestID,
         ingestDate = Instant.ofEpochSecond(2),
         ingestType = CreateIngestType,
@@ -96,7 +96,7 @@ class BagVersionerTest
         storageSpace = storageSpace
       )
 
-      val result = maybeAudit.success.get
+      val result = maybeVersion.success.get
       result shouldBe a[IngestFailed[_]]
 
       result.summary shouldBe a[BagVersionerFailureSummary]

--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/IngestVersionManagerDaoTestCases.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/IngestVersionManagerDaoTestCases.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.versioning
+package uk.ac.wellcome.platform.storage.bag_versioner.versioning
 
 import org.scalatest._
 import uk.ac.wellcome.fixtures.TestWith

--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/IngestVersionManagerTestCases.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/IngestVersionManagerTestCases.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.versioning
+package uk.ac.wellcome.platform.storage.bag_versioner.versioning
 
 import java.time.Instant
 

--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/VersionPickerTest.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/VersionPickerTest.scala
@@ -17,10 +17,6 @@ import uk.ac.wellcome.platform.archive.common.ingests.models.{
   UpdateIngestType
 }
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.platform.archive.common.versioning.{
-  ExternalIdentifiersMismatch,
-  NewerIngestAlreadyExists
-}
 import uk.ac.wellcome.platform.storage.bag_versioner.fixtures.VersionPickerFixtures
 import uk.ac.wellcome.storage.locking.{LockDao, LockFailure, UnlockFailure}
 

--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/VersionRecordGenerators.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/VersionRecordGenerators.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.versioning
+package uk.ac.wellcome.platform.storage.bag_versioner.versioning
 
 import java.time.Instant
 

--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/dynamo/DynamoIngestVersionManagerDaoTest.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/dynamo/DynamoIngestVersionManagerDaoTest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.versioning.dynamo
+package uk.ac.wellcome.platform.storage.bag_versioner.versioning.dynamo
 
 import java.time.temporal.ChronoUnit
 
@@ -9,7 +9,7 @@ import org.scanamo.time.JavaTimeFormats._
 import org.scanamo.{Table => ScanamoTable}
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
-import uk.ac.wellcome.platform.archive.common.versioning.{
+import uk.ac.wellcome.platform.storage.bag_versioner.versioning.{
   IngestVersionManagerDao,
   IngestVersionManagerDaoTestCases,
   VersionRecord

--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/dynamo/DynamoIngestVersionManagerTest.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/dynamo/DynamoIngestVersionManagerTest.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.versioning.dynamo
+package uk.ac.wellcome.platform.storage.bag_versioner.versioning.dynamo
 
 import org.scanamo.auto._
 import org.scanamo.time.JavaTimeFormats._
@@ -6,7 +6,7 @@ import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.platform.archive.common.versioning.{
+import uk.ac.wellcome.platform.storage.bag_versioner.versioning.{
   IngestVersionManager,
   IngestVersionManagerTestCases,
   VersionRecord

--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/dynamo/DynamoVersionRecordTest.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/dynamo/DynamoVersionRecordTest.scala
@@ -1,11 +1,11 @@
-package uk.ac.wellcome.platform.archive.common.versioning.dynamo
+package uk.ac.wellcome.platform.storage.bag_versioner.versioning.dynamo
 
 import java.time.Instant
 
 import org.scalatest.{FunSpec, Matchers, TryValues}
 import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.platform.archive.common.versioning.VersionRecordGenerators
+import uk.ac.wellcome.platform.storage.bag_versioner.versioning.VersionRecordGenerators
 
 class DynamoVersionRecordTest
     extends FunSpec

--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/dynamo/IngestVersionManagerTable.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/dynamo/IngestVersionManagerTable.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.versioning.dynamo
+package uk.ac.wellcome.platform.storage.bag_versioner.versioning.dynamo
 
 import com.amazonaws.services.dynamodbv2.model._
 import uk.ac.wellcome.fixtures.TestWith

--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/memory/MemoryIngestVersionManagerDaoTest.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/memory/MemoryIngestVersionManagerDaoTest.scala
@@ -1,7 +1,7 @@
-package uk.ac.wellcome.platform.archive.common.versioning.memory
+package uk.ac.wellcome.platform.storage.bag_versioner.versioning.memory
 
 import uk.ac.wellcome.fixtures.TestWith
-import uk.ac.wellcome.platform.archive.common.versioning.{
+import uk.ac.wellcome.platform.storage.bag_versioner.versioning.{
   IngestVersionManagerDao,
   IngestVersionManagerDaoTestCases,
   VersionRecord

--- a/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/memory/MemoryIngestVersionManagerTest.scala
+++ b/bag_versioner/src/test/scala/uk/ac/wellcome/platform/storage/bag_versioner/versioning/memory/MemoryIngestVersionManagerTest.scala
@@ -1,10 +1,10 @@
-package uk.ac.wellcome.platform.archive.common.versioning.memory
+package uk.ac.wellcome.platform.storage.bag_versioner.versioning.memory
 
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
-import uk.ac.wellcome.platform.archive.common.versioning.{
+import uk.ac.wellcome.platform.storage.bag_versioner.versioning.{
   IngestVersionManager,
   IngestVersionManagerTestCases,
   VersionRecord

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/dynamo/DynamoID.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/dynamo/DynamoID.scala
@@ -1,4 +1,4 @@
-package uk.ac.wellcome.platform.archive.common.versioning.dynamo
+package uk.ac.wellcome.platform.archive.common.storage.models.dynamo
 
 import java.net.{URLDecoder, URLEncoder}
 import java.nio.charset.StandardCharsets

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/dynamo/DynamoStorageManifestDao.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/dynamo/DynamoStorageManifestDao.scala
@@ -10,11 +10,11 @@ import uk.ac.wellcome.json.JsonUtil._
 import uk.ac.wellcome.platform.archive.common.bagit.models.{BagId, BagVersion}
 import uk.ac.wellcome.platform.archive.common.bagit.models.BagVersion._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifest
+import uk.ac.wellcome.platform.archive.common.storage.models.dynamo.DynamoID
 import uk.ac.wellcome.platform.archive.common.storage.services.{
   EmptyMetadata,
   StorageManifestDao
 }
-import uk.ac.wellcome.platform.archive.common.versioning.dynamo.DynamoID
 import uk.ac.wellcome.storage.{
   ObjectLocation,
   ObjectLocationPrefix,

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/versioning/dynamo/DynamoIngestVersionManager.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/versioning/dynamo/DynamoIngestVersionManager.scala
@@ -1,6 +1,0 @@
-package uk.ac.wellcome.platform.archive.common.versioning.dynamo
-
-import uk.ac.wellcome.platform.archive.common.versioning.IngestVersionManager
-
-class DynamoIngestVersionManager(val dao: DynamoIngestVersionManagerDao)
-    extends IngestVersionManager

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/versioning/memory/MemoryIngestVersionManager.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/versioning/memory/MemoryIngestVersionManager.scala
@@ -1,7 +1,0 @@
-package uk.ac.wellcome.platform.archive.common.versioning.memory
-
-import uk.ac.wellcome.platform.archive.common.versioning.IngestVersionManager
-
-class MemoryIngestVersionManager(
-  val dao: MemoryIngestVersionManagerDao = new MemoryIngestVersionManagerDao()
-) extends IngestVersionManager

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/dynamo/DynamoStorageManifestDaoTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/dynamo/DynamoStorageManifestDaoTest.scala
@@ -6,11 +6,11 @@ import org.scanamo.{Table => ScanamoTable}
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
+import uk.ac.wellcome.platform.archive.common.storage.models.dynamo.DynamoID
 import uk.ac.wellcome.platform.archive.common.storage.services.{
   StorageManifestDao,
   StorageManifestDaoTestCases
 }
-import uk.ac.wellcome.platform.archive.common.versioning.dynamo.DynamoID
 import uk.ac.wellcome.storage.fixtures.DynamoFixtures.Table
 import uk.ac.wellcome.storage.fixtures.{DynamoFixtures, S3Fixtures}
 import uk.ac.wellcome.storage.fixtures.S3Fixtures.Bucket

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -2,38 +2,27 @@
 
 These are the naming conventions used in the codebase, particularly in variable names.
 
-In particular, this is a good place to record an *old* name for something.
-Hopefully most names are self-explanatory, but how would you know that X used to be named Y, and a leftover reference to Y is really about X?
-Recording it here can help future developers.
-
-<dl>
 
 
-<dt>Glacier replica/Ireland replica</dt>
-<dd>
-  <p>
+## Terms in use
+
+*   **Glacier replica/Ireland replica.**
     The cold copy of a bag kept in S3 Glacier in Ireland.
-    In practice, this means the copy kept in <code>s3://wc-storage-replica-ireland</code> or the staging equivalent.
-  </p>
+    In practice, this means the copy kept in `s3://wc-storage-replica-ireland` or the staging equivalent.
 
-  <p>
-    This used to be called the <em>archive copy</em>, although hopefully all references to that have been removed.
-  </p>
-</dd>
-
-
-<dt>primary replica</dt>
-<dd>
-  <p>
+*   **Primary replica.**
     The primary/hot copy of a bag kept in the storage service.
-    In practice, this means the copy kept in <code>s3://wc-storage</code> or <code>s3://wc-storage-staging</code>, in Standard IA storage.
+    In practice, this means the copy kept in `s3://wc-storage` or `s3://wc-storage-staging`, in Standard IA storage.
     If somebody wants to read a file from the bag, they should read it from the primary replica.
-  </p>
-
-  <p>
-    This used to be called the <em>access copy</em>, although hopefully all references to that have been removed.
-  </p>
-</dd>
 
 
-</dl>
+
+## Terms we no longer use
+
+This is a list of terms that we used to use in the storage service codebase, but which have been replaced/removed.
+If you find references to these in current code, they should probably be updated/removed.
+
+*   **Access/archive copies**, now the *primary* or *Glacier replicas*, respectively.
+
+*   **Bag auditor.**
+    The early name of the *bag versioner*.


### PR DESCRIPTION
* Move all the versioner-related code into the versioner, and out of common
* Fix all the references to "auditing", which is a legacy term