### PR TITLE
Ensure a compressed bag download includes directory entries

### DIFF
--- a/python_client/CHANGELOG.md
+++ b/python_client/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v1.4.1 - 2019-11-14
+
+Change to the way compressed bags are downloaded, so now the archive includes
+directory entries.
+
 ## v1.4.0 - 2019-11-11
 
 Improvements to the way compressed bags are downloaded, specifically:

--- a/python_client/src/wellcome_storage_service/downloader.py
+++ b/python_client/src/wellcome_storage_service/downloader.py
@@ -2,6 +2,7 @@
 
 import abc
 import os
+import shutil
 import tarfile
 import tempfile
 
@@ -59,10 +60,11 @@ def download_compressed_bag(storage_manifest, out_path):
 
     temp_dir = tempfile.mkdtemp()
     download_bag(storage_manifest=storage_manifest, out_dir=temp_dir)
-    print(temp_dir)
 
     with tarfile.open(out_path, "w:gz") as tf:
         tf.add(temp_dir, arcname=ext_identifier)
+
+    shutil.rmtree(temp_dir)
 
 
 class AbstractProvider(object):

--- a/python_client/src/wellcome_storage_service/version.py
+++ b/python_client/src/wellcome_storage_service/version.py
@@ -1,4 +1,4 @@
 # -*- encoding: utf-8 -*-
 
-__version_info__ = (1, 4, 0)
+__version_info__ = (1, 4, 1)
 __version__ = ".".join(map(str, __version_info__))

