### PR TITLE
Fix an aggregator bug that meant retryable errors were being ignored

### DIFF
--- a/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
+++ b/replica_aggregator/src/test/scala/uk/ac/wellcome/platform/storage/replica_aggregator/services/ReplicaAggregatorWorkerTest.scala
@@ -225,7 +225,9 @@ class ReplicaAggregatorWorkerTest
             initialEntries = Map.empty
           ) with MemoryMaxima[ReplicaPath, AggregatorInternalRecord]
       ) {
-        override def put(id: Version[ReplicaPath, Int])(t: AggregatorInternalRecord): WriteEither =
+        override def put(
+          id: Version[ReplicaPath, Int]
+        )(t: AggregatorInternalRecord): WriteEither =
           Left(VersionAlreadyExistsError())
       }
 


### PR DESCRIPTION
This is caused by a subtle mismatch between the behaviour of the VersionedStore type class and the aggregator.

When the VersionedStore sees a retryable error in update() or upsert(), it wraps the underlying error as:

    new UpdateWriteError(err) with RetryableError

But the aggregator code was pattern matching on a different expression:

    case UpdateWriteError(err: RetryableError)

These aren't the same thing, and the mismatch meant these errors were still slipping through.  This should fix this source of flakiness in the replica aggregator.

See: https://github.com/wellcometrust/scala-storage/blob/95626ad8570a322421fcfd58e98bd50ed8016798/storage/src/main/scala/uk/ac/wellcome/storage/store/VersionedStore.scala#L41-L44

Closes https://github.com/wellcometrust/platform/issues/4074