### PR TITLE
Use DEEP_ARCHIVE storage class for the Glacier replica

### DIFF
--- a/terraform/modules/critical/s3_replica_glacier.tf
+++ b/terraform/modules/critical/s3_replica_glacier.tf
@@ -7,7 +7,7 @@ resource "aws_s3_bucket" "replica_glacier" {
 
     transition {
       days          = 90
-      storage_class = "GLACIER"
+      storage_class = "DEEP_ARCHIVE"
     }
   }
 }


### PR DESCRIPTION
This is cheaper, with the downsides that it's slower to retrieve and the minimum storage time is longer.  Neither of these are an issue for us!

This change is already applied.

Closes https://github.com/wellcometrust/platform/issues/4013