### PR TITLE
Use nginx defined in the storage service

### DIFF
--- a/.travis/run_job.py
+++ b/.travis/run_job.py
@@ -49,7 +49,7 @@ def should_run_sbt_project(repo, project_name, changed_paths):
         if path.endswith(".tf"):
             continue
 
-        if path.startswith("python_client/"):
+        if path.startswith(("python_client/", "nginx/")):
             continue
 
         if path.endswith("Makefile"):

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ ACCOUNT_ID = 975596993436
 include makefiles/functions.Makefile
 include makefiles/formatting.Makefile
 include api/Makefile
+include nginx/Makefile
 include python_client/Makefile
 
 PROJECT_ID = storage

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,6 @@
+FROM nginx:1.15.8-alpine
+
+COPY nginx.conf /etc/nginx/nginx.conf.template
+
+RUN apk add --update bash gettext
+CMD /bin/bash -c "envsubst '\$APP_HOST \$APP_PORT' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf && cat /etc/nginx/nginx.conf && nginx -g 'daemon off;'"

--- a/nginx/Makefile
+++ b/nginx/Makefile
@@ -1,0 +1,10 @@
+ACCOUNT_ID = 975596993436
+
+ROOT = $(shell git rev-parse --show-toplevel)
+include $(ROOT)/makefiles/functions.Makefile
+
+nginx-build:
+	$(call build_image,nginx,nginx/Dockerfile)
+
+nginx-publish: nginx-build
+	$(call publish_service,nginx,nginx,$(ACCOUNT_ID))

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,26 @@
+worker_processes 1;
+
+events { worker_connections 1024; }
+
+http {
+  server {
+    listen 9000;
+    server_tokens off;
+
+    location / {
+      proxy_pass http://${APP_HOST}:${APP_PORT}/;
+
+      add_header 'Access-Control-Allow-Origin' '*';
+      add_header 'Access-Control-Allow-Credentials' 'true';
+      add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS';
+      add_header 'Access-Control-Allow-Headers' 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+
+      if ($request_method = 'OPTIONS') {
+        add_header 'Access-Control-Max-Age' 1728000;
+        add_header 'Content-Type' 'text/plain charset=UTF-8';
+        add_header 'Content-Length' 0;
+        return 204;
+      }
+    }
+  }
+}

