### PR TITLE
Add tests and support for looking up external IDs with slashes

### DIFF
--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApi.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApi.scala
@@ -40,7 +40,6 @@ trait BagsApi extends LargeResponses with LookupBag with LookupBagVersions {
           }
         }
       },
-
       // Look up a single manifest.
       path(Segment / Remaining) { (space, remaining) =>
         val bagId = BagId(
@@ -57,7 +56,9 @@ trait BagsApi extends LargeResponses with LookupBag with LookupBagVersions {
     )
   }
 
-  private def decodeExternalIdentifier(remaining: String): ExternalIdentifier = {
+  private def decodeExternalIdentifier(
+    remaining: String
+  ): ExternalIdentifier = {
     // Sometimes we have an external identifier with slashes.
     // For maximum flexibility, we want to support both URL-encoded
     // and complete path versions.
@@ -69,7 +70,7 @@ trait BagsApi extends LargeResponses with LookupBag with LookupBagVersions {
     //    /bags/space-id/alfa%2Fbravo
     //
     val underlying =
-    URLDecoder.decode(remaining, StandardCharsets.UTF_8.toString)
+      URLDecoder.decode(remaining, StandardCharsets.UTF_8.toString)
 
     ExternalIdentifier(underlying)
   }

--- a/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApi.scala
+++ b/api/bags_api/src/main/scala/uk/ac/wellcome/platform/storage/bags/api/BagsApi.scala
@@ -1,5 +1,8 @@
 package uk.ac.wellcome.platform.storage.bags.api
 
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import uk.ac.wellcome.platform.archive.common.bagit.models.{
@@ -15,29 +18,60 @@ import uk.ac.wellcome.platform.storage.bags.api.lookups.{
 
 trait BagsApi extends LargeResponses with LookupBag with LookupBagVersions {
   private val routes: Route = pathPrefix("bags") {
-    path(Segment / Segment) { (space, externalIdentifier) =>
-      val bagId = BagId(
-        space = StorageSpace(space),
-        externalIdentifier = ExternalIdentifier(externalIdentifier)
-      )
+    concat(
+      // We look for /versions at the end of the path: this means we should
+      // return a list of versions, not the complete manifest.
+      //
+      // The trailing slash is significant: it causes Akka to consume "/versions",
+      // rather than "versions".  If you omit it, the externalIdentifier gets a
+      // slash appended!
+      //
+      pathSuffix("versions" /) {
+        path(Segment / Remaining) { (space, remaining) =>
+          val bagId = BagId(
+            space = StorageSpace(space),
+            externalIdentifier = decodeExternalIdentifier(remaining)
+          )
 
-      get {
-        parameter('version.as[String] ?) { maybeVersion =>
-          lookupBag(bagId = bagId, maybeVersion = maybeVersion)
+          get {
+            parameter('before.as[String] ?) { maybeBefore =>
+              lookupVersions(bagId = bagId, maybeBefore = maybeBefore)
+            }
+          }
+        }
+      },
+
+      // Look up a single manifest.
+      path(Segment / Remaining) { (space, remaining) =>
+        val bagId = BagId(
+          space = StorageSpace(space),
+          externalIdentifier = decodeExternalIdentifier(remaining)
+        )
+
+        get {
+          parameter('version.as[String] ?) { maybeVersion =>
+            lookupBag(bagId = bagId, maybeVersion = maybeVersion)
+          }
         }
       }
-    } ~ path(Segment / Segment / "versions") { (space, externalIdentifier) =>
-      val bagId = BagId(
-        space = StorageSpace(space),
-        externalIdentifier = ExternalIdentifier(externalIdentifier)
-      )
+    )
+  }
 
-      get {
-        parameter('before.as[String] ?) { maybeBefore =>
-          lookupVersions(bagId = bagId, maybeBefore = maybeBefore)
-        }
-      }
-    }
+  private def decodeExternalIdentifier(remaining: String): ExternalIdentifier = {
+    // Sometimes we have an external identifier with slashes.
+    // For maximum flexibility, we want to support both URL-encoded
+    // and complete path versions.
+    //
+    // For example, if the external identifier is "alfa/bravo",
+    // you could look up both of:
+    //
+    //    /bags/space-id/alfa/bravo
+    //    /bags/space-id/alfa%2Fbravo
+    //
+    val underlying =
+    URLDecoder.decode(remaining, StandardCharsets.UTF_8.toString)
+
+    ExternalIdentifier(underlying)
   }
 
   val bags: Route = wrapLargeResponses(routes)


### PR DESCRIPTION
Part of https://github.com/wellcometrust/platform/issues/4088

This works whether or not you URL encode the slash. Example:

```
GET /bags/space-id/alfa/bravo
GET /bags/space-id/alfa%2Fbravo
GET /bags/space-id/alfa/bravo/versions
GET /bags/space-id/alfa%2Fbravo/versions
```

If you're feeling perverse and your ID is `alfa/versions`, it also (mostly) works:

```
GET /bags/space-id/alfa%2Fversions
GET /bags/space-id/alfa/versions/versions
GET /bags/space-id/alfa%2Fversions/versions
```

Do not do this. It is silly.