### PR TITLE
Simplify the bags API tests

### DIFF
--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
@@ -303,16 +303,7 @@ class BagsApiFeatureTest
              |{
              |  "@context": "http://api.wellcomecollection.org/storage/v1/context.json",
              |  "type": "ResultList",
-             |  "results": [
-             |    {
-             |      "type": "Bag",
-             |      "id": "${storageManifest.id.toString}",
-             |      "version": "${storageManifest.version}",
-             |      "createdDate": "${DateTimeFormatter.ISO_INSTANT.format(
-                 storageManifest.createdDate
-               )}"
-             |    }
-             |  ]
+             |  "results": [${expectedVersionJson(storageManifest)}]
              |}
               """.stripMargin
 
@@ -356,46 +347,11 @@ class BagsApiFeatureTest
              |  "@context": "http://api.wellcomecollection.org/storage/v1/context.json",
              |  "type": "ResultList",
              |  "results": [
-             |    {
-             |      "type": "Bag",
-             |      "id": "${storageManifest.id.toString}",
-             |      "version": "v5",
-             |      "createdDate": "${DateTimeFormatter.ISO_INSTANT.format(
-                 multipleManifests(5).createdDate
-               )}"
-             |    },
-             |    {
-             |      "type": "Bag",
-             |      "id": "${storageManifest.id.toString}",
-             |      "version": "v4",
-             |      "createdDate": "${DateTimeFormatter.ISO_INSTANT.format(
-                 multipleManifests(4).createdDate
-               )}"
-             |    },
-             |    {
-             |      "type": "Bag",
-             |      "id": "${storageManifest.id.toString}",
-             |      "version": "v3",
-             |      "createdDate": "${DateTimeFormatter.ISO_INSTANT.format(
-                 multipleManifests(3).createdDate
-               )}"
-             |    },
-             |    {
-             |      "type": "Bag",
-             |      "id": "${storageManifest.id.toString}",
-             |      "version": "v2",
-             |      "createdDate": "${DateTimeFormatter.ISO_INSTANT.format(
-                 multipleManifests(2).createdDate
-               )}"
-             |    },
-             |    {
-             |      "type": "Bag",
-             |      "id": "${storageManifest.id.toString}",
-             |      "version": "v1",
-             |      "createdDate": "${DateTimeFormatter.ISO_INSTANT.format(
-                 multipleManifests(1).createdDate
-               )}"
-             |    }
+             |    ${expectedVersionJson(multipleManifests(5), expectedVersion = "v5")},
+             |    ${expectedVersionJson(multipleManifests(4), expectedVersion = "v4")},
+             |    ${expectedVersionJson(multipleManifests(3), expectedVersion = "v3")},
+             |    ${expectedVersionJson(multipleManifests(2), expectedVersion = "v2")},
+             |    ${expectedVersionJson(multipleManifests(1), expectedVersion = "v1")}
              |  ]
              |}
               """.stripMargin
@@ -440,30 +396,9 @@ class BagsApiFeatureTest
              |  "@context": "http://api.wellcomecollection.org/storage/v1/context.json",
              |  "type": "ResultList",
              |  "results": [
-             |    {
-             |      "type": "Bag",
-             |      "id": "${storageManifest.id.toString}",
-             |      "version": "v3",
-             |      "createdDate": "${DateTimeFormatter.ISO_INSTANT.format(
-                 multipleManifests(3).createdDate
-               )}"
-             |    },
-             |    {
-             |      "type": "Bag",
-             |      "id": "${storageManifest.id.toString}",
-             |      "version": "v2",
-             |      "createdDate": "${DateTimeFormatter.ISO_INSTANT.format(
-                 multipleManifests(2).createdDate
-               )}"
-             |    },
-             |    {
-             |      "type": "Bag",
-             |      "id": "${storageManifest.id.toString}",
-             |      "version": "v1",
-             |      "createdDate": "${DateTimeFormatter.ISO_INSTANT.format(
-                 multipleManifests(1).createdDate
-               )}"
-             |    }
+             |    ${expectedVersionJson(multipleManifests(3), expectedVersion = "v3")},
+             |    ${expectedVersionJson(multipleManifests(2), expectedVersion = "v2")},
+             |    ${expectedVersionJson(multipleManifests(1), expectedVersion = "v1")}
              |  ]
              |}
               """.stripMargin
@@ -552,6 +487,22 @@ class BagsApiFeatureTest
           }
       }
     }
+  }
+
+  private def expectedVersionJson(storageManifest: StorageManifest, expectedVersion: String): String =
+    expectedVersionJson(storageManifest, expectedVersion = Some(expectedVersion))
+
+  private def expectedVersionJson(storageManifest: StorageManifest, expectedVersion: Option[String] = None): String = {
+    val createdDate = DateTimeFormatter.ISO_INSTANT.format(storageManifest.createdDate)
+
+    s"""
+       |{
+       |  "id": "${storageManifest.id.toString}",
+       |  "version": "${expectedVersion.getOrElse(storageManifest.version)}",
+       |  "createdDate": "$createdDate",
+       |  "type": "Bag"
+       |}
+       """.stripMargin
   }
 
   private def assertJsonMatches(json: String, storageManifest: StorageManifest): Assertion = {

--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApiFeatureTest.scala
@@ -347,11 +347,26 @@ class BagsApiFeatureTest
              |  "@context": "http://api.wellcomecollection.org/storage/v1/context.json",
              |  "type": "ResultList",
              |  "results": [
-             |    ${expectedVersionJson(multipleManifests(5), expectedVersion = "v5")},
-             |    ${expectedVersionJson(multipleManifests(4), expectedVersion = "v4")},
-             |    ${expectedVersionJson(multipleManifests(3), expectedVersion = "v3")},
-             |    ${expectedVersionJson(multipleManifests(2), expectedVersion = "v2")},
-             |    ${expectedVersionJson(multipleManifests(1), expectedVersion = "v1")}
+             |    ${expectedVersionJson(
+                 multipleManifests(5),
+                 expectedVersion = "v5"
+               )},
+             |    ${expectedVersionJson(
+                 multipleManifests(4),
+                 expectedVersion = "v4"
+               )},
+             |    ${expectedVersionJson(
+                 multipleManifests(3),
+                 expectedVersion = "v3"
+               )},
+             |    ${expectedVersionJson(
+                 multipleManifests(2),
+                 expectedVersion = "v2"
+               )},
+             |    ${expectedVersionJson(
+                 multipleManifests(1),
+                 expectedVersion = "v1"
+               )}
              |  ]
              |}
               """.stripMargin
