### PR TITLE
Improve validation of StorageSpace and ExternalIdentifier

### DIFF
--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/DestinationBuilder.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/DestinationBuilder.scala
@@ -1,7 +1,5 @@
 package uk.ac.wellcome.platform.archive.bagreplicator.services
 
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
 import java.nio.file.Paths
 
 import uk.ac.wellcome.platform.archive.common.bagit.models.{
@@ -20,30 +18,10 @@ class DestinationBuilder(namespace: String) {
     namespace = namespace,
     path = Paths
       .get(
-        encode(storageSpace.toString),
-        encode(externalIdentifier.toString),
+        storageSpace.toString,
+        externalIdentifier.toString,
         version.toString
       )
       .toString
   )
-
-  // We encode the storage space and external identifier with
-  // a URL encoder so that:
-  //
-  //  - the path created is still human-readable
-  //  - slashes are escaped
-  //
-  // This means the replicator will never mix up:
-  //
-  //        space = "a/b"   identifier = "c"
-  // and
-  //        space = "a"     identifier = "b/c"
-  //
-  // They will get distinct paths.
-  //
-  // Names that only contain alphanumeric characters and hyphens
-  // (e.g. b1234, digitised-workflow) will be unmodified.
-  //
-  private def encode(s: String): String =
-    URLEncoder.encode(s, StandardCharsets.UTF_8.toString)
 }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/DestinationBuilderTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/services/DestinationBuilderTest.scala
@@ -51,47 +51,19 @@ class DestinationBuilderTest
     location.path shouldBe s"${storageSpace.underlying}/${externalIdentifier.toString}/$version"
   }
 
