### PR TITLE
Allow sending slashes in the external identifier

### DIFF
--- a/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/responses/CreateIngest.scala
+++ b/api/ingests_api/src/main/scala/uk/ac/wellcome/platform/storage/ingests/api/responses/CreateIngest.scala
@@ -30,11 +30,15 @@ trait CreateIngest extends ResponseBase with Logging {
     val externalIdentifier = requestDisplayIngest.bag.info.externalIdentifier
 
     if (space.contains("/")) {
-      createBadRequestResponse("Invalid value at .space.id: must not contain slashes.")
+      createBadRequestResponse(
+        "Invalid value at .space.id: must not contain slashes."
+      )
     } else if (space == "") {
       createBadRequestResponse("Invalid value at .space.id: must not be empty.")
     } else if (externalIdentifier == "") {
-      createBadRequestResponse("Invalid value at .bag.info.externalIdentifier: must not be empty.")
+      createBadRequestResponse(
+        "Invalid value at .bag.info.externalIdentifier: must not be empty."
+      )
     } else {
       triggerIngestStarter(requestDisplayIngest)
     }

--- a/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/CreateIngestApiTest.scala
+++ b/api/ingests_api/src/test/scala/uk/ac/wellcome/platform/storage/ingests/api/CreateIngestApiTest.scala
@@ -173,27 +173,28 @@ class CreateIngestApiTest
   }
 
   it("creates an ingest with a slash in the external identifier") {
-    withConfiguredApp() { case (_, _, _, baseUrl) =>
-      val url = s"$baseUrl/ingests"
+    withConfiguredApp() {
+      case (_, _, _, baseUrl) =>
+        val url = s"$baseUrl/ingests"
 
-      val externalIdentifier = ExternalIdentifier("PP/MIA/1")
+        val externalIdentifier = ExternalIdentifier("PP/MIA/1")
 
-      val entity = createRequestWith(
-        externalIdentifier = externalIdentifier
-      )
+        val entity = createRequestWith(
+          externalIdentifier = externalIdentifier
+        )
 
-      whenPostRequestReady(url, entity) { response: HttpResponse =>
-        response.status shouldBe StatusCodes.Created
+        whenPostRequestReady(url, entity) { response: HttpResponse =>
+          response.status shouldBe StatusCodes.Created
 
-        val ingestFuture =
-          withMaterializer { implicit materializer =>
-            Unmarshal(response.entity).to[ResponseDisplayIngest]
+          val ingestFuture =
+            withMaterializer { implicit materializer =>
+              Unmarshal(response.entity).to[ResponseDisplayIngest]
+            }
+
+          whenReady(ingestFuture) {
+            _.bag.info.externalIdentifier shouldBe externalIdentifier
           }
-
-        whenReady(ingestFuture) {
-          _.bag.info.externalIdentifier shouldBe externalIdentifier
         }
-      }
     }
   }
 
@@ -282,8 +283,7 @@ class CreateIngestApiTest
 
         assertCatchesMalformedRequest(
           badJson(json).noSpaces,
-          expectedMessage =
-            "Invalid value at .space.id: must not be empty."
+          expectedMessage = "Invalid value at .space.id: must not be empty."
         )
       }
     }

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayBagInfo.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayBagInfo.scala
@@ -4,7 +4,7 @@ import io.circe.generic.extras.JsonKey
 import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
 
 case class RequestDisplayBagInfo(
-  externalIdentifier: ExternalIdentifier,
+  externalIdentifier: String,
   @JsonKey("type") ontologyType: String = "BagInfo"
 )
 

--- a/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayIngest.scala
+++ b/display/src/main/scala/uk/ac/wellcome/platform/archive/display/DisplayIngest.scala
@@ -5,6 +5,7 @@ import java.time.Instant
 import java.util.UUID
 
 import io.circe.generic.extras.JsonKey
+import uk.ac.wellcome.platform.archive.common.bagit.models.ExternalIdentifier
 import uk.ac.wellcome.platform.archive.common.ingests.models._
 import uk.ac.wellcome.platform.archive.common.storage.models.StorageSpace
 
@@ -27,7 +28,7 @@ case class RequestDisplayIngest(
         callback.map(displayCallback => URI.create(displayCallback.url))
       ),
       space = StorageSpace(space.id),
-      externalIdentifier = bag.info.externalIdentifier,
+      externalIdentifier = ExternalIdentifier(bag.info.externalIdentifier),
       status = Ingest.Accepted,
       createdDate = Instant.now
     )

--- a/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayIngestTest.scala
+++ b/display/src/test/scala/uk/ac/wellcome/platform/archive/display/DisplayIngestTest.scala
@@ -130,7 +130,7 @@ class DisplayIngestTest
         ),
         bag = RequestDisplayBag(
           info = RequestDisplayBagInfo(
-            externalIdentifier = externalIdentifier
+            externalIdentifier = externalIdentifier.underlying
           )
         ),
         ingestType = CreateDisplayIngestType,
@@ -186,10 +186,8 @@ class DisplayIngestTest
       ingestType = ingestType,
       bag = RequestDisplayBag(
         info = RequestDisplayBagInfo(
-          externalIdentifier = createExternalIdentifier,
-          ontologyType = "BagInfo"
-        ),
-        ontologyType = "Bag"
+          externalIdentifier = createExternalIdentifier.underlying
+        )
       ),
       space = space
     )


### PR DESCRIPTION
Also add tests around validation for non-empty space/external ID. The new runtime assertions would have caught these, but with less nice error reporting back to the user.

For https://github.com/wellcometrust/platform/issues/4088