### PR TITLE
Compress a downloaded bag under a single directory, add modified dates

### DIFF
--- a/.travis/run_job.py
+++ b/.travis/run_job.py
@@ -49,10 +49,7 @@ def should_run_sbt_project(repo, project_name, changed_paths):
         if path.endswith(".tf"):
             continue
 
-        if path.startswith("bagger/") and os.environ.get("TASK") not in {
-            "bagger-publish",
-            "travis-format",
-        }:
+        if path.startswith("python_client/"):
             continue
 
         if path.endswith("Makefile"):

--- a/python_client/CHANGELOG.md
+++ b/python_client/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## Unreleased
+## v1.4.0 - 2019-11-11
 
 Improvements to the way compressed bags are downloaded, specifically:
 

--- a/python_client/CHANGELOG.md
+++ b/python_client/CHANGELOG.md
@@ -1,5 +1,12 @@
 # CHANGELOG
 
+## Unreleased
+
+Improvements to the way compressed bags are downloaded, specifically:
+
+-   The modified time inside the archive is set to the creation date of the storage manifest
+-   Files are now compressed within a directory inside the archive, so unpacking the archive with `tar -xzf` will put all the files inside a directory
+
 ## v1.3.0 - 2019-10-23
 
 Add two methods for downloading the complete contents of a bag to disk.  Namely:

--- a/python_client/src/wellcome_storage_service/downloader.py
+++ b/python_client/src/wellcome_storage_service/downloader.py
@@ -74,8 +74,7 @@ def download_compressed_bag(storage_manifest, out_path):
 
             # Set the modified time to the creation dateb of the storage manifest
             creation_date = dt.datetime.strptime(
-                storage_manifest["createdDate"],
-                "%Y-%m-%dT%H:%M:%S.%fZ"
+                storage_manifest["createdDate"], "%Y-%m-%dT%H:%M:%S.%fZ"
             )
             tarinfo.mtime = time.mktime(creation_date.timetuple())
 

--- a/python_client/src/wellcome_storage_service/downloader.py
+++ b/python_client/src/wellcome_storage_service/downloader.py
@@ -1,8 +1,10 @@
 # -*- encoding: utf-8
 
 import abc
+import datetime as dt
 import os
 import tarfile
+import time
 
 try:
     from collections.abc import ABC
@@ -69,6 +71,13 @@ def download_compressed_bag(storage_manifest, out_path):
                 name=os.path.join(ext_identifier, manifest_file["name"])
             )
             tarinfo.size = manifest_file["size"]
+
+            # Set the modified time to the creation dateb of the storage manifest
+            creation_date = dt.datetime.strptime(
+                storage_manifest["createdDate"],
+                "%Y-%m-%dT%H:%M:%S.%fZ"
+            )
+            tarinfo.mtime = time.mktime(creation_date.timetuple())
 
             tf.addfile(tarinfo=tarinfo, fileobj=fileobj)
 

--- a/python_client/src/wellcome_storage_service/downloader.py
+++ b/python_client/src/wellcome_storage_service/downloader.py
@@ -57,13 +57,17 @@ def download_compressed_bag(storage_manifest, out_path):
     location = storage_manifest["location"]
     provider = _choose_provider(location)
 
+    ext_identifier = storage_manifest["info"]["externalIdentifier"]
+
     with tarfile.open(out_path, "w:gz") as tf:
         for manifest_file in _all_files(storage_manifest):
             fileobj = provider.get_fileobj(
                 location=location, manifest_file=manifest_file
             )
 
-            tarinfo = tarfile.TarInfo(name=manifest_file["name"])
+            tarinfo = tarfile.TarInfo(
+                name=os.path.join(ext_identifier, manifest_file["name"])
+            )
             tarinfo.size = manifest_file["size"]
 
             tf.addfile(tarinfo=tarinfo, fileobj=fileobj)

--- a/python_client/src/wellcome_storage_service/version.py
+++ b/python_client/src/wellcome_storage_service/version.py
@@ -1,4 +1,4 @@
 # -*- encoding: utf-8 -*-
 
-__version_info__ = (1, 3, 0)
+__version_info__ = (1, 4, 0)
 __version__ = ".".join(map(str, __version_info__))