--- a/terraform/infra/ecr.tf
+++ b/terraform/infra/ecr.tf
@@ -1,77 +1,52 @@
-module "ecr_repository_bags_api" {
-  source    = "git::https://github.com/wellcometrust/terraform.git//ecr?ref=v19.5.1"
-  id        = "bags_api"
-  namespace = "uk.ac.wellcome"
+resource "aws_ecr_repository" "bags_api" {
+  name = "uk.ac.wellcome/bags_api"
 }
 
-module "ecr_repository_ingests" {
-  source    = "git::https://github.com/wellcometrust/terraform.git//ecr?ref=v19.5.1"
-  id        = "ingests"
-  namespace = "uk.ac.wellcome"
+resource "aws_ecr_repository" "ingests" {
+  name = "uk.ac.wellcome/ingests"
 }
 
-module "ecr_repository_ingests_api" {
-  source    = "git::https://github.com/wellcometrust/terraform.git//ecr?ref=v19.5.1"
-  id        = "ingests_api"
-  namespace = "uk.ac.wellcome"
+resource "aws_ecr_repository" "ingests_api" {
+  name = "uk.ac.wellcome/ingests_api"
 }
 
-module "ecr_repository_notifier" {
-  source    = "git::https://github.com/wellcometrust/terraform.git//ecr?ref=v19.5.1"
-  id        = "notifier"
-  namespace = "uk.ac.wellcome"
+
+resource "aws_ecr_repository" "notifier" {
+  name = "uk.ac.wellcome/notifier"
 }
 
-module "ecr_repository_bag_replicator" {
-  source    = "git::https://github.com/wellcometrust/terraform.git//ecr?ref=v19.5.1"
-  id        = "bag_replicator"
-  namespace = "uk.ac.wellcome"
+resource "aws_ecr_repository" "bag_replicator" {
+  name = "uk.ac.wellcome/bag_replicator"
 }
 
-module "ecr_repository_bag_root_finder" {
-  source    = "git::https://github.com/wellcometrust/terraform.git//ecr?ref=v19.5.1"
-  id        = "bag_root_finder"
-  namespace = "uk.ac.wellcome"
+resource "aws_ecr_repository" "bag_root_finder" {
+  name = "uk.ac.wellcome/bag_root_finder"
 }
 
-module "ecr_repository_bag_verifier" {
-  source    = "git::https://github.com/wellcometrust/terraform.git//ecr?ref=v19.5.1"
-  id        = "bag_verifier"
-  namespace = "uk.ac.wellcome"
+resource "aws_ecr_repository" "bag_verifier" {
+  name = "uk.ac.wellcome/bag_verifier"
 }
 
-module "ecr_repository_bag_unpacker" {
-  source    = "git::https://github.com/wellcometrust/terraform.git//ecr?ref=v19.5.1"
-  id        = "bag_unpacker"
-  namespace = "uk.ac.wellcome"
+resource "aws_ecr_repository" "bag_unpacker" {
+  name = "uk.ac.wellcome/bag_unpacker"
 }
 
-module "ecr_repository_bag_register" {
-  source    = "git::https://github.com/wellcometrust/terraform.git//ecr?ref=v19.5.1"
-  id        = "bags"
-  namespace = "uk.ac.wellcome"
+resource "aws_ecr_repository" "bag_register" {
+  name = "uk.ac.wellcome/bags"
 }
 
-module "ecr_repository_bag_auditor" {
-  source    = "git::https://github.com/wellcometrust/terraform.git//ecr?ref=v19.5.1"
-  id        = "bag_auditor"
-  namespace = "uk.ac.wellcome"
+resource "aws_ecr_repository" "bag_auditor" {
+  name = "uk.ac.wellcome/bag_auditor"
 }
 
-module "ecr_repository_bag_versioner" {
-  source    = "git::https://github.com/wellcometrust/terraform.git//ecr?ref=v19.5.1"
-  id        = "bag_versioner"
-  namespace = "uk.ac.wellcome"
+resource "aws_ecr_repository" "bag_versioner" {
+  name = "uk.ac.wellcome/bag_versioner"
 }
 
-module "ecr_repository_replica_aggregator" {
-  source    = "git::https://github.com/wellcometrust/terraform.git//ecr?ref=v19.5.1"
-  id        = "replica_aggregator"
-  namespace = "uk.ac.wellcome"
+resource "aws_ecr_repository" "replica_aggregator" {
+  name = "uk.ac.wellcome/replica_aggregator"
 }
 
-module "ecr_repository_nginx" {
-  source    = "git::https://github.com/wellcometrust/terraform.git//ecr?ref=v19.5.1"
-  id        = "nginx"
-  namespace = "uk.ac.wellcome"
+resource "aws_ecr_repository" "nginx" {
+  name = "uk.ac.wellcome/nginx"
 }

--- a/terraform/infra/ecr.tf
+++ b/terraform/infra/ecr.tf
@@ -70,3 +70,8 @@ module "ecr_repository_replica_aggregator" {
   namespace = "uk.ac.wellcome"
 }
 
+module "ecr_repository_nginx" {
+  source    = "git::https://github.com/wellcometrust/terraform.git//ecr?ref=v19.5.1"
+  id        = "nginx"
+  namespace = "uk.ac.wellcome"
+}

--- a/terraform/modules/queue/main.tf
+++ b/terraform/modules/queue/main.tf
@@ -3,7 +3,7 @@ locals {
 }
 
 module "queue" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.1"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//queue?ref=v1.1.2"
   queue_name = replace(var.name, "-", "_")
   aws_region = var.aws_region
   topic_arns = var.topic_arns
@@ -15,7 +15,7 @@ module "queue" {
 }
 
 module "scaling_alarm" {
-  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.0"
+  source     = "git::github.com/wellcomecollection/terraform-aws-sqs//autoscaling?ref=v1.1.2"
   queue_name = local.queue_name
 
   queue_high_actions = var.queue_high_actions

--- a/terraform/modules/resource/main.tf
+++ b/terraform/modules/resource/main.tf
@@ -14,18 +14,16 @@ resource "aws_api_gateway_method" "auth_resource" {
   authorization_scopes = var.auth_scopes
 }
 
-module "auth_resource_integration" {
-  source = "git::https://github.com/wellcometrust/terraform.git//api_gateway/modules/integration/proxy?ref=v16.1.8"
-
-  api_id        = var.api_id
-  resource_id   = aws_api_gateway_resource.auth_resource.id
-  connection_id = var.connection_id
-
-  hostname    = var.hostname
+resource "aws_api_gateway_integration" "auth_resource" {
+  rest_api_id = var.api_id
+  resource_id = aws_api_gateway_resource.auth_resource.id
   http_method = aws_api_gateway_method.auth_resource.http_method
 
-  forward_port = var.forward_port
-  forward_path = var.forward_path
+  integration_http_method = "ANY"
+  type                    = "HTTP_PROXY"
+  connection_type         = "VPC_LINK"
+  connection_id           = var.connection_id
+  uri                     = "http://${var.hostname}:${var.forward_port}/${var.forward_path}"
 }
 
 resource "aws_api_gateway_resource" "auth_subresource" {
@@ -48,18 +46,16 @@ resource "aws_api_gateway_method" "auth_subresource" {
   }
 }
 
-module "auth_subresource_integration" {
-  source = "git::https://github.com/wellcometrust/terraform.git//api_gateway/modules/integration/proxy?ref=v16.1.8"
-
-  api_id        = var.api_id
-  resource_id   = aws_api_gateway_resource.auth_subresource.id
-  connection_id = var.connection_id
-
-  hostname    = var.hostname
+resource "aws_api_gateway_integration" "auth_subresource" {
+  rest_api_id = var.api_id
+  resource_id = aws_api_gateway_resource.auth_subresource.id
   http_method = aws_api_gateway_method.auth_subresource.http_method
 
-  forward_port = var.forward_port
-  forward_path = "${var.forward_path}/{proxy}"
+  integration_http_method = "ANY"
+  type                    = "HTTP_PROXY"
+  connection_type         = "VPC_LINK"
+  connection_id           = var.connection_id
+  uri                     = "http://${var.hostname}:${var.forward_port}/${var.forward_path}/{proxy}"
 
   request_parameters = {
     "integration.request.path.proxy" = "method.request.path.proxy"

--- a/terraform/modules/resource/outputs.tf
+++ b/terraform/modules/resource/outputs.tf
@@ -1,6 +1,6 @@
 output "integration_uris" {
   value = [
-    module.auth_subresource_integration.uri,
-    module.auth_resource_integration.uri,
+    aws_api_gateway_integration.auth_subresource.uri,
+    aws_api_gateway_integration.auth_resource.uri,
   ]
 }

--- a/terraform/modules/service/api/main.tf
+++ b/terraform/modules/service/api/main.tf
@@ -1,5 +1,5 @@
 module "service" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//service?ref=v1.0.0"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//service?ref=v1.1.0"
 
   service_name = var.namespace
 
@@ -23,7 +23,7 @@ module "service" {
 }
 
 module "task_definition" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//task_definition/container_with_sidecar?ref=v1.0.0"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//task_definition/container_with_sidecar?ref=v1.1.0"
 
   task_name = var.namespace
 

--- a/terraform/modules/service/scaling_worker/main.tf
+++ b/terraform/modules/service/scaling_worker/main.tf
@@ -26,7 +26,7 @@ module "worker" {
 }
 
 module "scaling" {
-  source = "git::github.com/wellcometrust/terraform-modules.git//autoscaling/app/ecs?ref=v19.16.2"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//autoscaling?ref=v1.1.0"
 
   name   = var.service_name
 

--- a/terraform/modules/service/worker/main.tf
+++ b/terraform/modules/service/worker/main.tf
@@ -1,5 +1,5 @@
 module "service" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//service?ref=v1.0.1"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//service?ref=v1.1.0"
 
   service_name = var.service_name
 
@@ -19,7 +19,7 @@ module "service" {
 }
 
 module "task_definition" {
-  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//task_definition/single_container?ref=v1.0.0"
+  source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//task_definition/single_container?ref=v1.1.0"
 
   task_name = var.service_name
 

--- a/terraform/modules/stack/images.tf
+++ b/terraform/modules/stack/images.tf
@@ -1,9 +1,4 @@
-module "images" {
-  source = "git::https://github.com/wellcometrust/terraform.git//ecs/modules/images?ref=v19.8.0"
-
-  label   = var.release_label
-  project = "storage"
-
+locals {
   services = [
     "bags_api",
     "ingests",
@@ -19,3 +14,12 @@ module "images" {
   ]
 }
 
+data "aws_ssm_parameter" "image_ids" {
+  count = length(local.services)
+
+  name = "/storage/images/${var.release_label}/${local.services[count.index]}"
+}
+
+locals {
+  image_ids = zipmap(local.services, data.aws_ssm_parameter.image_ids.*.value)
+}

--- a/terraform/modules/stack/locals.tf
+++ b/terraform/modules/stack/locals.tf
@@ -13,17 +13,17 @@ locals {
   bag_verifier_pre_repl_service_name  = "${var.namespace}-bag-verifier-pre-replication"
   replica_aggregator_service_name     = "${var.namespace}-replica_aggregator"
 
-  bag_versioner_image      = module.images.services["bag_versioner"]
-  bag_register_image       = module.images.services["bag_register"]
-  bag_root_finder_image    = module.images.services["bag_root_finder"]
-  bags_api_image           = module.images.services["bags_api"]
-  ingests_image            = module.images.services["ingests"]
-  ingests_api_image        = module.images.services["ingests_api"]
-  notifier_image           = module.images.services["notifier"]
-  bag_replicator_image     = module.images.services["bag_replicator"]
-  bag_verifier_image       = module.images.services["bag_verifier"]
-  bag_unpacker_image       = module.images.services["bag_unpacker"]
-  replica_aggregator_image = module.images.services["replica_aggregator"]
+  bag_versioner_image      = local.image_ids["bag_versioner"]
+  bag_register_image       = local.image_ids["bag_register"]
+  bag_root_finder_image    = local.image_ids["bag_root_finder"]
+  bags_api_image           = local.image_ids["bags_api"]
+  ingests_image            = local.image_ids["ingests"]
+  ingests_api_image        = local.image_ids["ingests_api"]
+  notifier_image           = local.image_ids["notifier"]
+  bag_replicator_image     = local.image_ids["bag_replicator"]
+  bag_verifier_image       = local.image_ids["bag_verifier"]
+  bag_unpacker_image       = local.image_ids["bag_unpacker"]
+  replica_aggregator_image = local.image_ids["replica_aggregator"]
 
   logstash_transit_service_name = "${var.namespace}_logstash_transit"
   logstash_transit_image        = "wellcome/logstash_transit:edgelord"

--- a/terraform/modules/topic/main.tf
+++ b/terraform/modules/topic/main.tf
@@ -1,12 +1,22 @@
-module "topic" {
-  source = "git::https://github.com/wellcometrust/terraform-modules.git//sns?ref=v1.0.0"
-  name   = replace(var.name, "-", "_")
+resource "aws_sns_topic" "topic" {
+  name = replace(var.name, "-", "_")
+}
+
+data "aws_iam_policy_document" "publish_to_topic" {
+  statement {
+    actions = [
+      "sns:Publish",
+    ]
+
+    resources = [
+      aws_sns_topic.topic.arn,
+    ]
+  }
 }
 
 resource "aws_iam_role_policy" "policy" {
   count = length(var.role_names)
 
   role   = var.role_names[count.index]
-  policy = module.topic.publish_policy
+  policy = data.aws_iam_policy_document.publish_to_topic.json
 }
-

--- a/terraform/modules/topic/outputs.tf
+++ b/terraform/modules/topic/outputs.tf
@@ -1,8 +1,8 @@
 output "name" {
-  value = module.topic.name
+  value = aws_sns_topic.topic.name
 }
 
 output "arn" {
-  value = module.topic.arn
+  value = aws_sns_topic.topic.arn
 }
 

--- a/terraform/stack_prod/locals.tf
+++ b/terraform/stack_prod/locals.tf
@@ -14,7 +14,7 @@ locals {
   cognito_user_pool_arn          = data.terraform_remote_state.infra_critical.outputs.cognito_user_pool_arn
   cognito_storage_api_identifier = data.terraform_remote_state.infra_critical.outputs.cognito_storage_api_identifier
 
-  nginx_image = "760097843905.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx_api-gw:bad0dbfa548874938d16496e313b05adb71268b7"
+  nginx_image = "975596993436.dkr.ecr.eu-west-1.amazonaws.com/uk.ac.wellcome/nginx:135d8415f7071b7ef2b7b3a11313161569d7f7e4"
 
   gateway_server_error_alarm_arn = data.terraform_remote_state.infra_shared.outputs.gateway_server_error_alarm_arn
 

--- a/terraform/stack_prod/locals.tf
+++ b/terraform/stack_prod/locals.tf
@@ -20,8 +20,6 @@ locals {
 
   workflow_bucket_name = "wellcomecollection-workflow-export-bagit"
 
-  archivematica_ingests_bucket = data.terraform_remote_state.archivematica_infra.outputs.ingests_bucket
-
   subnets_ids = [
     data.terraform_remote_state.infra_shared.outputs.storage_vpc_private_subnets[0],
     data.terraform_remote_state.infra_shared.outputs.storage_vpc_private_subnets[2],


### PR DESCRIPTION
The storage service was pulling in an nginx image from the catalogue account, so when the permissions on that ECR repo changed, we could no longer start tasks using that image.

The bags API fell over this morning (out-of-memory from requesting a really big bag), so this PR brings a copy of the nginx image into this repo, and uses this in the tasks.