### PR TITLE
Include tagmanifest-sha256.txt in the storage manifests created in the bag register

### DIFF
--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/Main.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/Main.scala
@@ -27,6 +27,7 @@ import uk.ac.wellcome.platform.archive.common.storage.services.{
   S3SizeFinder,
   StorageManifestService
 }
+import uk.ac.wellcome.storage.store.s3.S3StreamStore
 import uk.ac.wellcome.storage.typesafe.S3Builder
 import uk.ac.wellcome.typesafe.WellcomeTypesafeApp
 import uk.ac.wellcome.typesafe.config.builders.AkkaBuilder
@@ -59,6 +60,8 @@ object Main extends WellcomeTypesafeApp {
       config,
       operationName
     )
+
+    implicit val s3StreamStore = new S3StreamStore()
 
     val storageManifestService = new StorageManifestService(
       sizeFinder = new S3SizeFinder()

--- a/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/Register.scala
+++ b/bag_register/src/main/scala/uk/ac/wellcome/platform/archive/bag_register/services/Register.scala
@@ -19,7 +19,7 @@ import scala.util.{Failure, Success, Try}
 class Register(
   bagReader: BagReader[_],
   storageManifestDao: StorageManifestDao,
-  storageManifestService: StorageManifestService
+  storageManifestService: StorageManifestService[_]
 ) extends Logging {
 
   def update(

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
@@ -279,8 +279,7 @@ class BagRegisterWorkerTest
 
     it("includes the tagmanifest-sha256.txt in the storage manifest") {
       val tagManifestFiles =
-        storageManifest
-          .tagManifest.files
+        storageManifest.tagManifest.files
           .filter { _.name == "tagmanifest-sha256.txt" }
 
       tagManifestFiles should have size 1

--- a/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
+++ b/bag_register/src/test/scala/uk/ac/wellcome/platform/archive/bag_register/services/BagRegisterWorkerTest.scala
@@ -250,15 +250,15 @@ class BagRegisterWorkerTest
         _.processMessage(payload)
       }
 
+    val storageManifest =
+      storageManifestDao.getLatest(bagId).right.value
+
     it("returns an IngestCompleted") {
       result shouldBe a[Success[_]]
       result.success.value shouldBe a[IngestCompleted[_]]
     }
 
     it("stores the manifest in the dao") {
-      val storageManifest =
-        storageManifestDao.getLatest(bagId).right.value
-
       storageManifest.location shouldBe primaryLocation.copy(
         prefix = bagRoot
           .copy(
@@ -275,6 +275,15 @@ class BagRegisterWorkerTest
               .copy(path = prefix.path.stripSuffix(s"/$version"))
           )
         }
+    }
+
+    it("includes the tagmanifest-sha256.txt in the storage manifest") {
+      val tagManifestFiles =
+        storageManifest
+          .tagManifest.files
+          .filter { _.name == "tagmanifest-sha256.txt" }
+
+      tagManifestFiles should have size 1
     }
   }
 

--- a/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
+++ b/bag_verifier/src/main/scala/uk/ac/wellcome/platform/archive/bagverifier/services/BagVerifier.scala
@@ -244,33 +244,16 @@ class BagVerifier()(
 
   // Files that it's okay not to be referenced by any other manifests/files.
   //
-  // The BagIt spec supports four checksum algorithms, and you can send
-  // multiple manifests with different algorithms in the same bag.
-  // See https://tools.ietf.org/html/rfc8493#section-2.4
-  //
-  // The bag verifier only requires that bags include SHA256 manifests,
-  // so we ignore tag/file manifests for other algorithms without
-  // checking them.
-  //
   // We ignore the tag manifests because they're not referred to by the
   // checksum lists in any other manifests:
   //
   //        (tag manifest) -> (file manifest) -> (files)
   //
-  // The files are checked by the file manifest, the file manifest is
-  // checked by the tag manifest, but at the top you can't check the
-  // tag manifest -- how would you check the thing that checks that?
-  //
   // We don't ignore the file manifests (e.g. manifest-md5.txt), because
   // those should be included in the SHA256 tag manifest.  Every tag manifest
   // should include checksums for every file manifest.
   //
-  private val excludedFiles = Seq(
-    "tagmanifest-md5.txt",
-    "tagmanifest-sha1.txt",
-    "tagmanifest-sha256.txt",
-    "tagmanifest-sha512.txt"
-  )
+  private val excludedFiles = UnreferencedFiles.tagManifestFiles
 
   // Check that there aren't any files in the bag that aren't referenced in
   // either the file manifest or the tag manifest.

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/UnreferencedFiles.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/UnreferencedFiles.scala
@@ -1,0 +1,33 @@
+package uk.ac.wellcome.platform.archive.common.bagit.models
+
+/** In a bag, we have objects.  Those objects are referred to by a manifest file,
+  * which is in turn referred to by a tag manifest file.  But how do we know the
+  * tag manifest file is there?
+  *
+  *     b1234.jp2
+  *     object
+  *     |
+  *     +---- manifest-sha256.txt
+  *           manifest file
+  *           |
+  *           +---- tagmanifest-sha256.txt
+  *                 tag manifest file
+  *
+  * There's nothing in a bag that refers to the tag manifest file.  This is okay --
+  * the chain of checksums/references has to stop somewhere!
+  *
+  * This object records the filenames of all the tag manifests we might expect to see.
+  *
+  * The BagIt spec supports four checksum algorithms, and you can send
+  * multiple manifests with different algorithms in the same bag.
+  * See https://tools.ietf.org/html/rfc8493#section-2.4
+  *
+  */
+object UnreferencedFiles {
+  val tagManifestFiles: Seq[String] = Seq(
+    "tagmanifest-md5.txt",
+    "tagmanifest-sha1.txt",
+    "tagmanifest-sha256.txt",
+    "tagmanifest-sha512.txt"
+  )
+}

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/SizeFinder.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/SizeFinder.scala
@@ -24,7 +24,7 @@ class MemorySizeFinder(
 class S3SizeFinder(implicit s3Client: AmazonS3) extends SizeFinder {
   def getSize(location: ObjectLocation): Try[Long] = Try {
     s3Client
-    .getObjectMetadata(location.namespace, location.path)
-    .getContentLength
+      .getObjectMetadata(location.namespace, location.path)
+      .getContentLength
   }
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/SizeFinder.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/SizeFinder.scala
@@ -24,7 +24,7 @@ class MemorySizeFinder(
 class S3SizeFinder(implicit s3Client: AmazonS3) extends SizeFinder {
   def getSize(location: ObjectLocation): Try[Long] = Try {
     s3Client
-      .getObjectMetadata(location.namespace, location.path)
-      .getContentLength
+    .getObjectMetadata(location.namespace, location.path)
+    .getContentLength
   }
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
@@ -26,7 +26,9 @@ class StorageManifestException(message: String)
 class BadFetchLocationException(message: String)
     extends StorageManifestException(message)
 
-class StorageManifestService[IS <: InputStream with HasLength](sizeFinder: SizeFinder)(
+class StorageManifestService[IS <: InputStream with HasLength](
+  sizeFinder: SizeFinder
+)(
   implicit streamReader: Readable[ObjectLocation, IS]
 ) extends Logging {
   private val tagManifestFileFinder = new TagManifestFileFinder[IS]()
@@ -253,14 +255,22 @@ class StorageManifestService[IS <: InputStream with HasLength](sizeFinder: SizeF
   // This should only be the tagmanifest-*.txt files -- the verifier checks that these
   // are the only unreferenced files.
   //
-  private def getUnreferencedFiles(bagRoot: ObjectLocationPrefix, version: BagVersion, tagManifest: BagManifest): Try[Seq[StorageManifestFile]] =
-    tagManifestFileFinder.getTagManifestFiles(
-      prefix = bagRoot.asLocation(version.toString).asPrefix,
-      algorithm = tagManifest.checksumAlgorithm
-    ).map {
-      // Remember to prefix all the entries with a version string
-      _.map { f => f.copy(path = s"$version/${f.path}") }
-    }
+  private def getUnreferencedFiles(
+    bagRoot: ObjectLocationPrefix,
+    version: BagVersion,
+    tagManifest: BagManifest
+  ): Try[Seq[StorageManifestFile]] =
+    tagManifestFileFinder
+      .getTagManifestFiles(
+        prefix = bagRoot.asLocation(version.toString).asPrefix,
+        algorithm = tagManifest.checksumAlgorithm
+      )
+      .map {
+        // Remember to prefix all the entries with a version string
+        _.map { f =>
+          f.copy(path = s"$version/${f.path}")
+        }
+      }
 
   private def getReplicaLocations(
     replicas: Seq[SecondaryStorageLocation],

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
@@ -1,5 +1,6 @@
 package uk.ac.wellcome.platform.archive.common.storage.services
 
+import java.io.InputStream
 import java.time.Instant
 
 import grizzled.slf4j.Logging
@@ -13,6 +14,8 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.{
 import uk.ac.wellcome.platform.archive.common.bagit.services.BagMatcher
 import uk.ac.wellcome.platform.archive.common.ingests.models.IngestID
 import uk.ac.wellcome.platform.archive.common.storage.models._
+import uk.ac.wellcome.storage.store.Readable
+import uk.ac.wellcome.storage.streaming.HasLength
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 
 import scala.util.{Failure, Success, Try}
@@ -23,7 +26,11 @@ class StorageManifestException(message: String)
 class BadFetchLocationException(message: String)
     extends StorageManifestException(message)
 
-class StorageManifestService(sizeFinder: SizeFinder) extends Logging {
+class StorageManifestService[IS <: InputStream with HasLength](sizeFinder: SizeFinder)(
+  implicit streamReader: Readable[ObjectLocation, IS]
+) extends Logging {
+  private val tagManifestFileFinder = new TagManifestFileFinder[IS]()
+
   def createManifest(
     ingestId: IngestID,
     bag: Bag,
@@ -57,6 +64,12 @@ class StorageManifestService(sizeFinder: SizeFinder) extends Logging {
         entries = entries
       )
 
+      unreferencedTagManifestFiles <- getUnreferencedFiles(
+        bagRoot = bagRoot,
+        version = version,
+        tagManifest = bag.tagManifest
+      )
+
       storageManifest = StorageManifest(
         space = space,
         info = bag.info,
@@ -67,7 +80,7 @@ class StorageManifestService(sizeFinder: SizeFinder) extends Logging {
         ),
         tagManifest = FileManifest(
           checksumAlgorithm = bag.tagManifest.checksumAlgorithm,
-          files = tagManifestFiles
+          files = tagManifestFiles ++ unreferencedTagManifestFiles
         ),
         location = PrimaryStorageLocation(
           provider = location.provider,
@@ -233,6 +246,21 @@ class StorageManifestService(sizeFinder: SizeFinder) extends Logging {
       )
     }
   }
+
+  // Get StorageManifestFile entries for everything not listed in either the manifest
+  // or tag manifest BagIt files.
+  //
+  // This should only be the tagmanifest-*.txt files -- the verifier checks that these
+  // are the only unreferenced files.
+  //
+  private def getUnreferencedFiles(bagRoot: ObjectLocationPrefix, version: BagVersion, tagManifest: BagManifest): Try[Seq[StorageManifestFile]] =
+    tagManifestFileFinder.getTagManifestFiles(
+      prefix = bagRoot.asLocation(version.toString).asPrefix,
+      algorithm = tagManifest.checksumAlgorithm
+    ).map {
+      // Remember to prefix all the entries with a version string
+      _.map { f => f.copy(path = s"$version/${f.path}") }
+    }
 
   private def getReplicaLocations(
     replicas: Seq[SecondaryStorageLocation],

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestService.scala
@@ -192,7 +192,7 @@ class StorageManifestService(sizeFinder: SizeFinder) extends Logging {
     manifest: BagManifest,
     entries: Map[BagPath, (ObjectLocation, Option[Long])],
     bagRoot: ObjectLocationPrefix
-  ) = Try {
+  ): Try[Seq[StorageManifestFile]] = Try {
     manifest.files.map { bagFile =>
       // This lookup should never file -- the BagMatcher populates the
       // entries from the original manifests in the bag.

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/TagManifestFileFinder.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/TagManifestFileFinder.scala
@@ -4,10 +4,17 @@ import java.io.InputStream
 
 import uk.ac.wellcome.platform.archive.common.bagit.models.UnreferencedFiles
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifestFile
-import uk.ac.wellcome.platform.archive.common.verify.{ChecksumValue, HashingAlgorithm}
+import uk.ac.wellcome.platform.archive.common.verify.{
+  ChecksumValue,
+  HashingAlgorithm
+}
 import uk.ac.wellcome.storage.store.Readable
 import uk.ac.wellcome.storage.streaming.HasLength
-import uk.ac.wellcome.storage.{DoesNotExistError, ObjectLocation, ObjectLocationPrefix}
+import uk.ac.wellcome.storage.{
+  DoesNotExistError,
+  ObjectLocation,
+  ObjectLocationPrefix
+}
 
 import scala.util.Try
 
@@ -19,10 +26,13 @@ import scala.util.Try
   *
   */
 class TagManifestFileFinder[IS <: InputStream with HasLength](
-  implicit streamReader: Readable[ObjectLocation, IS]) {
+  implicit streamReader: Readable[ObjectLocation, IS]
+) {
 
-  def getTagManifestFiles(prefix: ObjectLocationPrefix,
-                          algorithm: HashingAlgorithm): Try[Seq[StorageManifestFile]] = Try {
+  def getTagManifestFiles(
+    prefix: ObjectLocationPrefix,
+    algorithm: HashingAlgorithm
+  ): Try[Seq[StorageManifestFile]] = Try {
     val entries: Seq[StorageManifestFile] =
       UnreferencedFiles.tagManifestFiles.flatMap {
         findIndividualTagManifestFile(_, prefix, algorithm)
@@ -35,12 +45,17 @@ class TagManifestFileFinder[IS <: InputStream with HasLength](
     }
   }
 
-  private def findIndividualTagManifestFile(name: String, prefix: ObjectLocationPrefix, algorithm: HashingAlgorithm): Option[StorageManifestFile] =
+  private def findIndividualTagManifestFile(
+    name: String,
+    prefix: ObjectLocationPrefix,
+    algorithm: HashingAlgorithm
+  ): Option[StorageManifestFile] =
     streamReader.get(prefix.asLocation(name)) match {
       case Right(is) =>
         Some(
           StorageManifestFile(
-            checksum = ChecksumValue.create(is.identifiedT, algorithm = algorithm).get,
+            checksum =
+              ChecksumValue.create(is.identifiedT, algorithm = algorithm).get,
             name = name,
             path = name,
             size = is.identifiedT.length
@@ -49,6 +64,7 @@ class TagManifestFileFinder[IS <: InputStream with HasLength](
 
       case Left(err: DoesNotExistError) => None
 
-      case Left(err) => throw new RuntimeException(s"Error looking up $prefix/$name: $err")
+      case Left(err) =>
+        throw new RuntimeException(s"Error looking up $prefix/$name: $err")
     }
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/TagManifestFileFinder.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/services/TagManifestFileFinder.scala
@@ -1,0 +1,50 @@
+package uk.ac.wellcome.platform.archive.common.storage.services
+
+import java.io.InputStream
+
+import uk.ac.wellcome.platform.archive.common.bagit.models.UnreferencedFiles
+import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifestFile
+import uk.ac.wellcome.platform.archive.common.verify.{ChecksumValue, HashingAlgorithm}
+import uk.ac.wellcome.storage.store.StreamStore
+import uk.ac.wellcome.storage.streaming.HasLength
+import uk.ac.wellcome.storage.{DoesNotExistError, ObjectLocation, ObjectLocationPrefix}
+
+import scala.util.Try
+
+/** The tag manifest files (e.g. tagmanifest-sha256.txt) aren't referred to by
+  * any of the other manifests in the bag, but we still want to include them in
+  * the storage manifest created by the storage service.
+  *
+  * This class creates the `StorageManifestFile` entries for BagIt tag manifest files.
+  *
+  */
+class TagManifestFileFinder[IS <: InputStream with HasLength](
+  implicit streamStore: StreamStore[ObjectLocation, IS]) {
+
+  def getTagManifestFiles(prefix: ObjectLocationPrefix,
+                          algorithm: HashingAlgorithm): Try[Seq[StorageManifestFile]] = Try {
+    val entries: Seq[StorageManifestFile] =
+      UnreferencedFiles.tagManifestFiles.flatMap {
+        findIndividualTagManifestFile(_, prefix, algorithm)
+      }
+
+    entries
+  }
+
+  private def findIndividualTagManifestFile(name: String, prefix: ObjectLocationPrefix, algorithm: HashingAlgorithm): Option[StorageManifestFile] =
+    streamStore.get(prefix.asLocation(name)) match {
+      case Right(is) =>
+        Some(
+          StorageManifestFile(
+            checksum = ChecksumValue.create(is.identifiedT, algorithm = algorithm).get,
+            name = name,
+            path = name,
+            size = is.identifiedT.length
+          )
+        )
+
+      case Left(err: DoesNotExistError) => None
+
+      case Left(err) => throw new RuntimeException(s"Error looking up $prefix/$name: $err")
+    }
+}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageRandomThings.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/fixtures/StorageRandomThings.scala
@@ -165,5 +165,5 @@ trait StorageRandomThings extends RandomThings {
   }
 
   def createBagVersion: BagVersion =
-    BagVersion(Random.nextInt)
+    BagVersion(randomInt(from = 1, to = 100000))
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
@@ -31,10 +31,7 @@ import uk.ac.wellcome.platform.archive.common.storage.models.{
 }
 import uk.ac.wellcome.platform.archive.common.verify.{MD5, SHA256}
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
-import uk.ac.wellcome.storage.store.memory.{
-  MemoryStreamStore,
-  MemoryTypedStore
-}
+import uk.ac.wellcome.storage.store.memory.{MemoryStreamStore, MemoryTypedStore}
 
 import scala.util.{Failure, Random, Success, Try}
 
@@ -136,7 +133,9 @@ class StorageManifestServiceTest
     }
 
     it("sets the correct prefix on the primary location") {
-      storageManifest.location.prefix shouldBe bagRoot.copy(path = bagRoot.path.stripSuffix(s"/$version"))
+      storageManifest.location.prefix shouldBe bagRoot.copy(
+        path = bagRoot.path.stripSuffix(s"/$version")
+      )
     }
 
     it("uses the correct providers on the replica locations") {
@@ -185,18 +184,14 @@ class StorageManifestServiceTest
     )
 
     it("manifest entries") {
-      storageManifest
-        .manifest
-        .files
+      storageManifest.manifest.files
         .foreach { file =>
           file.path shouldBe s"$version/${file.name}"
         }
     }
 
     it("tag manifest entries") {
-      storageManifest
-        .tagManifest
-        .files
+      storageManifest.tagManifest.files
         .foreach { file =>
           file.path shouldBe s"$version/${file.name}"
         }
@@ -227,17 +222,15 @@ class StorageManifestServiceTest
       version = version
     )
 
-    val bagFetchFiles = bag
-      .fetch.get
-      .files
-      .map { entry => entry.path -> entry }
-      .toMap
+    val bagFetchFiles = bag.fetch.get.files.map { entry =>
+      entry.path -> entry
+    }.toMap
 
     it("puts fetched entries under a versioned path") {
-      val fetchedFiles = storageManifest
-        .manifest
-        .files
-        .filter { file => bagFetchFiles.contains(BagPath(file.name)) }
+      val fetchedFiles = storageManifest.manifest.files
+        .filter { file =>
+          bagFetchFiles.contains(BagPath(file.name))
+        }
 
       fetchedFiles.isEmpty shouldBe false
 
@@ -259,19 +252,17 @@ class StorageManifestServiceTest
     }
 
     it("puts non-fetched entries under the current version") {
-      storageManifest
-        .manifest
-        .files
-        .filterNot { file => bagFetchFiles.contains(BagPath(file.name)) }
+      storageManifest.manifest.files
+        .filterNot { file =>
+          bagFetchFiles.contains(BagPath(file.name))
+        }
         .foreach { file =>
           file.path shouldBe s"$version/${file.name}"
         }
     }
 
     it("tag manifest entries are always under the current version") {
-      storageManifest
-        .tagManifest
-        .files
+      storageManifest.tagManifest.files
         .foreach { file =>
           file.path shouldBe s"$version/${file.name}"
         }
@@ -298,36 +289,28 @@ class StorageManifestServiceTest
 
     it("uses the checksum values from the file manifest") {
       val storageManifestChecksums =
-        storageManifest.manifest.files
-          .map { file =>
-            file.name -> file.checksum.value
-          }
-          .toMap
+        storageManifest.manifest.files.map { file =>
+          file.name -> file.checksum.value
+        }.toMap
 
       val bagChecksums =
-        bag.manifest.files
-          .map { file =>
-            file.path.value -> file.checksum.value.value
-          }
-          .toMap
+        bag.manifest.files.map { file =>
+          file.path.value -> file.checksum.value.value
+        }.toMap
 
       storageManifestChecksums shouldBe bagChecksums
     }
 
     it("uses the checksum values from the tag manifest") {
       val storageManifestChecksums =
-        storageManifest.tagManifest.files
-          .map { file =>
-            file.name -> file.checksum.value
-          }
-          .toMap
+        storageManifest.tagManifest.files.map { file =>
+          file.name -> file.checksum.value
+        }.toMap
 
       val bagChecksums =
-        bag.tagManifest.files
-          .map { file =>
-            file.path.value -> file.checksum.value.value
-          }
-          .toMap
+        bag.tagManifest.files.map { file =>
+          file.path.value -> file.checksum.value.value
+        }.toMap
 
       storageManifestChecksums.filterKeys { _ != "tagmanifest-sha256.txt" } shouldBe bagChecksums
     }
@@ -535,7 +518,8 @@ class StorageManifestServiceTest
 
     it("uses the size finder to get sizes") {
       object NoFetchBagBuilder extends BagBuilderBase {
-        override protected def getFetchEntryCount(payloadFileCount: Int): Int = 0
+        override protected def getFetchEntryCount(payloadFileCount: Int): Int =
+          0
       }
 
       val version = createBagVersion
@@ -590,7 +574,9 @@ class StorageManifestServiceTest
         override protected def getFetchEntryCount(payloadFileCount: Int): Int =
           payloadFileCount
 
-        override protected def buildFetchEntryLine(entry: PayloadEntry)(implicit namespace: String): String =
+        override protected def buildFetchEntryLine(
+          entry: PayloadEntry
+        )(implicit namespace: String): String =
           s"""bag://$namespace/${entry.path} ${entry.contents.getBytes.length} ${entry.bagPath}"""
       }
 
@@ -621,19 +607,14 @@ class StorageManifestServiceTest
       )
 
       val manifestSizes =
-        storageManifest.manifest.files
-          .map { file =>
-            file.name -> file.size
-          }
-        .toMap
+        storageManifest.manifest.files.map { file =>
+          file.name -> file.size
+        }.toMap
 
       val bagSizes =
-        bag.fetch.get
-          .files
-          .map { file =>
-            file.path.value -> file.length.get
-          }
-          .toMap
+        bag.fetch.get.files.map { file =>
+          file.path.value -> file.length.get
+        }.toMap
 
       manifestSizes shouldBe bagSizes
     }
@@ -664,7 +645,9 @@ class StorageManifestServiceTest
     (bagRoot, new MemoryBagReader().get(bagRoot).right.value)
   }
 
-  describe("finds files that aren't referenced in the BagIt tagmanifest-sha256.txt") {
+  describe(
+    "finds files that aren't referenced in the BagIt tagmanifest-sha256.txt"
+  ) {
     it("finds BagIt tag manifest files") {
       implicit val streamStore: MemoryStreamStore[ObjectLocation] =
         MemoryStreamStore[ObjectLocation]()
@@ -686,7 +669,9 @@ class StorageManifestServiceTest
         version = version
       )
 
-      val tagManifestFiles = manifest.tagManifest.files.filter { _.name.startsWith("tagmanifest-") }
+      val tagManifestFiles = manifest.tagManifest.files.filter {
+        _.name.startsWith("tagmanifest-")
+      }
 
       tagManifestFiles.isEmpty shouldBe false
     }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
@@ -7,10 +7,14 @@ import uk.ac.wellcome.platform.archive.common.bagit.models.{
   Bag,
   BagFetchEntry,
   BagPath,
-  BagVersion
+  BagVersion,
+  ExternalIdentifier
 }
 import uk.ac.wellcome.platform.archive.common.bagit.services.memory.MemoryBagReader
-import uk.ac.wellcome.platform.archive.common.fixtures.BagBuilder
+import uk.ac.wellcome.platform.archive.common.fixtures.{
+  BagBuilder,
+  BagBuilderBase
+}
 import uk.ac.wellcome.platform.archive.common.generators.{
   BagFileGenerators,
   BagGenerators,
@@ -26,7 +30,7 @@ import uk.ac.wellcome.platform.archive.common.storage.models.{
   StorageSpace
 }
 import uk.ac.wellcome.platform.archive.common.verify.{MD5, SHA256}
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
 import uk.ac.wellcome.storage.store.memory.{
   MemoryStreamStore,
   MemoryTypedStore
@@ -106,11 +110,14 @@ class StorageManifestServiceTest
 
   describe("sets the locations and replicaLocations correctly") {
     val version = createBagVersion
-    val bagRoot = createObjectLocation
+
+    implicit val streamStore: MemoryStreamStore[ObjectLocation] =
+      MemoryStreamStore[ObjectLocation]()
+
+    val (bagRoot, bag) = createStorageManifestBag(version = version)
 
     val location = createPrimaryLocationWith(
-      bagRoot = bagRoot,
-      version = version
+      prefix = bagRoot
     )
 
     val replicas = collectionOf(max = 10) {
@@ -118,6 +125,7 @@ class StorageManifestServiceTest
     }
 
     val storageManifest = createManifest(
+      bag = bag,
       location = location,
       replicas = replicas,
       version = version
@@ -128,7 +136,7 @@ class StorageManifestServiceTest
     }
 
     it("sets the correct prefix on the primary location") {
-      storageManifest.location.prefix shouldBe bagRoot.asPrefix
+      storageManifest.location.prefix shouldBe bagRoot.copy(path = bagRoot.path.stripSuffix(s"/$version"))
     }
 
     it("uses the correct providers on the replica locations") {
@@ -153,217 +161,175 @@ class StorageManifestServiceTest
     }
   }
 
-  describe("constructs the paths correctly") {
-    it("no fetch.txt => all the file entries under a versioned path") {
-      val version = createBagVersion
-      val location = createPrimaryLocationWith(version = version)
+  describe("if there's no fetch.txt, it versions the paths") {
+    object NoFetchBagBuilder extends BagBuilderBase {
+      override protected def getFetchEntryCount(payloadFileCount: Int): Int = 0
+    }
 
-      val files = Seq("data/file1.txt", "data/file2.txt", "data/dir/file3.txt")
+    val version = createBagVersion
 
-      val bag = createBagWith(
-        manifestFiles = files.map { path =>
-          createBagFileWith(path = path)
+    implicit val streamStore: MemoryStreamStore[ObjectLocation] =
+      MemoryStreamStore[ObjectLocation]()
+
+    val (bagRoot, bag) = createStorageManifestBag(
+      version = version,
+      bagBuilder = NoFetchBagBuilder
+    )
+
+    val location = createPrimaryLocationWith(prefix = bagRoot)
+
+    val storageManifest = createManifest(
+      bag = bag,
+      location = location,
+      version = version
+    )
+
+    it("manifest entries") {
+      storageManifest
+        .manifest
+        .files
+        .foreach { file =>
+          file.path shouldBe s"$version/${file.name}"
         }
-      )
-
-      val storageManifest = createManifest(
-        bag = bag,
-        location = location,
-        version = version
-      )
-
-      val namePathMap =
-        storageManifest.manifest.files.map { file =>
-          (file.name, file.path)
-        }.toMap
-
-      namePathMap shouldBe files.map { f =>
-        (f, s"$version/$f")
-      }.toMap
     }
 
-    it("puts the tag manifest files under a versioned path") {
-      val version = createBagVersion
-      val location = createPrimaryLocationWith(version = version)
-
-      val files =
-        Seq("bag-info.txt", "tag-manifest-sha256.txt", "manifest-sha256.txt")
-
-      val bag = createBagWith(
-        tagManifestFiles = files.map { path =>
-          createBagFileWith(path = path)
+    it("tag manifest entries") {
+      storageManifest
+        .tagManifest
+        .files
+        .foreach { file =>
+          file.path shouldBe s"$version/${file.name}"
         }
-      )
+    }
+  }
 
-      val storageManifest = createManifest(
-        bag = bag,
-        location = location,
-        version = version
-      )
-
-      val namePathMap =
-        storageManifest.tagManifest.files.map { file =>
-          (file.name, file.path)
-        }.toMap
-
-      namePathMap shouldBe files.map { f =>
-        (f, s"$version/$f")
-      }.toMap
+  describe("if there's a fetch.txt, it constructs the right paths") {
+    object AtLeastOneFetchEntryBagBuilder extends BagBuilderBase {
+      override protected def getFetchEntryCount(payloadFileCount: Int): Int =
+        randomInt(from = 1, to = payloadFileCount)
     }
 
-    it("puts a fetch entry under the right versioned path") {
-      val version = createBagVersion
-      val bagRoot = createObjectLocation
+    val version = createBagVersion
 
-      val location = createPrimaryLocationWith(
-        bagRoot = bagRoot,
-        version = version
-      )
+    implicit val streamStore: MemoryStreamStore[ObjectLocation] =
+      MemoryStreamStore[ObjectLocation]()
 
-      val fetchVersion = version.copy(underlying = version.underlying - 1)
-      val fetchLocation = bagRoot.copy(
-        path = s"${bagRoot.path}/$fetchVersion/data/file1.txt"
-      )
+    val (bagRoot, bag) = createStorageManifestBag(
+      version = version,
+      bagBuilder = AtLeastOneFetchEntryBagBuilder
+    )
 
-      val fetchEntries = Seq(
-        BagFetchEntry(
-          uri =
-            new URI(s"s3://${fetchLocation.namespace}/${fetchLocation.path}"),
-          length = None,
-          path = BagPath("data/file1.txt")
-        )
-      )
+    val location = createPrimaryLocationWith(prefix = bagRoot)
 
-      val bag = createBagWith(
-        manifestFiles = Seq(
-          createBagFileWith("data/file1.txt")
-        ),
-        fetchEntries = fetchEntries
-      )
+    val storageManifest = createManifest(
+      bag = bag,
+      location = location,
+      version = version
+    )
 
-      val storageManifest = createManifest(
-        bag = bag,
-        location = location,
-        version = version
-      )
+    val bagFetchFiles = bag
+      .fetch.get
+      .files
+      .map { entry => entry.path -> entry }
+      .toMap
 
-      storageManifest.manifest.files.map { f =>
-        f.name -> f.path
-      }.toMap shouldBe Map("data/file1.txt" -> s"$fetchVersion/data/file1.txt")
+    it("puts fetched entries under a versioned path") {
+      val fetchedFiles = storageManifest
+        .manifest
+        .files
+        .filter { file => bagFetchFiles.contains(BagPath(file.name)) }
+
+      fetchedFiles.isEmpty shouldBe false
+
+      fetchedFiles
+        .foreach { file =>
+          val fetchEntry = bagFetchFiles(BagPath(file.name))
+
+          // The fetch entry URI is of the form
+          //
+          //    s3://{bucket}/{space}/{externalIdentifier}/{version}/{path_inside_bag}
+          //
+          // We want to check that matches the bag path, which is of the form
+          //
+          //    {version}/{path_inside_bag}
+          //
+          fetchEntry.uri.toString should endWith(file.path)
+          file.path.matches("^v\\d+/")
+        }
     }
 
-    it("uses a mixture of fetch entries and concrete files") {
-      val version = createBagVersion
-      val bagRoot = createObjectLocation
+    it("puts non-fetched entries under the current version") {
+      storageManifest
+        .manifest
+        .files
+        .filterNot { file => bagFetchFiles.contains(BagPath(file.name)) }
+        .foreach { file =>
+          file.path shouldBe s"$version/${file.name}"
+        }
+    }
 
-      val location = createPrimaryLocationWith(
-        bagRoot = bagRoot,
-        version = version
-      )
-
-      val fetchVersion = version.copy(underlying = version.underlying - 1)
-      val fetchLocation = bagRoot.copy(
-        path = s"${bagRoot.path}/$fetchVersion/data/file1.txt"
-      )
-
-      val fetchEntries = Seq(
-        BagFetchEntry(
-          uri =
-            new URI(s"s3://${fetchLocation.namespace}/${fetchLocation.path}"),
-          length = None,
-          path = BagPath("data/file1.txt")
-        )
-      )
-
-      val bag = createBagWith(
-        manifestFiles = Seq(
-          createBagFileWith("data/file1.txt"),
-          createBagFileWith("data/file2.txt")
-        ),
-        fetchEntries = fetchEntries
-      )
-
-      val storageManifest = createManifest(
-        bag = bag,
-        location = location,
-        version = version
-      )
-
-      storageManifest.manifest.files.map { f =>
-        f.name -> f.path
-      }.toMap shouldBe Map(
-        "data/file1.txt" -> s"$fetchVersion/data/file1.txt",
-        "data/file2.txt" -> s"$version/data/file2.txt"
-      )
+    it("tag manifest entries are always under the current version") {
+      storageManifest
+        .tagManifest
+        .files
+        .foreach { file =>
+          file.path shouldBe s"$version/${file.name}"
+        }
     }
   }
 
   describe("validates the checksums") {
+    val version = createBagVersion
+
+    implicit val streamStore: MemoryStreamStore[ObjectLocation] =
+      MemoryStreamStore[ObjectLocation]()
+
+    val (bagRoot, bag) = createStorageManifestBag(
+      version = version
+    )
+
+    val location = createPrimaryLocationWith(prefix = bagRoot)
+
+    val storageManifest = createManifest(
+      bag = bag,
+      location = location,
+      version = version
+    )
+
     it("uses the checksum values from the file manifest") {
-      val paths = Seq("data/file1.txt", "data/file2.txt", "data/dir/file3.txt")
-
-      val filesWithChecksums =
-        paths.map { _ -> randomAlphanumeric }
-
-      val bag = createBagWith(
-        manifestFiles = filesWithChecksums.map {
-          case (path, checksumValue) =>
-            createBagFileWith(path = path, checksum = checksumValue)
-        }
-      )
-
-      val version = createBagVersion
-      val location = createPrimaryLocationWith(
-        version = version
-      )
-
-      val storageManifest = createManifest(
-        bag = bag,
-        location = location,
-        version = version
-      )
-
-      val nameChecksumMap =
+      val storageManifestChecksums =
         storageManifest.manifest.files
           .map { file =>
-            (file.name, file.checksum.value)
+            file.name -> file.checksum.value
           }
+          .toMap
 
-      nameChecksumMap should contain theSameElementsAs filesWithChecksums
+      val bagChecksums =
+        bag.manifest.files
+          .map { file =>
+            file.path.value -> file.checksum.value.value
+          }
+          .toMap
+
+      storageManifestChecksums shouldBe bagChecksums
     }
 
     it("uses the checksum values from the tag manifest") {
-      val paths =
-        Seq("bag-info.txt", "tag-manifest-sha256.txt", "manifest-sha256.txt")
-
-      val filesWithChecksums =
-        paths.map { _ -> randomAlphanumeric }
-
-      val bag = createBagWith(
-        tagManifestFiles = filesWithChecksums.map {
-          case (path, checksum) =>
-            createBagFileWith(path = path, checksum = checksum)
-        }
-      )
-
-      val version = createBagVersion
-      val location = createPrimaryLocationWith(
-        version = version
-      )
-
-      val storageManifest = createManifest(
-        bag = bag,
-        location = location,
-        version = version
-      )
-
-      val nameChecksumMap =
+      val storageManifestChecksums =
         storageManifest.tagManifest.files
           .map { file =>
-            (file.name, file.checksum.value)
+            file.name -> file.checksum.value
           }
+          .toMap
 
-      nameChecksumMap should contain theSameElementsAs filesWithChecksums
+      val bagChecksums =
+        bag.tagManifest.files
+          .map { file =>
+            file.path.value -> file.checksum.value.value
+          }
+          .toMap
+
+      storageManifestChecksums.filterKeys { _ != "tagmanifest-sha256.txt" } shouldBe bagChecksums
     }
 
     it(
@@ -488,38 +454,40 @@ class StorageManifestServiceTest
   }
 
   describe("passes through metadata correctly") {
+    val version = createBagVersion
+    val space = createStorageSpace
+
+    implicit val streamStore: MemoryStreamStore[ObjectLocation] =
+      MemoryStreamStore[ObjectLocation]()
+
+    val (bagRoot, bag) = createStorageManifestBag(
+      space = space,
+      version = version
+    )
+
+    val location = createPrimaryLocationWith(prefix = bagRoot)
+
+    val storageManifest = createManifest(
+      bag = bag,
+      location = location,
+      space = space,
+      version = version
+    )
+
     it("sets the correct storage space") {
-      val space = createStorageSpace
-
-      val manifest = createManifest(space = space)
-
-      manifest.space shouldBe space
+      storageManifest.space shouldBe space
     }
 
     it("sets the correct bagInfo") {
-      val bag = createBag
-
-      val manifest = createManifest(bag = bag)
-
-      manifest.info shouldBe bag.info
+      storageManifest.info shouldBe bag.info
     }
 
     it("sets the correct version") {
-      val version = createBagVersion
-      val location = createPrimaryLocationWith(
-        version = version
-      )
-
-      val manifest =
-        createManifest(location = location, version = version)
-
-      manifest.version shouldBe version
+      storageManifest.version shouldBe version
     }
 
     it("sets a recent createdDate") {
-      val manifest = createManifest()
-
-      assertRecent(manifest.createdDate)
+      assertRecent(storageManifest.createdDate)
     }
   }
 
@@ -545,6 +513,9 @@ class StorageManifestServiceTest
           Failure(err)
       }
 
+      implicit val streamStore: MemoryStreamStore[ObjectLocation] =
+        MemoryStreamStore[ObjectLocation]()
+
       val service = new StorageManifestService(brokenSizeFinder)
 
       val result = service.createManifest(
@@ -562,87 +533,78 @@ class StorageManifestServiceTest
       )
     }
 
-    it("uses the provided sizes") {
-      val paths = Seq("data/file1.txt", "data/file2.txt", "data/dir/file3.txt")
-      val expectedSizes = paths.map { _ -> Random.nextLong().abs }.toMap
-
-      val filesWithChecksums =
-        paths.map { _ -> randomAlphanumeric }
-
-      val bag = createBagWith(
-        manifestFiles = filesWithChecksums.map {
-          case (path, checksum) =>
-            createBagFileWith(path = path, checksum = checksum)
-        }
-      )
-
-      val version = createBagVersion
-      val location = createPrimaryLocationWith(
-        version = version
-      )
-
-      val sizes = expectedSizes.map {
-        case (path, size) => location.prefix.asLocation(path) -> size
+    it("uses the size finder to get sizes") {
+      object NoFetchBagBuilder extends BagBuilderBase {
+        override protected def getFetchEntryCount(payloadFileCount: Int): Int = 0
       }
 
-      val sizeFinder = new SizeFinder {
-        override def getSize(location: ObjectLocation): Try[Long] =
-          Try { sizes(location) }
+      val version = createBagVersion
+
+      implicit val streamStore: MemoryStreamStore[ObjectLocation] =
+        MemoryStreamStore[ObjectLocation]()
+
+      val (bagRoot, bag) = createStorageManifestBag(
+        version = version,
+        bagBuilder = NoFetchBagBuilder
+      )
+
+      val location = createPrimaryLocationWith(prefix = bagRoot)
+
+      var sizeCache: Map[ObjectLocation, Long] = Map.empty
+
+      val cachingSizeFinder = new SizeFinder {
+        override def getSize(location: ObjectLocation): Try[Long] = Try {
+          sizeCache = sizeCache + (location -> Random.nextLong())
+          sizeCache(location)
+        }
       }
 
       val storageManifest = createManifest(
-        bag = bag,
+        bag = bag.copy(
+          tagManifest = bag.tagManifest.copy(files = Seq.empty)
+        ),
         location = location,
         version = version,
-        sizeFinder = sizeFinder
+        sizeFinder = cachingSizeFinder
       )
 
-      val actualSizes =
-        storageManifest.manifest.files
-          .map { file =>
-            (file.name, file.size)
+      val storageManifestSizes =
+        (storageManifest.manifest.files ++ storageManifest.tagManifest.files)
+          .filterNot {
+            // The size of this tag manifest is fetched when we read the file contents,
+            // not from the size finder.
+            _.name == "tagmanifest-sha256.txt"
           }
+          .map { file =>
+            storageManifest.location.prefix.asLocation(file.path) -> file.size
+          }
+          .toMap
 
-      actualSizes should contain theSameElementsAs expectedSizes.toSeq
+      storageManifestSizes shouldBe sizeCache
     }
 
     it("uses the size from the fetch file") {
+      // Always create a fetch.txt entry rather than a concrete file, always
+      // include the size in the fetch.txt.
+      object ConcreteFetchEntryBagBuilder extends BagBuilderBase {
+        override protected def getFetchEntryCount(payloadFileCount: Int): Int =
+          payloadFileCount
+
+        override protected def buildFetchEntryLine(entry: PayloadEntry)(implicit namespace: String): String =
+          s"""bag://$namespace/${entry.path} ${entry.contents.getBytes.length} ${entry.bagPath}"""
+      }
+
       val version = createBagVersion
-      val bagRoot = createObjectLocation
 
-      val location = createPrimaryLocationWith(
-        bagRoot = bagRoot,
-        version = version
+      implicit val streamStore: MemoryStreamStore[ObjectLocation] =
+        MemoryStreamStore[ObjectLocation]()
+
+      val (bagRoot, bag) = createStorageManifestBag(
+        version = version,
+        bagBuilder = ConcreteFetchEntryBagBuilder
       )
 
-      val fetchVersion = version.copy(
-        underlying = version.underlying - 1
-      )
-
-      val fetchLocation = bagRoot.copy(
-        path = s"${bagRoot.path}/$fetchVersion/data/file1.txt"
-      )
-
-      val bag = createBagWith(
-        manifestFiles = Seq(
-          createBagFileWith("data/1.txt"),
-          createBagFileWith("data/2.txt")
-        ),
-        fetchEntries = Seq(
-          BagFetchEntry(
-            uri =
-              new URI(s"s3://${fetchLocation.namespace}/${fetchLocation.path}"),
-            length = Some(10),
-            path = BagPath("data/1.txt")
-          ),
-          BagFetchEntry(
-            uri =
-              new URI(s"s3://${fetchLocation.namespace}/${fetchLocation.path}"),
-            length = Some(20),
-            path = BagPath("data/2.txt")
-          )
-        )
-      )
+      val location = createPrimaryLocationWith(prefix = bagRoot)
 
       val brokenSizeFinder = new SizeFinder {
         override def getSize(location: ObjectLocation): Try[Long] =
@@ -650,23 +612,56 @@ class StorageManifestServiceTest
       }
 
       val storageManifest = createManifest(
-        bag = bag,
+        bag = bag.copy(
+          tagManifest = bag.tagManifest.copy(files = Seq.empty)
+        ),
         location = location,
         version = version,
         sizeFinder = brokenSizeFinder
       )
 
-      val actualSizes =
+      val manifestSizes =
         storageManifest.manifest.files
           .map { file =>
-            (file.name, file.size)
+            file.name -> file.size
           }
+        .toMap
 
-      actualSizes should contain theSameElementsAs Seq(
-        ("data/1.txt", 10L),
-        ("data/2.txt", 20L)
-      )
+      val bagSizes =
+        bag.fetch.get
+          .files
+          .map { file =>
+            file.path.value -> file.length.get
+          }
+          .toMap
+
+      manifestSizes shouldBe bagSizes
     }
+  }
+
+  def createStorageManifestBag(
+    space: StorageSpace = createStorageSpace,
+    externalIdentifier: ExternalIdentifier = createExternalIdentifier,
+    version: BagVersion,
+    bagBuilder: BagBuilderBase = BagBuilder
+  )(
+    implicit
+    namespace: String = randomAlphanumeric,
+    streamStore: MemoryStreamStore[ObjectLocation]
+  ): (ObjectLocationPrefix, Bag) = {
+    implicit val typedStore: MemoryTypedStore[ObjectLocation, String] =
+      new MemoryTypedStore[ObjectLocation, String]()
+
+    val (bagObjects, bagRoot, _) =
+      bagBuilder.createBagContentsWith(
+        space = space,
+        externalIdentifier = externalIdentifier,
+        version = version
+      )
+
+    bagBuilder.uploadBagObjects(bagObjects)
+
+    (bagRoot, new MemoryBagReader().get(bagRoot).right.value)
   }
 
   describe("finds files that aren't referenced in the BagIt tagmanifest-sha256.txt") {
@@ -674,25 +669,15 @@ class StorageManifestServiceTest
       implicit val streamStore: MemoryStreamStore[ObjectLocation] =
         MemoryStreamStore[ObjectLocation]()
 
-      implicit val typedStore: MemoryTypedStore[ObjectLocation, String] =
-        new MemoryTypedStore[ObjectLocation, String]()
-
-      implicit val namespace = randomAlphanumeric
-
       val space = createStorageSpace
       val externalIdentifier = createExternalIdentifier
       val version = createBagVersion
 
-      val (bagObjects, bagRoot, _) =
-        BagBuilder.createBagContentsWith(
-          space = space,
-          externalIdentifier = externalIdentifier,
-          version = version
-        )
-
-      BagBuilder.uploadBagObjects(bagObjects)
-
-      val bag = new MemoryBagReader().get(bagRoot).right.value
+      val (bagRoot, bag) = createStorageManifestBag(
+        space = space,
+        externalIdentifier,
+        version = version
+      )
 
       val manifest = createManifest(
         bag = bag,
@@ -709,15 +694,15 @@ class StorageManifestServiceTest
 
   private def createManifest(
     ingestId: IngestID = createIngestID,
-    bag: Bag = createBag,
-    location: PrimaryStorageLocation = createPrimaryLocationWith(
-      version = BagVersion(1)
-    ),
+    bag: Bag,
+    location: PrimaryStorageLocation,
     replicas: Seq[SecondaryStorageLocation] = Seq.empty,
     space: StorageSpace = createStorageSpace,
-    version: BagVersion = BagVersion(1),
+    version: BagVersion,
     sizeFinder: SizeFinder = (location: ObjectLocation) =>
       Success(Random.nextLong().abs)
+  )(
+    implicit streamStore: MemoryStreamStore[ObjectLocation]
   ): StorageManifest = {
     val service = new StorageManifestService(sizeFinder)
 
@@ -770,6 +755,9 @@ class StorageManifestServiceTest
     val sizeFinder = new SizeFinder {
       override def getSize(location: ObjectLocation): Try[Long] = Success(1)
     }
+
+    implicit val streamStore: MemoryStreamStore[ObjectLocation] =
+      MemoryStreamStore[ObjectLocation]()
 
     val service = new StorageManifestService(sizeFinder)
 

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/TagManifestFileFinderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/TagManifestFileFinderTest.scala
@@ -3,23 +3,32 @@ package uk.ac.wellcome.platform.archive.common.storage.services
 import org.scalatest.{EitherValues, FunSpec, Matchers, TryValues}
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifestFile
-import uk.ac.wellcome.platform.archive.common.verify.{ChecksumValue, MD5, SHA256}
+import uk.ac.wellcome.platform.archive.common.verify.{
+  ChecksumValue,
+  MD5,
+  SHA256
+}
 import uk.ac.wellcome.storage.{ObjectLocation, StoreReadError}
 import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
 import uk.ac.wellcome.storage.store.Readable
 import uk.ac.wellcome.storage.store.memory.MemoryStreamStoreFixtures
 import uk.ac.wellcome.storage.streaming.Codec._
-import uk.ac.wellcome.storage.streaming.{InputStreamWithLength, InputStreamWithLengthAndMetadata}
+import uk.ac.wellcome.storage.streaming.{
+  InputStreamWithLength,
+  InputStreamWithLengthAndMetadata
+}
 
 class TagManifestFileFinderTest
-  extends FunSpec
+    extends FunSpec
     with Matchers
     with EitherValues
     with TryValues
     with ObjectLocationGenerators
     with MemoryStreamStoreFixtures[ObjectLocation] {
 
-  def withTagManifestFileFinder[R](entries: Map[ObjectLocation, String])(testWith: TestWith[TagManifestFileFinder[_], R]): R =
+  def withTagManifestFileFinder[R](
+    entries: Map[ObjectLocation, String]
+  )(testWith: TestWith[TagManifestFileFinder[_], R]): R =
     withStreamStoreContext { memoryStore =>
       val initialEntries = entries
         .map {
@@ -32,10 +41,11 @@ class TagManifestFileFinderTest
             (loc, is)
         }
 
-      withMemoryStreamStoreImpl(memoryStore, initialEntries = initialEntries) { implicit streamStore =>
-        testWith(
-          new TagManifestFileFinder()
-        )
+      withMemoryStreamStoreImpl(memoryStore, initialEntries = initialEntries) {
+        implicit streamStore =>
+          testWith(
+            new TagManifestFileFinder()
+          )
       }
     }
 
@@ -43,36 +53,48 @@ class TagManifestFileFinderTest
     val prefix = createObjectLocationPrefix
 
     val result =
-      withTagManifestFileFinder(entries = Map(
-        prefix.asLocation("tagmanifest-md5.txt") -> "My MD5 tag manifest",
-        prefix.asLocation("tagmanifest-sha1.txt") -> "My SHA1 tag manifest",
-        prefix.asLocation("tagmanifest-sha256.txt") -> "My SHA256 tag manifest",
-        prefix.asLocation("tagmanifest-sha512.txt") -> "My SHA512 tag manifest",
-      )) {
+      withTagManifestFileFinder(
+        entries = Map(
+          prefix.asLocation("tagmanifest-md5.txt") -> "My MD5 tag manifest",
+          prefix.asLocation("tagmanifest-sha1.txt") -> "My SHA1 tag manifest",
+          prefix
+            .asLocation("tagmanifest-sha256.txt") -> "My SHA256 tag manifest",
+          prefix
+            .asLocation("tagmanifest-sha512.txt") -> "My SHA512 tag manifest"
+        )
+      ) {
         _.getTagManifestFiles(prefix, algorithm = SHA256)
       }
 
     result.success.value should contain theSameElementsAs Seq(
       StorageManifestFile(
-        checksum = ChecksumValue("fe9a209b4ef3426c9b30e7808047689e3bacedb0aa58db91cf2aa355834199c1"),
+        checksum = ChecksumValue(
+          "fe9a209b4ef3426c9b30e7808047689e3bacedb0aa58db91cf2aa355834199c1"
+        ),
         name = "tagmanifest-md5.txt",
         size = 19,
         path = "tagmanifest-md5.txt"
       ),
       StorageManifestFile(
-        checksum = ChecksumValue("3a2d9e87f82ca9c6fb16b8af5968e405f8952cedc73134e3b222a6e5f45aedff"),
+        checksum = ChecksumValue(
+          "3a2d9e87f82ca9c6fb16b8af5968e405f8952cedc73134e3b222a6e5f45aedff"
+        ),
         name = "tagmanifest-sha1.txt",
         size = 20,
         path = "tagmanifest-sha1.txt"
       ),
       StorageManifestFile(
-        checksum = ChecksumValue("1359a6582aa673ed377f017abd62f2f4f6fc77cb9477423444b95ba0996f3f14"),
+        checksum = ChecksumValue(
+          "1359a6582aa673ed377f017abd62f2f4f6fc77cb9477423444b95ba0996f3f14"
+        ),
         name = "tagmanifest-sha256.txt",
         size = 22,
         path = "tagmanifest-sha256.txt"
       ),
       StorageManifestFile(
-        checksum = ChecksumValue("e749dc748023730bee5b04f477934cc7fc8e4dc4d98521a82aef471c38235fd6"),
+        checksum = ChecksumValue(
+          "e749dc748023730bee5b04f477934cc7fc8e4dc4d98521a82aef471c38235fd6"
+        ),
         name = "tagmanifest-sha512.txt",
         size = 22,
         path = "tagmanifest-sha512.txt"
@@ -84,12 +106,16 @@ class TagManifestFileFinderTest
     val prefix = createObjectLocationPrefix
 
     val result =
-      withTagManifestFileFinder(entries = Map(
-        prefix.asLocation("tagmanifest-md5.txt") -> "My MD5 tag manifest",
-        prefix.asLocation("tagmanifest-sha1.txt") -> "My SHA1 tag manifest",
-        prefix.asLocation("tagmanifest-sha256.txt") -> "My SHA256 tag manifest",
-        prefix.asLocation("tagmanifest-sha512.txt") -> "My SHA512 tag manifest",
-      )) {
+      withTagManifestFileFinder(
+        entries = Map(
+          prefix.asLocation("tagmanifest-md5.txt") -> "My MD5 tag manifest",
+          prefix.asLocation("tagmanifest-sha1.txt") -> "My SHA1 tag manifest",
+          prefix
+            .asLocation("tagmanifest-sha256.txt") -> "My SHA256 tag manifest",
+          prefix
+            .asLocation("tagmanifest-sha512.txt") -> "My SHA512 tag manifest"
+        )
+      ) {
         _.getTagManifestFiles(prefix, algorithm = MD5)
       }
 
@@ -125,22 +151,30 @@ class TagManifestFileFinderTest
     val prefix = createObjectLocationPrefix
 
     val result =
-      withTagManifestFileFinder(entries = Map(
-        prefix.asLocation("tagmanifest-sha256.txt") -> "My SHA256 tag manifest",
-        prefix.asLocation("tagmanifest-sha512.txt") -> "My SHA512 tag manifest",
-      )) {
+      withTagManifestFileFinder(
+        entries = Map(
+          prefix
+            .asLocation("tagmanifest-sha256.txt") -> "My SHA256 tag manifest",
+          prefix
+            .asLocation("tagmanifest-sha512.txt") -> "My SHA512 tag manifest"
+        )
+      ) {
         _.getTagManifestFiles(prefix, algorithm = SHA256)
       }
 
     result.success.value should contain theSameElementsAs Seq(
       StorageManifestFile(
-        checksum = ChecksumValue("1359a6582aa673ed377f017abd62f2f4f6fc77cb9477423444b95ba0996f3f14"),
+        checksum = ChecksumValue(
+          "1359a6582aa673ed377f017abd62f2f4f6fc77cb9477423444b95ba0996f3f14"
+        ),
         name = "tagmanifest-sha256.txt",
         size = 22,
         path = "tagmanifest-sha256.txt"
       ),
       StorageManifestFile(
-        checksum = ChecksumValue("e749dc748023730bee5b04f477934cc7fc8e4dc4d98521a82aef471c38235fd6"),
+        checksum = ChecksumValue(
+          "e749dc748023730bee5b04f477934cc7fc8e4dc4d98521a82aef471c38235fd6"
+        ),
         name = "tagmanifest-sha512.txt",
         size = 22,
         path = "tagmanifest-sha512.txt"
@@ -162,10 +196,11 @@ class TagManifestFileFinderTest
   it("fails if the underlying reader has an error") {
     val prefix = createObjectLocationPrefix
 
-    implicit val brokenReader = new Readable[ObjectLocation, InputStreamWithLength] {
-      override def get(id: ObjectLocation): this.ReadEither =
-        Left(StoreReadError(new Throwable("BOOM!")))
-    }
+    implicit val brokenReader =
+      new Readable[ObjectLocation, InputStreamWithLength] {
+        override def get(id: ObjectLocation): this.ReadEither =
+          Left(StoreReadError(new Throwable("BOOM!")))
+      }
 
     val tagManifestFileFinder = new TagManifestFileFinder()
 
@@ -175,6 +210,8 @@ class TagManifestFileFinderTest
     )
 
     result.failed.get shouldBe a[RuntimeException]
-    result.failed.get.getMessage should startWith(s"Error looking up $prefix/tagmanifest-md5.txt:")
+    result.failed.get.getMessage should startWith(
+      s"Error looking up $prefix/tagmanifest-md5.txt:"
+    )
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/TagManifestFileFinderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/TagManifestFileFinderTest.scala
@@ -1,0 +1,80 @@
+package uk.ac.wellcome.platform.archive.common.storage.services
+import org.scalatest.{EitherValues, FunSpec, Matchers, TryValues}
+import uk.ac.wellcome.fixtures.TestWith
+import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifestFile
+import uk.ac.wellcome.platform.archive.common.verify.{ChecksumValue, SHA256}
+import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
+import uk.ac.wellcome.storage.store.memory.MemoryStreamStoreFixtures
+import uk.ac.wellcome.storage.streaming.Codec._
+import uk.ac.wellcome.storage.streaming.InputStreamWithLengthAndMetadata
+
+class TagManifestFileFinderTest
+  extends FunSpec
+    with Matchers
+    with EitherValues
+    with TryValues
+    with ObjectLocationGenerators
+    with MemoryStreamStoreFixtures[ObjectLocation] {
+
+  def withTagManifestFileFinder[R](entries: Map[ObjectLocation, String])(testWith: TestWith[TagManifestFileFinder[_], R]): R =
+    withStreamStoreContext { memoryStore =>
+      val initialEntries = entries
+        .map {
+          case (loc, str) =>
+            val is = InputStreamWithLengthAndMetadata(
+              stringCodec.toStream(str).right.value,
+              metadata = Map.empty
+            )
+
+            (loc, is)
+        }
+
+      withMemoryStreamStoreImpl(memoryStore, initialEntries = initialEntries) { implicit streamStore =>
+        testWith(
+          new TagManifestFileFinder()
+        )
+      }
+    }
+
+  it("handles a bag that contains all four tag manifest files") {
+    val prefix = createObjectLocationPrefix
+
+    val result =
+      withTagManifestFileFinder(entries = Map(
+        prefix.asLocation("tagmanifest-md5.txt") -> "My MD5 tag manifest",
+        prefix.asLocation("tagmanifest-sha1.txt") -> "My SHA1 tag manifest",
+        prefix.asLocation("tagmanifest-sha256.txt") -> "My SHA256 tag manifest",
+        prefix.asLocation("tagmanifest-sha512.txt") -> "My SHA512 tag manifest",
+      )) {
+        _.getTagManifestFiles(prefix, algorithm = SHA256)
+      }
+
+    result.success.value should contain theSameElementsAs Seq(
+      StorageManifestFile(
+        checksum = ChecksumValue("fe9a209b4ef3426c9b30e7808047689e3bacedb0aa58db91cf2aa355834199c1"),
+        name = "tagmanifest-md5.txt",
+        size = 19,
+        path = "tagmanifest-md5.txt"
+      ),
+      StorageManifestFile(
+        checksum = ChecksumValue("3a2d9e87f82ca9c6fb16b8af5968e405f8952cedc73134e3b222a6e5f45aedff"),
+        name = "tagmanifest-sha1.txt",
+        size = 20,
+        path = "tagmanifest-sha1.txt"
+      ),
+      StorageManifestFile(
+        checksum = ChecksumValue("1359a6582aa673ed377f017abd62f2f4f6fc77cb9477423444b95ba0996f3f14"),
+        name = "tagmanifest-sha256.txt",
+        size = 22,
+        path = "tagmanifest-sha256.txt"
+      ),
+      StorageManifestFile(
+        checksum = ChecksumValue("e749dc748023730bee5b04f477934cc7fc8e4dc4d98521a82aef471c38235fd6"),
+        name = "tagmanifest-sha512.txt",
+        size = 22,
+        path = "tagmanifest-sha512.txt"
+      )
+    )
+  }
+}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/TagManifestFileFinderTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/TagManifestFileFinderTest.scala
@@ -1,13 +1,15 @@
 package uk.ac.wellcome.platform.archive.common.storage.services
+
 import org.scalatest.{EitherValues, FunSpec, Matchers, TryValues}
 import uk.ac.wellcome.fixtures.TestWith
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageManifestFile
-import uk.ac.wellcome.platform.archive.common.verify.{ChecksumValue, SHA256}
-import uk.ac.wellcome.storage.ObjectLocation
+import uk.ac.wellcome.platform.archive.common.verify.{ChecksumValue, MD5, SHA256}
+import uk.ac.wellcome.storage.{ObjectLocation, StoreReadError}
 import uk.ac.wellcome.storage.generators.ObjectLocationGenerators
+import uk.ac.wellcome.storage.store.Readable
 import uk.ac.wellcome.storage.store.memory.MemoryStreamStoreFixtures
 import uk.ac.wellcome.storage.streaming.Codec._
-import uk.ac.wellcome.storage.streaming.InputStreamWithLengthAndMetadata
+import uk.ac.wellcome.storage.streaming.{InputStreamWithLength, InputStreamWithLengthAndMetadata}
 
 class TagManifestFileFinderTest
   extends FunSpec
@@ -76,5 +78,103 @@ class TagManifestFileFinderTest
         path = "tagmanifest-sha512.txt"
       )
     )
+  }
+
+  it("uses the selected algorithm to create the checksums") {
+    val prefix = createObjectLocationPrefix
+
+    val result =
+      withTagManifestFileFinder(entries = Map(
+        prefix.asLocation("tagmanifest-md5.txt") -> "My MD5 tag manifest",
+        prefix.asLocation("tagmanifest-sha1.txt") -> "My SHA1 tag manifest",
+        prefix.asLocation("tagmanifest-sha256.txt") -> "My SHA256 tag manifest",
+        prefix.asLocation("tagmanifest-sha512.txt") -> "My SHA512 tag manifest",
+      )) {
+        _.getTagManifestFiles(prefix, algorithm = MD5)
+      }
+
+    result.success.value should contain theSameElementsAs Seq(
+      StorageManifestFile(
+        checksum = ChecksumValue("825a10d25c6d52e83482918cbe9320ac"),
+        name = "tagmanifest-md5.txt",
+        size = 19,
+        path = "tagmanifest-md5.txt"
+      ),
+      StorageManifestFile(
+        checksum = ChecksumValue("e32d1253cebc7426cf09f5ff18153333"),
+        name = "tagmanifest-sha1.txt",
+        size = 20,
+        path = "tagmanifest-sha1.txt"
+      ),
+      StorageManifestFile(
+        checksum = ChecksumValue("0c55b168d2be86bcf9e372cd0128154c"),
+        name = "tagmanifest-sha256.txt",
+        size = 22,
+        path = "tagmanifest-sha256.txt"
+      ),
+      StorageManifestFile(
+        checksum = ChecksumValue("2c7c12559437326973adc7ec5a0328ab"),
+        name = "tagmanifest-sha512.txt",
+        size = 22,
+        path = "tagmanifest-sha512.txt"
+      )
+    )
+  }
+
+  it("returns only the tag manifest files that are present") {
+    val prefix = createObjectLocationPrefix
+
+    val result =
+      withTagManifestFileFinder(entries = Map(
+        prefix.asLocation("tagmanifest-sha256.txt") -> "My SHA256 tag manifest",
+        prefix.asLocation("tagmanifest-sha512.txt") -> "My SHA512 tag manifest",
+      )) {
+        _.getTagManifestFiles(prefix, algorithm = SHA256)
+      }
+
+    result.success.value should contain theSameElementsAs Seq(
+      StorageManifestFile(
+        checksum = ChecksumValue("1359a6582aa673ed377f017abd62f2f4f6fc77cb9477423444b95ba0996f3f14"),
+        name = "tagmanifest-sha256.txt",
+        size = 22,
+        path = "tagmanifest-sha256.txt"
+      ),
+      StorageManifestFile(
+        checksum = ChecksumValue("e749dc748023730bee5b04f477934cc7fc8e4dc4d98521a82aef471c38235fd6"),
+        name = "tagmanifest-sha512.txt",
+        size = 22,
+        path = "tagmanifest-sha512.txt"
+      )
+    )
+  }
+
+  it("fails if it doesn't find any files") {
+    val prefix = createObjectLocationPrefix
+
+    val result = withTagManifestFileFinder(entries = Map.empty) {
+      _.getTagManifestFiles(prefix, algorithm = SHA256)
+    }
+
+    result.failed.get shouldBe a[RuntimeException]
+    result.failed.get.getMessage shouldBe s"No tag manifest files found under $prefix"
+  }
+
+  it("fails if the underlying reader has an error") {
+    val prefix = createObjectLocationPrefix
+
+    implicit val brokenReader = new Readable[ObjectLocation, InputStreamWithLength] {
+      override def get(id: ObjectLocation): this.ReadEither =
+        Left(StoreReadError(new Throwable("BOOM!")))
+    }
+
+    val tagManifestFileFinder = new TagManifestFileFinder()
+
+    val result = tagManifestFileFinder.getTagManifestFiles(
+      prefix = prefix,
+      algorithm = SHA256
+    )
+
+    result.failed.get shouldBe a[RuntimeException]
+    result.failed.get.getMessage should startWith(s"Error looking up $prefix/tagmanifest-md5.txt:")
   }
 }


### PR DESCRIPTION
Code fix for https://github.com/wellcometrust/platform/issues/4012

This will ensure that all new bags we register get a `tagmanifest-sha256.txt` entry in the `tagManifest` field of the storage service manifest, where previously they didn't.

Backfilling old bags will be handled separately.

(Too many manifests!)