--- a/python_client/tests/cassettes/test_downloading_compressed_bag_gets_dir_entries.json
+++ b/python_client/tests/cassettes/test_downloading_compressed_bag_gets_dir_entries.json
@@ -1,0 +1,207 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2019-11-14T12:14:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=client_credentials"
+        },
+        "headers": {
+          "Accept": [
+            "application/json"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "<AUTH_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "29"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded;charset=UTF-8"
+          ],
+          "User-Agent": [
+            "python-requests/2.21.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://auth.wellcomecollection.org/oauth2/token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\":\"<ACCESS_TOKEN_15>\",\"expires_in\":3600,\"token_type\":\"Bearer\"}"
+        },
+        "headers": {
+          "Cache-Control": [
+            "no-cache, no-store, max-age=0, must-revalidate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json;charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 14 Nov 2019 12:14:34 GMT"
+          ],
+          "Expires": [
+            "0"
+          ],
+          "Pragma": [
+            "no-cache"
+          ],
+          "Server": [
+            "Server"
+          ],
+          "Set-Cookie": [
+            "XSRF-TOKEN=8636a1b9-d1f5-4caa-8700-91d9141e64cc; Path=/; Secure; HttpOnly"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000 ; includeSubDomains"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Via": [
+            "1.1 299d6cdcc49a194864ae1dbfa6512d01.cloudfront.net (CloudFront)"
+          ],
+          "X-Amz-Cf-Id": [
+            "sggafiCNdQIypoFmD8yPEV808oh5W5YW-yLdia9WdCq1Nt_p8LXSyA=="
+          ],
+          "X-Amz-Cf-Pop": [
+            "LHR62-C3"
+          ],
+          "X-Application-Context": [
+            "application:prod:8443"
+          ],
+          "X-Cache": [
+            "Miss from cloudfront"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "DENY"
+          ],
+          "X-XSS-Protection": [
+            "1; mode=block"
+          ],
+          "x-amz-cognito-request-id": [
+            "d879716f-308a-4667-b364-93d310eaf1d9"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://auth.wellcomecollection.org/oauth2/token"
+      }
+    },
+    {
+      "recorded_at": "2019-11-14T12:14:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN_15>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.21.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://api.wellcomecollection.org/storage/v1/bags/digitised/b11733330?version=v1"
+      },
+      "response": {
+        "body": {
+          "encoding": null,
+          "string": "{\"@context\":\"https://api.wellcomecollection.org/context.json\",\"id\":\"digitised/b11733330\",\"space\":{\"id\":\"digitised\",\"type\":\"Space\"},\"info\":{\"externalIdentifier\":\"b11733330\",\"payloadOxum\":\"1335376.2\",\"baggingDate\":\"2019-08-22\",\"sourceOrganization\":\"Intranda GmbH\",\"externalDescription\":\"Thomas Wakley. Stipple engraving by W. H. Egleton after J.K. Meadows.\",\"type\":\"BagInfo\"},\"manifest\":{\"checksumAlgorithm\":\"SHA-256\",\"files\":[{\"checksum\":\"c195e863630433d2e5e92d5970cfab7321568657d29439c00d35e4c4f6990993\",\"name\":\"data/b11733330.xml\",\"path\":\"v1/data/b11733330.xml\",\"size\":8132,\"type\":\"File\"},{\"checksum\":\"ac4fde3a0e2188de91b3e961310a978e749cf456f18d5830ffcffd59111385ba\",\"name\":\"data/objects/L0008210-LS-CS.jp2\",\"path\":\"v1/data/objects/L0008210-LS-CS.jp2\",\"size\":1327244,\"type\":\"File\"}],\"type\":\"BagManifest\"},\"tagManifest\":{\"checksumAlgorithm\":\"SHA-256\",\"files\":[{\"checksum\":\"894867de4f57a3ed316ec43138190cdd752da95bfa68fd96a7721808bfdcbd5a\",\"name\":\"manifest-sha256.txt\",\"path\":\"v1/manifest-sha256.txt\",\"size\":183,\"type\":\"File\"},{\"checksum\":\"e91f941be5973ff71f1dccbdd1a32d598881893a7f21be516aca743da38b1689\",\"name\":\"bagit.txt\",\"path\":\"v1/bagit.txt\",\"size\":55,\"type\":\"File\"},{\"checksum\":\"d9cf709e5fb7a93a55ba9bd6b69be72a50b5921c97bc67d6e6b2c843b3c32b73\",\"name\":\"manifest-sha512.txt\",\"path\":\"v1/manifest-sha512.txt\",\"size\":311,\"type\":\"File\"},{\"checksum\":\"c793b81c816fcab9b469a6db9a1ba885f5f3ae69a8b8c71eef578e794f370e4d\",\"name\":\"bag-info.txt\",\"path\":\"v1/bag-info.txt\",\"size\":331,\"type\":\"File\"},{\"checksum\":\"8b840d1a71e0d1d127fcad5bd7ba966215161e0883390a3f746d01c438931885\",\"name\":\"tagmanifest-sha256.txt\",\"path\":\"v1/tagmanifest-sha256.txt\",\"size\":323,\"type\":\"File\"},{\"checksum\":\"ce305bde91373d26103390e939611041bd9a58ce74048c85cad7665896fbe5f6\",\"name\":\"tagmanifest-sha512.txt\",\"path\":\"v1/tagmanifest-sha512.txt\",\"size\":579,\"type\":\"File\"}],\"type\":\"BagManifest\"},\"location\":{\"provider\":{\"id\":\"aws-s3-ia\",\"type\":\"Provider\"},\"bucket\":\"wellcomecollection-storage\",\"path\":\"digitised/b11733330\",\"type\":\"Location\"},\"replicaLocations\":[{\"provider\":{\"id\":\"aws-s3-glacier\",\"type\":\"Provider\"},\"bucket\":\"wellcomecollection-storage-replica-ireland\",\"path\":\"digitised/b11733330\",\"type\":\"Location\"}],\"createdDate\":\"2019-09-12T20:26:53.094757Z\",\"version\":\"v1\",\"type\":\"Bag\"}"
+        },
+        "headers": {
+          "Access-Control-Allow-Credentials": [
+            "true"
+          ],
+          "Access-Control-Allow-Headers": [
+            "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type"
+          ],
+          "Access-Control-Allow-Methods": [
+            "GET, POST, OPTIONS"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2252"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Thu, 14 Nov 2019 12:14:34 GMT"
+          ],
+          "ETag": [
+            "\"digitised/b11733330/v1\""
+          ],
+          "Via": [
+            "1.1 c72aed82acf017b1476dc574b8d5da80.cloudfront.net (CloudFront)"
+          ],
+          "X-Amz-Cf-Id": [
+            "EcSdLxLdpoUD5QCvuP8tWNYtBvHcvslsKEa4yKdJCWXVHKttdWjIyQ=="
+          ],
+          "X-Amz-Cf-Pop": [
+            "LHR62-C3"
+          ],
+          "X-Cache": [
+            "Miss from cloudfront"
+          ],
+          "x-amz-apigw-id": [
+            "DJe-pHn2joEF4Pw="
+          ],
+          "x-amzn-Remapped-Connection": [
+            "keep-alive"
+          ],
+          "x-amzn-Remapped-Content-Length": [
+            "2252"
+          ],
+          "x-amzn-Remapped-Date": [
+            "Thu, 14 Nov 2019 12:14:34 GMT"
+          ],
+          "x-amzn-Remapped-Server": [
+            "nginx"
+          ],
+          "x-amzn-RequestId": [
+            "4eda9e84-8d14-408f-a443-b39e68f39003"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.wellcomecollection.org/storage/v1/bags/digitised/b11733330?version=v1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/python_client/tests/test_downloader.py
+++ b/python_client/tests/test_downloader.py
@@ -78,11 +78,7 @@ class TestS3IADownload(object):
         }
 
         with tarfile.open(str(out_path), "r:gz") as tf:
-            tarred_files = [
-                member
-                for member in tf.getmembers()
-                if member.isfile()
-            ]
+            tarred_files = [member for member in tf.getmembers() if member.isfile()]
 
             assert len(tarred_files) == len(files)
 
@@ -91,7 +87,7 @@ class TestS3IADownload(object):
                 # All files in the compressed bag are under a directory
                 assert tarinfo.name.startswith("b11733330/")
 
-                inner_name = tarinfo.name[len("b11733330/"):]
+                inner_name = tarinfo.name[len("b11733330/") :]
                 assert files[inner_name] == tarinfo.size
 
             bagit = tf.getmember("b11733330/bagit.txt")
@@ -109,17 +105,11 @@ class TestS3IADownload(object):
 
         downloader.download_compressed_bag(bag, out_path=str(out_path))
 
-        directories = {
-            "b11733330",
-            "b11733330/data",
-            "b11733330/data/objects"
-        }
+        directories = {"b11733330", "b11733330/data", "b11733330/data/objects"}
 
         with tarfile.open(str(out_path), "r:gz") as tf:
             tarred_directories = {
-                member.name
-                for member in tf.getmembers()
-                if member.isdir()
+                member.name for member in tf.getmembers() if member.isdir()
             }
 
             assert tarred_directories == directories


### PR DESCRIPTION
For https://github.com/wellcometrust/platform/issues/4004

I hadn't realised lsar was being used inside Archivematica, or I'd have paid more attention to this the first time round – handily we can simplify this code *and* get directory entries for free.