--- a/python_client/tests/cassettes/test_downloading_compressed_bag.json
+++ b/python_client/tests/cassettes/test_downloading_compressed_bag.json
@@ -1,0 +1,207 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2019-11-07T10:39:04",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=client_credentials"
+        },
+        "headers": {
+          "Accept": [
+            "application/json"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "<AUTH_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "29"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded;charset=UTF-8"
+          ],
+          "User-Agent": [
+            "python-requests/2.21.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://auth.wellcomecollection.org/oauth2/token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\":\"<ACCESS_TOKEN_13>\",\"expires_in\":3600,\"token_type\":\"Bearer\"}"
+        },
+        "headers": {
+          "Cache-Control": [
+            "no-cache, no-store, max-age=0, must-revalidate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json;charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 07 Nov 2019 10:39:04 GMT"
+          ],
+          "Expires": [
+            "0"
+          ],
+          "Pragma": [
+            "no-cache"
+          ],
+          "Server": [
+            "Server"
+          ],
+          "Set-Cookie": [
+            "XSRF-TOKEN=482fdc65-f1af-4d88-9174-a05ba2fb5086; Path=/; Secure; HttpOnly"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000 ; includeSubDomains"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Via": [
+            "1.1 2fafb26bfb5e0420de152a7abef27a44.cloudfront.net (CloudFront)"
+          ],
+          "X-Amz-Cf-Id": [
+            "3CP5hRpzZl-B_l3epAhDVps8ce-eqK_Wr5dawlSlYNlEEG3Y7rYx0w=="
+          ],
+          "X-Amz-Cf-Pop": [
+            "LHR52-C1"
+          ],
+          "X-Application-Context": [
+            "application:prod:8443"
+          ],
+          "X-Cache": [
+            "Miss from cloudfront"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "DENY"
+          ],
+          "X-XSS-Protection": [
+            "1; mode=block"
+          ],
+          "x-amz-cognito-request-id": [
+            "78d618fd-d005-48fc-a2f2-a5158198eba3"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://auth.wellcomecollection.org/oauth2/token"
+      }
+    },
+    {
+      "recorded_at": "2019-11-07T10:39:04",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN_13>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.21.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://api.wellcomecollection.org/storage/v1/bags/digitised/b11733330"
+      },
+      "response": {
+        "body": {
+          "encoding": null,
+          "string": "{\"@context\":\"https://api.wellcomecollection.org/context.json\",\"id\":\"digitised/b11733330\",\"space\":{\"id\":\"digitised\",\"type\":\"Space\"},\"info\":{\"externalIdentifier\":\"b11733330\",\"payloadOxum\":\"1335376.2\",\"baggingDate\":\"2019-08-22\",\"sourceOrganization\":\"Intranda GmbH\",\"externalDescription\":\"Thomas Wakley. Stipple engraving by W. H. Egleton after J.K. Meadows.\",\"type\":\"BagInfo\"},\"manifest\":{\"checksumAlgorithm\":\"SHA-256\",\"files\":[{\"checksum\":\"c195e863630433d2e5e92d5970cfab7321568657d29439c00d35e4c4f6990993\",\"name\":\"data/b11733330.xml\",\"path\":\"v1/data/b11733330.xml\",\"size\":8132,\"type\":\"File\"},{\"checksum\":\"ac4fde3a0e2188de91b3e961310a978e749cf456f18d5830ffcffd59111385ba\",\"name\":\"data/objects/L0008210-LS-CS.jp2\",\"path\":\"v1/data/objects/L0008210-LS-CS.jp2\",\"size\":1327244,\"type\":\"File\"}],\"type\":\"BagManifest\"},\"tagManifest\":{\"checksumAlgorithm\":\"SHA-256\",\"files\":[{\"checksum\":\"894867de4f57a3ed316ec43138190cdd752da95bfa68fd96a7721808bfdcbd5a\",\"name\":\"manifest-sha256.txt\",\"path\":\"v1/manifest-sha256.txt\",\"size\":183,\"type\":\"File\"},{\"checksum\":\"e91f941be5973ff71f1dccbdd1a32d598881893a7f21be516aca743da38b1689\",\"name\":\"bagit.txt\",\"path\":\"v1/bagit.txt\",\"size\":55,\"type\":\"File\"},{\"checksum\":\"d9cf709e5fb7a93a55ba9bd6b69be72a50b5921c97bc67d6e6b2c843b3c32b73\",\"name\":\"manifest-sha512.txt\",\"path\":\"v1/manifest-sha512.txt\",\"size\":311,\"type\":\"File\"},{\"checksum\":\"c793b81c816fcab9b469a6db9a1ba885f5f3ae69a8b8c71eef578e794f370e4d\",\"name\":\"bag-info.txt\",\"path\":\"v1/bag-info.txt\",\"size\":331,\"type\":\"File\"},{\"checksum\":\"8b840d1a71e0d1d127fcad5bd7ba966215161e0883390a3f746d01c438931885\",\"name\":\"tagmanifest-sha256.txt\",\"path\":\"v1/tagmanifest-sha256.txt\",\"size\":323,\"type\":\"File\"},{\"checksum\":\"ce305bde91373d26103390e939611041bd9a58ce74048c85cad7665896fbe5f6\",\"name\":\"tagmanifest-sha512.txt\",\"path\":\"v1/tagmanifest-sha512.txt\",\"size\":579,\"type\":\"File\"}],\"type\":\"BagManifest\"},\"location\":{\"provider\":{\"id\":\"aws-s3-ia\",\"type\":\"Provider\"},\"bucket\":\"wellcomecollection-storage\",\"path\":\"digitised/b11733330\",\"type\":\"Location\"},\"replicaLocations\":[{\"provider\":{\"id\":\"aws-s3-glacier\",\"type\":\"Provider\"},\"bucket\":\"wellcomecollection-storage-replica-ireland\",\"path\":\"digitised/b11733330\",\"type\":\"Location\"}],\"createdDate\":\"2019-09-12T20:26:53.094757Z\",\"version\":\"v1\",\"type\":\"Bag\"}"
+        },
+        "headers": {
+          "Access-Control-Allow-Credentials": [
+            "true"
+          ],
+          "Access-Control-Allow-Headers": [
+            "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type"
+          ],
+          "Access-Control-Allow-Methods": [
+            "GET, POST, OPTIONS"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2252"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Thu, 07 Nov 2019 10:39:04 GMT"
+          ],
+          "ETag": [
+            "\"digitised/b11733330/v1\""
+          ],
+          "Via": [
+            "1.1 15c672a1a96e298467d88307b9c85a7b.cloudfront.net (CloudFront)"
+          ],
+          "X-Amz-Cf-Id": [
+            "-jc4XfEX5M-1Rc7opF7vHXtP7Ne7Kh5ql1uA3pfa-TEIbu4zyZ8DwQ=="
+          ],
+          "X-Amz-Cf-Pop": [
+            "LHR52-C1"
+          ],
+          "X-Cache": [
+            "Miss from cloudfront"
+          ],
+          "x-amz-apigw-id": [
+            "CyMbTEmjDoEF-yQ="
+          ],
+          "x-amzn-Remapped-Connection": [
+            "keep-alive"
+          ],
+          "x-amzn-Remapped-Content-Length": [
+            "2252"
+          ],
+          "x-amzn-Remapped-Date": [
+            "Thu, 07 Nov 2019 10:39:04 GMT"
+          ],
+          "x-amzn-Remapped-Server": [
+            "nginx"
+          ],
+          "x-amzn-RequestId": [
+            "0f118ee5-0781-4a77-a926-c30e1b04f22d"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.wellcomecollection.org/storage/v1/bags/digitised/b11733330"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/python_client/tests/cassettes/test_downloading_compressed_bag.json
+++ b/python_client/tests/cassettes/test_downloading_compressed_bag.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2019-11-07T10:39:04",
+      "recorded_at": "2019-11-07T10:46:48",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -49,7 +49,7 @@
             "application/json;charset=UTF-8"
           ],
           "Date": [
-            "Thu, 07 Nov 2019 10:39:04 GMT"
+            "Thu, 07 Nov 2019 10:46:48 GMT"
           ],
           "Expires": [
             "0"
@@ -61,7 +61,7 @@
             "Server"
           ],
           "Set-Cookie": [
-            "XSRF-TOKEN=482fdc65-f1af-4d88-9174-a05ba2fb5086; Path=/; Secure; HttpOnly"
+            "XSRF-TOKEN=99255a18-d2b5-44fe-951c-527b6bcd0ce5; Path=/; Secure; HttpOnly"
           ],
           "Strict-Transport-Security": [
             "max-age=31536000 ; includeSubDomains"
@@ -70,13 +70,13 @@
             "chunked"
           ],
           "Via": [
-            "1.1 2fafb26bfb5e0420de152a7abef27a44.cloudfront.net (CloudFront)"
+            "1.1 a654b4b54d3322bdcbd8b65f511761c1.cloudfront.net (CloudFront)"
           ],
           "X-Amz-Cf-Id": [
-            "3CP5hRpzZl-B_l3epAhDVps8ce-eqK_Wr5dawlSlYNlEEG3Y7rYx0w=="
+            "XAwdT5_NeUvyEc8LkelrVryM5mS2PfF-1A7RjFuAxPCfZPMm6J8NFA=="
           ],
           "X-Amz-Cf-Pop": [
-            "LHR52-C1"
+            "LHR3-C1"
           ],
           "X-Application-Context": [
             "application:prod:8443"
@@ -94,7 +94,7 @@
             "1; mode=block"
           ],
           "x-amz-cognito-request-id": [
-            "78d618fd-d005-48fc-a2f2-a5158198eba3"
+            "1af28590-9f27-4dfd-a4b7-73680520963b"
           ]
         },
         "status": {
@@ -105,7 +105,7 @@
       }
     },
     {
-      "recorded_at": "2019-11-07T10:39:04",
+      "recorded_at": "2019-11-07T10:46:48",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -129,7 +129,7 @@
           ]
         },
         "method": "GET",
-        "uri": "https://api.wellcomecollection.org/storage/v1/bags/digitised/b11733330"
+        "uri": "https://api.wellcomecollection.org/storage/v1/bags/digitised/b11733330?version=v1"
       },
       "response": {
         "body": {
@@ -159,25 +159,25 @@
             "application/json"
           ],
           "Date": [
-            "Thu, 07 Nov 2019 10:39:04 GMT"
+            "Thu, 07 Nov 2019 10:46:48 GMT"
           ],
           "ETag": [
             "\"digitised/b11733330/v1\""
           ],
           "Via": [
-            "1.1 15c672a1a96e298467d88307b9c85a7b.cloudfront.net (CloudFront)"
+            "1.1 d31be1bb3cd2f187c0f45c1f03ead3c6.cloudfront.net (CloudFront)"
           ],
           "X-Amz-Cf-Id": [
-            "-jc4XfEX5M-1Rc7opF7vHXtP7Ne7Kh5ql1uA3pfa-TEIbu4zyZ8DwQ=="
+            "PU-xkdGb112E2s2dWLgCCyCZYcB6XKZbWmjUpYMCdMDoBb7eSJ4NSw=="
           ],
           "X-Amz-Cf-Pop": [
-            "LHR52-C1"
+            "LHR3-C2"
           ],
           "X-Cache": [
             "Miss from cloudfront"
           ],
           "x-amz-apigw-id": [
-            "CyMbTEmjDoEF-yQ="
+            "CyNj1EE9DoEFplw="
           ],
           "x-amzn-Remapped-Connection": [
             "keep-alive"
@@ -186,20 +186,20 @@
             "2252"
           ],
           "x-amzn-Remapped-Date": [
-            "Thu, 07 Nov 2019 10:39:04 GMT"
+            "Thu, 07 Nov 2019 10:46:48 GMT"
           ],
           "x-amzn-Remapped-Server": [
             "nginx"
           ],
           "x-amzn-RequestId": [
-            "0f118ee5-0781-4a77-a926-c30e1b04f22d"
+            "514784fe-f712-4664-adec-90e9e623f56d"
           ]
         },
         "status": {
           "code": 200,
           "message": "OK"
         },
