### PR TITLE
Allow top level dir to be specified for compressed bag download

### DIFF
--- a/python_client/src/wellcome_storage_service/downloader.py
+++ b/python_client/src/wellcome_storage_service/downloader.py
@@ -47,22 +47,25 @@ def download_bag(storage_manifest, out_dir):
         )
 
 
-def download_compressed_bag(storage_manifest, out_path):
+def download_compressed_bag(storage_manifest, out_path, top_level_dir=None):
     """
     Download all the files in a bag to a compressed archive.
 
     :param storage_manifest: A storage manifest returned from the storage
         service, as retrieved with ``get_bag()``.
     :param out_path: The path to download the tar.gz to.
+    :param top_level_dir: Name of top level directory in archive (defaults to
+        the bag's external identifier).
 
     """
-    ext_identifier = storage_manifest["info"]["externalIdentifier"]
+    if top_level_dir is None:
+        top_level_dir = storage_manifest["info"]["externalIdentifier"]
 
     temp_dir = tempfile.mkdtemp()
     download_bag(storage_manifest=storage_manifest, out_dir=temp_dir)
 
     with tarfile.open(out_path, "w:gz") as tf:
-        tf.add(temp_dir, arcname=ext_identifier)
+        tf.add(temp_dir, arcname=top_level_dir)
 
     shutil.rmtree(temp_dir)
 

