### PR TITLE
Don't allow slashes in the storage service

### DIFF
--- a/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApi.scala
+++ b/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApi.scala
@@ -42,7 +42,6 @@ trait IngestsApi extends Logging {
   val ingests: Route = pathPrefix("ingests") {
     post {
       entity(as[RequestDisplayIngest]) { requestDisplayIngest =>
-
         // We disallow slashes for space/external identifier.
         //
         // In theory there's nothing that means we can't support it, but it's liable
@@ -57,15 +56,18 @@ trait IngestsApi extends Logging {
             StatusCodes.BadRequest -> UserErrorResponse(
               contextURL,
               statusCode = StatusCodes.BadRequest,
-              description = "Invalid value at .space.id: must not contain slashes."
+              description =
+                "Invalid value at .space.id: must not contain slashes."
             )
           )
-        } else if (requestDisplayIngest.bag.info.externalIdentifier.underlying.contains("/")) {
+        } else if (requestDisplayIngest.bag.info.externalIdentifier.underlying
+                     .contains("/")) {
           complete(
             StatusCodes.BadRequest -> UserErrorResponse(
               contextURL,
               statusCode = StatusCodes.BadRequest,
-              description = "Invalid value at .bag.info.externalIdentifier: must not contain slashes."
+              description =
+                "Invalid value at .bag.info.externalIdentifier: must not contain slashes."
             )
           )
         } else {

--- a/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApi.scala
+++ b/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApi.scala
@@ -42,7 +42,6 @@ trait IngestsApi extends Logging {
   val ingests: Route = pathPrefix("ingests") {
     post {
       entity(as[RequestDisplayIngest]) { requestDisplayIngest =>
-        // TODO: Do we have a test for the failure case?
         ingestStarter.initialise(requestDisplayIngest.toIngest) match {
           case Success(ingest) =>
             respondWithHeaders(List(createLocationHeader(ingest))) {
@@ -68,7 +67,6 @@ trait IngestsApi extends Logging {
       }
     } ~ path(JavaUUID) { id: UUID =>
       get {
-        // TODO: Do we have a test for the failure case?
         ingestTracker.get(IngestID(id)) match {
           case Right(ingest) =>
             complete(ResponseDisplayIngest(ingest.identifiedT, contextURL))

--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/IngestsApiFeatureTest.scala
@@ -382,6 +382,18 @@ class IngestsApiFeatureTest
               "Invalid value at .space.id: required property not supplied."
           )
         }
+
+        it("if the space contains a slash") {
+          val badJson = root.space.obj.modify {
+            _.add("id", Json.fromString("alfa/bravo"))
+          }
+
+          assertCatchesMalformedRequest(
+            badJson(json).noSpaces,
+            expectedMessage =
+              "Invalid value at .space.id: must not contain slashes."
+          )
+        }
       }
 
       describe("problems with the bag") {
@@ -418,6 +430,18 @@ class IngestsApiFeatureTest
             badJson(json).noSpaces,
             expectedMessage =
               "Invalid value at .bag.info.externalIdentifier: required property not supplied."
+          )
+        }
+
+        it("if the info.externalIdentifier field contains a slash") {
+          val badJson = root.bag.info.obj.modify {
+            _.add("externalIdentifier", Json.fromString("alfa/bravo"))
+          }
+
+          assertCatchesMalformedRequest(
+            badJson(json).noSpaces,
+            expectedMessage =
+              "Invalid value at .bag.info.externalIdentifier: must not contain slashes."
           )
         }
       }


### PR DESCRIPTION
Supporting slashes adds a bunch of edge cases and weirdnesses that we'd need to check (e.g. around S3 paths and URL path components). If we had time to test it thoroughly, we could do it, but for now reject any ingest that tries to use "a/b" or "b/c" as a space or external ID.

---

Prompted by thinking about Archivematica, where the Calm IDs do contain slashes (but there's no way we want to pass those through).

The Archivematica side should never be sending them; to be on the safe side the storage service will reject them if it does.