### PR TITLE
Allow the storage service to scale to 0 when not running

### DIFF
--- a/terraform/modules/service/scaling_worker/main.tf
+++ b/terraform/modules/service/scaling_worker/main.tf
@@ -28,7 +28,7 @@ module "worker" {
 module "scaling" {
   source = "git::github.com/wellcomecollection/terraform-aws-ecs-service.git//autoscaling?ref=v1.1.0"
 
-  name   = var.service_name
+  name = var.service_name
 
   cluster_name = var.cluster_name
   service_name = var.service_name

--- a/terraform/modules/stack/main.tf
+++ b/terraform/modules/stack/main.tf
@@ -464,7 +464,10 @@ module "api" {
   interservice_security_group_id = aws_security_group.interservice.id
   alarm_topic_arn                = var.alarm_topic_arn
   bag_unpacker_topic_arn         = module.bag_unpacker_input_topic.arn
-  desired_bags_api_count         = var.desired_bags_api_count
-  desired_ingests_api_count      = var.desired_ingests_api_count
+
+  # The number of API tasks MUST be one per AZ.  This is due to the behaviour of
+  # NLBs that seem to increase latency significantly if number of tasks < number of AZs.
+  desired_bags_api_count    = max(3, var.desired_bags_api_count)
+  desired_ingests_api_count = max(3, var.desired_ingests_api_count)
 }
 

--- a/terraform/modules/stack/variables.tf
+++ b/terraform/modules/stack/variables.tf
@@ -94,8 +94,6 @@ variable "versioner_versions_table_name" {
 variable "versioner_versions_table_index" {
 }
 
-# The number of api tasks MUST be one per AZ.  This is due to the behaviour of
-# NLBs that seem to increase latency significantly if number of tasks < number of AZs.
 variable "desired_bags_api_count" {
   default = 3
 }
@@ -107,9 +105,5 @@ variable "desired_ingests_api_count" {
 variable "archivematica_ingests_bucket" {
 }
 
-variable "min_capacity" {
-}
-
-variable "max_capacity" {
-}
-
+variable "min_capacity" {}
+variable "max_capacity" {}

--- a/terraform/stack_prod/main.tf
+++ b/terraform/stack_prod/main.tf
@@ -13,7 +13,7 @@ module "stack_prod" {
   domain_name      = local.domain_name
   cert_domain_name = local.cert_domain_name
 
-  min_capacity = 1
+  min_capacity = 0
   max_capacity = 10
 
   vpc_id = local.vpc_id

--- a/terraform/stack_staging/main.tf
+++ b/terraform/stack_staging/main.tf
@@ -13,7 +13,7 @@ module "stack_staging" {
   domain_name      = local.staging_domain_name
   cert_domain_name = local.cert_domain_name
 
-  min_capacity = 1
+  min_capacity = 0
   max_capacity = 3
 
   vpc_id = local.vpc_id


### PR DESCRIPTION
Most of the time the storage service isn't doing anything, but we have Fargate instances running anyway. This is just burning money – allowing it to scale to 0 will save us ~$1200/month.

Applying this config showed up a bug in autoscaling setup – despite it being configured in Terraform, the notifier and ingests monitor both had broken autoscaling, so they'd never run anything except 1 instance.

Closes https://github.com/wellcometrust/platform/issues/4014. I did try writing a script to automate warming the pipeline, but let's see if we need it first.