@@ -396,9 +411,18 @@ class BagsApiFeatureTest
              |  "@context": "http://api.wellcomecollection.org/storage/v1/context.json",
              |  "type": "ResultList",
              |  "results": [
-             |    ${expectedVersionJson(multipleManifests(3), expectedVersion = "v3")},
-             |    ${expectedVersionJson(multipleManifests(2), expectedVersion = "v2")},
-             |    ${expectedVersionJson(multipleManifests(1), expectedVersion = "v1")}
+             |    ${expectedVersionJson(
+                 multipleManifests(3),
+                 expectedVersion = "v3"
+               )},
+             |    ${expectedVersionJson(
+                 multipleManifests(2),
+                 expectedVersion = "v2"
+               )},
+             |    ${expectedVersionJson(
+                 multipleManifests(1),
+                 expectedVersion = "v1"
+               )}
              |  ]
              |}
               """.stripMargin
@@ -489,11 +513,21 @@ class BagsApiFeatureTest
     }
   }
 
-  private def expectedVersionJson(storageManifest: StorageManifest, expectedVersion: String): String =
-    expectedVersionJson(storageManifest, expectedVersion = Some(expectedVersion))
+  private def expectedVersionJson(
+    storageManifest: StorageManifest,
+    expectedVersion: String
+  ): String =
+    expectedVersionJson(
+      storageManifest,
+      expectedVersion = Some(expectedVersion)
+    )
 
-  private def expectedVersionJson(storageManifest: StorageManifest, expectedVersion: Option[String] = None): String = {
-    val createdDate = DateTimeFormatter.ISO_INSTANT.format(storageManifest.createdDate)
+  private def expectedVersionJson(
+    storageManifest: StorageManifest,
+    expectedVersion: Option[String] = None
+  ): String = {
+    val createdDate =
+      DateTimeFormatter.ISO_INSTANT.format(storageManifest.createdDate)
 
     s"""
        |{
@@ -505,7 +539,10 @@ class BagsApiFeatureTest
        """.stripMargin
   }
 
-  private def assertJsonMatches(json: String, storageManifest: StorageManifest): Assertion = {
+  private def assertJsonMatches(
+    json: String,
+    storageManifest: StorageManifest
+  ): Assertion = {
     val expectedJson =
       s"""
          |{
@@ -523,8 +560,8 @@ class BagsApiFeatureTest
          |    ${asList(storageManifest.replicaLocations, location)}
          |  ],
          |  "createdDate": "${DateTimeFormatter.ISO_INSTANT.format(
-        storageManifest.createdDate
-      )}",
+           storageManifest.createdDate
+         )}",
          |  "version": "${storageManifest.version}",
          |  "type": "Bag"
          |}


### PR DESCRIPTION
Arose from an experiment for https://github.com/wellcometrust/platform/issues/4088

This doesn't change any behaviour, just simplifies some of the test code, and makes it easier to add more tests later. At some point we'll be adding support for external identifiers with slashes, at which case we'll need more tests!