-  it("URL encodes slashes in the path") {
+  it("uses slashes in the external identifier to build a hierarchy") {
     val builder = new DestinationBuilder(
       namespace = createNamespace
     )
 
     val version = createBagVersion
-
-    val externalIdentifier = createExternalIdentifier
 
     val location = builder.buildDestination(
-      storageSpace = StorageSpace("a/b"),
-      externalIdentifier = externalIdentifier,
+      storageSpace = StorageSpace("alfa"),
+      externalIdentifier = ExternalIdentifier("bravo/charlie"),
       version = version
     )
 
-    location.path shouldBe s"a%2Fb/$externalIdentifier/$version"
-  }
-
-  it("encodes slashes in a way that avoids ambiguity") {
-    val builder = new DestinationBuilder(
-      namespace = createNamespace
-    )
-
-    val version = createBagVersion
-
-    val component1 = s"1-$randomAlphanumeric"
-    val component2 = s"2-$randomAlphanumeric"
-    val component3 = s"3-$randomAlphanumeric"
-
-    val location_12_3 = builder.buildDestination(
-      storageSpace = StorageSpace(s"$component1/$component2"),
-      externalIdentifier = ExternalIdentifier(component3),
-      version = version
-    )
-
-    val location_1_23 = builder.buildDestination(
-      storageSpace = StorageSpace(component1),
-      externalIdentifier = ExternalIdentifier(s"$component2/$component3"),
-      version = version
-    )
-
-    location_12_3 should not be location_1_23
+    location.path shouldBe s"alfa/bravo/charlie/$version"
   }
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifier.scala
@@ -35,7 +35,7 @@ object ExternalIdentifier {
     cursor.value.as[String].map(ExternalIdentifier(_))
 
   implicit def evidence: DynamoFormat[ExternalIdentifier] =
-    DynamoFormat.iso[ExternalIdentifier, String](
+    DynamoFormat.coercedXmap[ExternalIdentifier, String, IllegalArgumentException](
       ExternalIdentifier(_)
     )(
       _.underlying

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifier.scala
@@ -3,8 +3,10 @@ package uk.ac.wellcome.platform.archive.common.bagit.models
 import org.scanamo.DynamoFormat
 import io.circe.{Decoder, Encoder, HCursor, Json}
 
-case class ExternalIdentifier(underlying: String) extends AnyVal {
+case class ExternalIdentifier(underlying: String) {
   override def toString: String = underlying
+
+  require(!underlying.isEmpty, "External identifier cannot be empty")
 }
 
 object ExternalIdentifier {

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifier.scala
@@ -13,7 +13,7 @@ class ExternalIdentifier(val underlying: String) {
   //
   // We deliberately don't use case classes here so we skip automatic
   // case class derivation for JSON encoding/DynamoDB in Scanamo,
-  // and force callers to use the implicits below.
+  // and force callers to intentionally import the implicits below.
   def canEqual(a: Any): Boolean = a.isInstanceOf[ExternalIdentifier]
 
   override def equals(that: Any): Boolean =

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifier.scala
@@ -22,6 +22,8 @@ class ExternalIdentifier(val underlying: String) {
         that.canEqual(this) && this.underlying == that.underlying
       case _ => false
     }
+
+  override def hashCode: Int = underlying.hashCode
 }
 
 object ExternalIdentifier {

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifier.scala
@@ -35,9 +35,10 @@ object ExternalIdentifier {
     cursor.value.as[String].map(ExternalIdentifier(_))
 
   implicit def evidence: DynamoFormat[ExternalIdentifier] =
-    DynamoFormat.coercedXmap[ExternalIdentifier, String, IllegalArgumentException](
-      ExternalIdentifier(_)
-    )(
-      _.underlying
-    )
+    DynamoFormat
+      .coercedXmap[ExternalIdentifier, String, IllegalArgumentException](
+        ExternalIdentifier(_)
+      )(
+        _.underlying
+      )
 }

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifier.scala
@@ -3,13 +3,31 @@ package uk.ac.wellcome.platform.archive.common.bagit.models
 import org.scanamo.DynamoFormat
 import io.circe.{Decoder, Encoder, HCursor, Json}
 
-case class ExternalIdentifier(underlying: String) {
+class ExternalIdentifier(val underlying: String) {
   override def toString: String = underlying
 
   require(!underlying.isEmpty, "External identifier cannot be empty")
+
+  // Normally we use case classes for immutable data, which provide these
+  // methods for us.
+  //
+  // We deliberately don't use case classes here so we skip automatic
+  // case class derivation for JSON encoding/DynamoDB in Scanamo,
+  // and force callers to use the implicits below.
+  def canEqual(a: Any): Boolean = a.isInstanceOf[ExternalIdentifier]
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case that: ExternalIdentifier =>
+        that.canEqual(this) && this.underlying == that.underlying
+      case _ => false
+    }
 }
 
 object ExternalIdentifier {
+  def apply(underlying: String): ExternalIdentifier =
+    new ExternalIdentifier(underlying)
+
   implicit val encoder: Encoder[ExternalIdentifier] =
     (value: ExternalIdentifier) => Json.fromString(value.toString)
 

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageSpace.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageSpace.scala
@@ -23,6 +23,8 @@ class StorageSpace(val underlying: String) {
       case _ => false
     }
 
+  override def hashCode: Int = underlying.hashCode
+
   // At various points in the pipeline, we combine the storage space and
   // the external identifier into a bag ID, for example:
   //

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageSpace.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageSpace.scala
@@ -13,7 +13,7 @@ class StorageSpace(val underlying: String) {
   //
   // We deliberately don't use case classes here so we skip automatic
   // case class derivation for JSON encoding/DynamoDB in Scanamo,
-  // and force callers to use the implicits below.
+  // and force callers to intentionally import the implicits below.
   def canEqual(a: Any): Boolean = a.isInstanceOf[StorageSpace]
 
   override def equals(that: Any): Boolean =

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageSpace.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageSpace.scala
@@ -3,8 +3,34 @@ package uk.ac.wellcome.platform.archive.common.storage.models
 import org.scanamo.DynamoFormat
 import io.circe.{Decoder, Encoder, HCursor, Json}
 
-case class StorageSpace(underlying: String) extends AnyVal {
+case class StorageSpace(underlying: String) {
   override def toString: String = underlying
+
+  require(!underlying.isEmpty, "Storage space cannot be empty")
+
+  // At various points in the pipeline, we combine the storage space and
+  // the external identifier into a bag ID, for example:
+  //
+  //    space = "digitised"
+  //    identifier = "b12345678"
+  //     => bag ID = "digitised/b12345678"
+  //
+  // We allow slashes in the IDs (for example, to match CALM IDs like PP/MIA/1).
+  // To avoid ambiguity when looking at a bag ID, we forbid slashes in
+  // the external identifier.
+  //
+  // For example, this allows us to say unambiguously that
+  //
+  //    bag ID = "alfa/bravo/charlie"
+  //     => space = "alfa"
+  //        identifier = "bravo/charlie"
+  //
+  // If both the space and external identifier could contain slashes,
+  // this bag ID would be ambiguous.
+  require(
+    !underlying.contains("/"),
+    s"Storage space cannot contain slashes, but got $underlying"
+  )
 }
 
 object StorageSpace {

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageSpace.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageSpace.scala
@@ -59,7 +59,7 @@ object StorageSpace {
     cursor.value.as[String].map(StorageSpace(_))
 
   implicit def evidence: DynamoFormat[StorageSpace] =
-    DynamoFormat.iso[StorageSpace, String](
+    DynamoFormat.coercedXmap[StorageSpace, String, IllegalArgumentException](
       StorageSpace(_)
     )(
       _.underlying

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifierTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifierTest.scala
@@ -14,4 +14,8 @@ class ExternalIdentifierTest extends FunSpec with Matchers {
 
     err.getMessage shouldBe "requirement failed: External identifier cannot be empty"
   }
+
+  it("allows creating an external identifier with slashes") {
+    ExternalIdentifier("PP/MIA/1")
+  }
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifierTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifierTest.scala
@@ -1,0 +1,17 @@
+package uk.ac.wellcome.platform.archive.common.bagit.models
+
+import org.scalatest.{FunSpec, Matchers}
+
+class ExternalIdentifierTest extends FunSpec with Matchers {
+  it("allows creating an external identifier") {
+    ExternalIdentifier("b12345678")
+  }
+
+  it("blocks creating an external identifier with an empty string") {
+    val err = intercept[IllegalArgumentException] {
+      ExternalIdentifier("")
+    }
+
+    err.getMessage shouldBe "requirement failed: External identifier cannot be empty"
+  }
+}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageSpaceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageSpaceTest.scala
@@ -12,7 +12,9 @@ class StorageSpaceTest extends FunSpec with Matchers {
       StorageSpace("alfa/bravo")
     }
 
-    err.getMessage should startWith("requirement failed: Storage space cannot contain slashes")
+    err.getMessage should startWith(
+      "requirement failed: Storage space cannot contain slashes"
+    )
   }
 
   it("blocks creating a storage space with an empty string") {

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageSpaceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageSpaceTest.scala
@@ -1,0 +1,35 @@
+package uk.ac.wellcome.platform.archive.common.storage.models
+
+import org.scalatest.{FunSpec, Matchers}
+
+class StorageSpaceTest extends FunSpec with Matchers {
+  it("allows creating a storage space") {
+    StorageSpace("digitised")
+  }
+
+  it("blocks creating a storage space with a slash") {
+    val err = intercept[IllegalArgumentException] {
+      StorageSpace("alfa/bravo")
+    }
+
+    err.getMessage should startWith("requirement failed: Storage space cannot contain slashes")
+  }
+
+  it("blocks creating a storage space with a slash using .copy()") {
+    val space = StorageSpace("digitised")
+
+    val err = intercept[IllegalArgumentException] {
+      space.copy(underlying = "alfa/bravo")
+    }
+
+    err.getMessage should startWith("requirement failed: Storage space cannot contain slashes")
+  }
+
+  it("blocks creating a storage space with an empty string") {
+    val err = intercept[IllegalArgumentException] {
+      StorageSpace("")
+    }
+
+    err.getMessage shouldBe "requirement failed: Storage space cannot be empty"
+  }
+}

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageSpaceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageSpaceTest.scala
@@ -15,16 +15,6 @@ class StorageSpaceTest extends FunSpec with Matchers {
     err.getMessage should startWith("requirement failed: Storage space cannot contain slashes")
   }
 
-  it("blocks creating a storage space with a slash using .copy()") {
-    val space = StorageSpace("digitised")
-
-    val err = intercept[IllegalArgumentException] {
-      space.copy(underlying = "alfa/bravo")
-    }
-
-    err.getMessage should startWith("requirement failed: Storage space cannot contain slashes")
-  }
-
   it("blocks creating a storage space with an empty string") {
     val err = intercept[IllegalArgumentException] {
       StorageSpace("")

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/services/StorageManifestServiceTest.scala
@@ -470,7 +470,9 @@ class StorageManifestServiceTest
     }
 
     it("sets a recent createdDate") {
-      assertRecent(storageManifest.createdDate)
+      // This test takes longer when running on a Mac, not in CI, so allow some
+      // flex on the definition of "recent".
+      assertRecent(storageManifest.createdDate, recentSeconds = 30)
     }
   }
 

--- a/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/tracker/dynamo/DynamoIngestTrackerTest.scala
+++ b/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/tracker/dynamo/DynamoIngestTrackerTest.scala
@@ -122,7 +122,7 @@ class DynamoIngestTrackerTest
     }
 
   // TODO: Add tests for handling DynamoDB errors
-  
+
   override protected def assertIngestsEqual(
     ingest1: Ingest,
     ingest2: Ingest

--- a/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/tracker/dynamo/DynamoIngestTrackerTest.scala
+++ b/ingests_common/src/test/scala/uk/ac/wellcome/platform/archive/common/ingests/tracker/dynamo/DynamoIngestTrackerTest.scala
@@ -122,11 +122,7 @@ class DynamoIngestTrackerTest
     }
 
   // TODO: Add tests for handling DynamoDB errors
-
-  // TODO: Add tests that lookupBagId returns a finite list of results
-
-  // TODO: Add tests that failing to store the bag ID lookup don't fail the overall result
-
+  
   override protected def assertIngestsEqual(
     ingest1: Ingest,
     ingest2: Ingest


### PR DESCRIPTION
If you try to create a:

* Storage space with a slash (e.g. `alfa/bravo`)
* An empty storage space `StorageSpace("")`
* An empty external identifier `ExternalIdentifier("")`

You hit these new runtime assertions. In practice, you should never hit these unless you're doing something very silly – but for https://github.com/wellcometrust/platform/issues/4088 in particular, we're going to have to assume spaces can't contain slashes, and it's better to encode that in the type system than assuming it won't happen.

This allows us to unambiguously distinguish the storage space/external identifier in a bag ID.

e.g. if you look at bag ID `alfa/bravo/charlie`, the space is `alfa` and the external ID is `bravo/Charlie`.