-        "url": "https://api.wellcomecollection.org/storage/v1/bags/digitised/b11733330"
+        "url": "https://api.wellcomecollection.org/storage/v1/bags/digitised/b11733330?version=v1"
       }
     }
   ],

--- a/python_client/tests/test_downloader.py
+++ b/python_client/tests/test_downloader.py
@@ -1,6 +1,8 @@
 # -*- encoding: utf-8
 
+import datetime as dt
 import tarfile
+import time
 
 from botocore.exceptions import ClientError
 import pytest
@@ -77,6 +79,9 @@ class TestS3IADownload(object):
             "tagmanifest-sha512.txt": 579,
         }
 
+        creation_date = dt.datetime(2019, 9, 12, 20, 26, 53)
+        timestamp = time.mktime(creation_date.timetuple())
+
         with tarfile.open(str(out_path), "r:gz") as tf:
             members = tf.getmembers()
             assert len(members) == len(files)
@@ -88,6 +93,9 @@ class TestS3IADownload(object):
 
                 inner_name = tarinfo.name[len("b11733330/"):]
                 assert files[inner_name] == tarinfo.size
+
+                # Check the date matches that of the original manifest
+                assert tarinfo.mtime == timestamp
 
             bagit = tf.getmember("b11733330/bagit.txt")
             tf.extract(bagit, path=str(tmpdir))