--- a/python_client/tests/cassettes/test_downloading_compressed_bag_with_custom_directory.json
+++ b/python_client/tests/cassettes/test_downloading_compressed_bag_with_custom_directory.json
@@ -1,0 +1,207 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2019-11-07T10:46:48",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=client_credentials"
+        },
+        "headers": {
+          "Accept": [
+            "application/json"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "<AUTH_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "29"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded;charset=UTF-8"
+          ],
+          "User-Agent": [
+            "python-requests/2.21.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://auth.wellcomecollection.org/oauth2/token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\":\"<ACCESS_TOKEN_13>\",\"expires_in\":3600,\"token_type\":\"Bearer\"}"
+        },
+        "headers": {
+          "Cache-Control": [
+            "no-cache, no-store, max-age=0, must-revalidate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Type": [
+            "application/json;charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 07 Nov 2019 10:46:48 GMT"
+          ],
+          "Expires": [
+            "0"
+          ],
+          "Pragma": [
+            "no-cache"
+          ],
+          "Server": [
+            "Server"
+          ],
+          "Set-Cookie": [
+            "XSRF-TOKEN=99255a18-d2b5-44fe-951c-527b6bcd0ce5; Path=/; Secure; HttpOnly"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=31536000 ; includeSubDomains"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "Via": [
+            "1.1 a654b4b54d3322bdcbd8b65f511761c1.cloudfront.net (CloudFront)"
+          ],
+          "X-Amz-Cf-Id": [
+            "XAwdT5_NeUvyEc8LkelrVryM5mS2PfF-1A7RjFuAxPCfZPMm6J8NFA=="
+          ],
+          "X-Amz-Cf-Pop": [
+            "LHR3-C1"
+          ],
+          "X-Application-Context": [
+            "application:prod:8443"
+          ],
+          "X-Cache": [
+            "Miss from cloudfront"
+          ],
+          "X-Content-Type-Options": [
+            "nosniff"
+          ],
+          "X-Frame-Options": [
+            "DENY"
+          ],
+          "X-XSS-Protection": [
+            "1; mode=block"
+          ],
+          "x-amz-cognito-request-id": [
+            "1af28590-9f27-4dfd-a4b7-73680520963b"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://auth.wellcomecollection.org/oauth2/token"
+      }
+    },
+    {
+      "recorded_at": "2019-11-07T10:46:48",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Bearer <ACCESS_TOKEN_13>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "python-requests/2.21.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://api.wellcomecollection.org/storage/v1/bags/digitised/b11733330?version=v1"
+      },
+      "response": {
+        "body": {
+          "encoding": null,
+          "string": "{\"@context\":\"https://api.wellcomecollection.org/context.json\",\"id\":\"digitised/b11733330\",\"space\":{\"id\":\"digitised\",\"type\":\"Space\"},\"info\":{\"externalIdentifier\":\"b11733330\",\"payloadOxum\":\"1335376.2\",\"baggingDate\":\"2019-08-22\",\"sourceOrganization\":\"Intranda GmbH\",\"externalDescription\":\"Thomas Wakley. Stipple engraving by W. H. Egleton after J.K. Meadows.\",\"type\":\"BagInfo\"},\"manifest\":{\"checksumAlgorithm\":\"SHA-256\",\"files\":[{\"checksum\":\"c195e863630433d2e5e92d5970cfab7321568657d29439c00d35e4c4f6990993\",\"name\":\"data/b11733330.xml\",\"path\":\"v1/data/b11733330.xml\",\"size\":8132,\"type\":\"File\"},{\"checksum\":\"ac4fde3a0e2188de91b3e961310a978e749cf456f18d5830ffcffd59111385ba\",\"name\":\"data/objects/L0008210-LS-CS.jp2\",\"path\":\"v1/data/objects/L0008210-LS-CS.jp2\",\"size\":1327244,\"type\":\"File\"}],\"type\":\"BagManifest\"},\"tagManifest\":{\"checksumAlgorithm\":\"SHA-256\",\"files\":[{\"checksum\":\"894867de4f57a3ed316ec43138190cdd752da95bfa68fd96a7721808bfdcbd5a\",\"name\":\"manifest-sha256.txt\",\"path\":\"v1/manifest-sha256.txt\",\"size\":183,\"type\":\"File\"},{\"checksum\":\"e91f941be5973ff71f1dccbdd1a32d598881893a7f21be516aca743da38b1689\",\"name\":\"bagit.txt\",\"path\":\"v1/bagit.txt\",\"size\":55,\"type\":\"File\"},{\"checksum\":\"d9cf709e5fb7a93a55ba9bd6b69be72a50b5921c97bc67d6e6b2c843b3c32b73\",\"name\":\"manifest-sha512.txt\",\"path\":\"v1/manifest-sha512.txt\",\"size\":311,\"type\":\"File\"},{\"checksum\":\"c793b81c816fcab9b469a6db9a1ba885f5f3ae69a8b8c71eef578e794f370e4d\",\"name\":\"bag-info.txt\",\"path\":\"v1/bag-info.txt\",\"size\":331,\"type\":\"File\"},{\"checksum\":\"8b840d1a71e0d1d127fcad5bd7ba966215161e0883390a3f746d01c438931885\",\"name\":\"tagmanifest-sha256.txt\",\"path\":\"v1/tagmanifest-sha256.txt\",\"size\":323,\"type\":\"File\"},{\"checksum\":\"ce305bde91373d26103390e939611041bd9a58ce74048c85cad7665896fbe5f6\",\"name\":\"tagmanifest-sha512.txt\",\"path\":\"v1/tagmanifest-sha512.txt\",\"size\":579,\"type\":\"File\"}],\"type\":\"BagManifest\"},\"location\":{\"provider\":{\"id\":\"aws-s3-ia\",\"type\":\"Provider\"},\"bucket\":\"wellcomecollection-storage\",\"path\":\"digitised/b11733330\",\"type\":\"Location\"},\"replicaLocations\":[{\"provider\":{\"id\":\"aws-s3-glacier\",\"type\":\"Provider\"},\"bucket\":\"wellcomecollection-storage-replica-ireland\",\"path\":\"digitised/b11733330\",\"type\":\"Location\"}],\"createdDate\":\"2019-09-12T20:26:53.094757Z\",\"version\":\"v1\",\"type\":\"Bag\"}"
+        },
+        "headers": {
+          "Access-Control-Allow-Credentials": [
+            "true"
+          ],
+          "Access-Control-Allow-Headers": [
+            "DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type"
+          ],
+          "Access-Control-Allow-Methods": [
+            "GET, POST, OPTIONS"
+          ],
+          "Access-Control-Allow-Origin": [
+            "*"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2252"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Date": [
+            "Thu, 07 Nov 2019 10:46:48 GMT"
+          ],
+          "ETag": [
+            "\"digitised/b11733330/v1\""
+          ],
+          "Via": [
+            "1.1 d31be1bb3cd2f187c0f45c1f03ead3c6.cloudfront.net (CloudFront)"
+          ],
+          "X-Amz-Cf-Id": [
+            "PU-xkdGb112E2s2dWLgCCyCZYcB6XKZbWmjUpYMCdMDoBb7eSJ4NSw=="
+          ],
+          "X-Amz-Cf-Pop": [
+            "LHR3-C2"
+          ],
+          "X-Cache": [
+            "Miss from cloudfront"
+          ],
+          "x-amz-apigw-id": [
+            "CyNj1EE9DoEFplw="
+          ],
+          "x-amzn-Remapped-Connection": [
+            "keep-alive"
+          ],
+          "x-amzn-Remapped-Content-Length": [
+            "2252"
+          ],
+          "x-amzn-Remapped-Date": [
+            "Thu, 07 Nov 2019 10:46:48 GMT"
+          ],
+          "x-amzn-Remapped-Server": [
+            "nginx"
+          ],
+          "x-amzn-RequestId": [
+            "514784fe-f712-4664-adec-90e9e623f56d"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.wellcomecollection.org/storage/v1/bags/digitised/b11733330?version=v1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/python_client/tests/test_downloader.py
+++ b/python_client/tests/test_downloader.py
@@ -164,3 +164,18 @@ class TestS3IADownload(object):
                 "An error occurred (NoSuchKey) when calling the GetObject operation",
             )
         )
+
+    def test_downloading_compressed_bag_with_custom_directory(self, client, tmpdir):
+        out_path = tmpdir.join("b11733330.tar.gz")
+
+        bag = client.get_bag("digitised", "b11733330", "v1")
+
+        downloader.download_compressed_bag(bag, out_path=str(out_path), top_level_dir='custom_dir')
+
+        with tarfile.open(str(out_path), "r:gz") as tf:
+            tarred_files = [member for member in tf.getmembers() if member.isfile()]
+
+            for tarinfo in tarred_files:
+
+                # All files in the compressed bag are under a directory
+                assert tarinfo.name.startswith("custom_dir/")

--- a/python_client/tests/test_downloader.py
+++ b/python_client/tests/test_downloader.py
@@ -170,7 +170,9 @@ class TestS3IADownload(object):
 
         bag = client.get_bag("digitised", "b11733330", "v1")
 
-        downloader.download_compressed_bag(bag, out_path=str(out_path), top_level_dir='custom_dir')
+        downloader.download_compressed_bag(
+            bag, out_path=str(out_path), top_level_dir="custom_dir"
+        )
 
         with tarfile.open(str(out_path), "r:gz") as tf:
             tarred_files = [member for member in tf.getmembers() if member.isfile()]


### PR DESCRIPTION
If omitted, the external identifier string is used as a top level directory name, as is the current behaviour.

Fixes https://github.com/wellcometrust/platform/issues/4071