--- a/python_client/tests/test_downloader.py
+++ b/python_client/tests/test_downloader.py
@@ -91,7 +91,7 @@ class TestS3IADownload(object):
                 # All files in the compressed bag are under a directory
                 assert tarinfo.name.startswith("b11733330/")
 
-                inner_name = tarinfo.name[len("b11733330/"):]
+                inner_name = tarinfo.name[len("b11733330/") :]
                 assert files[inner_name] == tarinfo.size
 
                 # Check the date matches that of the original manifest

--- a/python_client/tests/test_downloader.py
+++ b/python_client/tests/test_downloader.py
@@ -64,7 +64,7 @@ class TestS3IADownload(object):
         # only 1.3MB in size, and we can download the whole thing.
         out_path = tmpdir.join("b11733330.tar.gz")
 
-        bag = client.get_bag("digitised", "b11733330")
+        bag = client.get_bag("digitised", "b11733330", "v1")
 
         downloader.download_compressed_bag(bag, out_path=str(out_path))
 


### PR DESCRIPTION
Closes https://github.com/wellcometrust/platform/issues/4007, closes https://github.com/wellcometrust/platform/issues/4008

I don't think we need to create directory entries explicitly; I think `tarfile.addfile()` does it implicitly. We'll find out when we deploy it!

For https://github.com/wellcometrust/platform/issues/4004