### PR TITLE
Add more restrictions on external identifier and storage space

### DIFF
--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/LookupBagApiTest.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/LookupBagApiTest.scala
@@ -179,33 +179,6 @@ class LookupBagApiTest
     }
   }
 
-  // Creating a bag whose external identifier ends with /versions seems unlikely
-  // in practice, but we should be able to support it if you correctly URL-encode
-  // the slash.
-  //
-  // (Do not create bags like this.  It is silly.)
-  it("finds a bag whose identifier ends with /versions") {
-    val storageManifest = createStorageManifestWith(
-      bagInfo = createBagInfoWith(
-        externalIdentifier = ExternalIdentifier("alfa/versions")
-      )
-    )
-
-    withConfiguredApp(initialManifests = Seq(storageManifest)) {
-      case (_, _, baseUrl) =>
-        val url =
-          s"$baseUrl/bags/${storageManifest.id.space.underlying}/alfa%2Fversions"
-
-        whenGetRequestReady(url) { response =>
-          response.status shouldBe StatusCodes.OK
-
-          withStringEntity(response.entity) {
-            assertJsonMatches(_, storageManifest)
-          }
-        }
-    }
-  }
-
   it("does not output null values") {
     val storageManifest = createStorageManifestWith(
       bagInfo = createBagInfoWith(externalDescription = None)

--- a/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/LookupBagVersionsApiTest.scala
+++ b/api/bags_api/src/test/scala/uk/ac/wellcome/platform/storage/bags/api/LookupBagVersionsApiTest.scala
@@ -244,65 +244,6 @@ class LookupBagVersionsApiTest
     }
   }
 
-  // Creating a bag whose external identifier ends with /versions seems unlikely
-  // in practice, but we should be able to support it if you correctly URL-encode
-  // the slash.
-  //
-  // (Do not create bags like this.  It is silly.)
-  it("finds versions a bag whose identifier ends with /versions (URL-encoded)") {
-    val storageManifest = createStorageManifestWith(
-      bagInfo = createBagInfoWith(
-        externalIdentifier = ExternalIdentifier("alfa/versions")
-      )
-    )
-
-    val expectedJson = expectedVersionList(
-      expectedVersionJson(storageManifest)
-    )
-
-    withConfiguredApp(initialManifests = Seq(storageManifest)) {
-      case (_, _, baseUrl) =>
-        val url =
-          s"$baseUrl/bags/${storageManifest.id.space.underlying}/alfa%2Fversions/versions"
-
-        whenGetRequestReady(url) { response =>
-          response.status shouldBe StatusCodes.OK
-
-          withStringEntity(response.entity) {
-            assertJsonStringsAreEqual(_, expectedJson)
-          }
-        }
-    }
-  }
-
-  it(
-    "finds versions a bag whose identifier ends with /versions (not URL-encoded)"
-  ) {
-    val storageManifest = createStorageManifestWith(
-      bagInfo = createBagInfoWith(
-        externalIdentifier = ExternalIdentifier("alfa/versions")
-      )
-    )
-
-    val expectedJson = expectedVersionList(
-      expectedVersionJson(storageManifest)
-    )
-
-    withConfiguredApp(initialManifests = Seq(storageManifest)) {
-      case (_, _, baseUrl) =>
-        val url =
-          s"$baseUrl/bags/${storageManifest.id.space.underlying}/alfa/versions/versions"
-
-        whenGetRequestReady(url) { response =>
-          response.status shouldBe StatusCodes.OK
-
-          withStringEntity(response.entity) {
-            assertJsonStringsAreEqual(_, expectedJson)
-          }
-        }
-    }
-  }
-
   it(
     "returns a 404 NotFound if there are no manifests before the specified version"
   ) {

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifier.scala
@@ -48,6 +48,7 @@ class ExternalIdentifier(val underlying: String) {
   // the key, so prevent people from putting slashes at the beginning or end.
   require(!underlying.startsWith("/"), "External identifier cannot start with a slash")
   require(!underlying.endsWith("/"), "External identifier cannot end with a slash")
+  require(!underlying.contains("//"), "External identifier cannot contain consecutive slashes")
 
   // Normally we use case classes for immutable data, which provide these
   // methods for us.

--- a/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifier.scala
+++ b/common/src/main/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifier.scala
@@ -14,7 +14,10 @@ class ExternalIdentifier(val underlying: String) {
   //
   // To avoid ambiguity, block callers from creating an identifier that
   // ends with /versions.
-  require(!underlying.endsWith("/versions"), "External identifier cannot end with /versions")
+  require(
+    !underlying.endsWith("/versions"),
+    "External identifier cannot end with /versions"
+  )
 
   // When we store a bag in S3, we store different versions of it under the key
   //
@@ -46,9 +49,18 @@ class ExternalIdentifier(val underlying: String) {
   //
   // The S3 Console is liable to do weird things if you have a double slash in
   // the key, so prevent people from putting slashes at the beginning or end.
-  require(!underlying.startsWith("/"), "External identifier cannot start with a slash")
-  require(!underlying.endsWith("/"), "External identifier cannot end with a slash")
-  require(!underlying.contains("//"), "External identifier cannot contain consecutive slashes")
+  require(
+    !underlying.startsWith("/"),
+    "External identifier cannot start with a slash"
+  )
+  require(
+    !underlying.endsWith("/"),
+    "External identifier cannot end with a slash"
+  )
+  require(
+    !underlying.contains("//"),
+    "External identifier cannot contain consecutive slashes"
+  )
 
   // Normally we use case classes for immutable data, which provide these
   // methods for us.

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifierTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifierTest.scala
@@ -30,6 +30,13 @@ class ExternalIdentifierTest extends FunSpec with Matchers {
     )
   }
 
+  it("blocks creating an external identifier with consecutive slashes") {
+    assertFailsRequirement(
+      identifier = "PP//MIA",
+      message = "External identifier cannot contain consecutive slashes"
+    )
+  }
+
   it("blocks creating an external identifier that ends with /versions") {
     assertFailsRequirement(
       identifier = "b12345678/versions",

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifierTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifierTest.scala
@@ -71,7 +71,10 @@ class ExternalIdentifierTest extends FunSpec with Matchers {
     )
   }
 
-  private def assertFailsRequirement(identifier: String, message: String): Assertion = {
+  private def assertFailsRequirement(
+    identifier: String,
+    message: String
+  ): Assertion = {
     val err = intercept[IllegalArgumentException] {
       ExternalIdentifier(identifier)
     }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifierTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/bagit/models/ExternalIdentifierTest.scala
@@ -1,21 +1,74 @@
 package uk.ac.wellcome.platform.archive.common.bagit.models
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.{Assertion, FunSpec, Matchers}
 
 class ExternalIdentifierTest extends FunSpec with Matchers {
   it("allows creating an external identifier") {
     ExternalIdentifier("b12345678")
   }
 
-  it("blocks creating an external identifier with an empty string") {
-    val err = intercept[IllegalArgumentException] {
-      ExternalIdentifier("")
-    }
-
-    err.getMessage shouldBe "requirement failed: External identifier cannot be empty"
-  }
-
   it("allows creating an external identifier with slashes") {
     ExternalIdentifier("PP/MIA/1")
+  }
+
+  it("blocks creating an external identifier with an empty string") {
+    assertFailsRequirement(
+      identifier = "",
+      message = "External identifier cannot be empty"
+    )
+  }
+
+  it("blocks creating an external identifier that begins or ends with a slash") {
+    assertFailsRequirement(
+      identifier = "PP/MIA/",
+      message = "External identifier cannot end with a slash"
+    )
+
+    assertFailsRequirement(
+      identifier = "/PP/MIA",
+      message = "External identifier cannot start with a slash"
+    )
+  }
+
+  it("blocks creating an external identifier that ends with /versions") {
+    assertFailsRequirement(
+      identifier = "b12345678/versions",
+      message = "External identifier cannot end with /versions"
+    )
+  }
+
+  it("blocks creating an external identifier that contains a /vNN-like string") {
+    assertFailsRequirement(
+      identifier = "b12345678/v1",
+      message = "External identifier cannot end with a version string"
+    )
+
+    assertFailsRequirement(
+      identifier = "b12345678/v0",
+      message = "External identifier cannot end with a version string"
+    )
+
+    assertFailsRequirement(
+      identifier = "b12345678/v200",
+      message = "External identifier cannot end with a version string"
+    )
+
+    assertFailsRequirement(
+      identifier = "v2/a",
+      message = "External identifier cannot start with a version string"
+    )
+
+    assertFailsRequirement(
+      identifier = "b12345678/v2/a",
+      message = "External identifier cannot contain a version string"
+    )
+  }
+
+  private def assertFailsRequirement(identifier: String, message: String): Assertion = {
+    val err = intercept[IllegalArgumentException] {
+      ExternalIdentifier(identifier)
+    }
+
+    err.getMessage shouldBe s"requirement failed: $message"
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageSpaceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageSpaceTest.scala
@@ -1,6 +1,6 @@
 package uk.ac.wellcome.platform.archive.common.storage.models
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.{Assertion, FunSpec, Matchers}
 
 class StorageSpaceTest extends FunSpec with Matchers {
   it("allows creating a storage space") {
@@ -8,20 +8,46 @@ class StorageSpaceTest extends FunSpec with Matchers {
   }
 
   it("blocks creating a storage space with a slash") {
-    val err = intercept[IllegalArgumentException] {
-      StorageSpace("alfa/bravo")
-    }
-
-    err.getMessage should startWith(
-      "requirement failed: Storage space cannot contain slashes"
+    assertFailsRequirement(
+      space = "alfa/bravo",
+      message = "Storage space cannot contain slashes"
     )
   }
 
   it("blocks creating a storage space with an empty string") {
+    assertFailsRequirement(
+      space = "",
+      message = "Storage space cannot be empty"
+    )
+  }
+
+  // When we construct the S3 key for a bag, it's typically of the form
+  //
+  //    s3://{bucket}/{space}/{externalIdentifier}
+  //
+  // So if the space began with a slash (say /digitised), the key would be
+  //
+  //    s3://{bucket}//digitised/{externalIdentifier}
+  //
+  // And the S3 Console is liable to do weird things with double slashes
+  // in the key.
+  it("blocks creating a storage sapce that begins or ends with a slash") {
+    assertFailsRequirement(
+      space = "digitised/",
+      message = "Storage space cannot contain slashes"
+    )
+
+    assertFailsRequirement(
+      space = "/digitised",
+      message = "Storage space cannot contain slashes"
+    )
+  }
+
+  private def assertFailsRequirement(space: String, message: String): Assertion = {
     val err = intercept[IllegalArgumentException] {
-      StorageSpace("")
+      StorageSpace(space)
     }
 
-    err.getMessage shouldBe "requirement failed: Storage space cannot be empty"
+    err.getMessage should startWith(s"requirement failed: $message")
   }
 }

--- a/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageSpaceTest.scala
+++ b/common/src/test/scala/uk/ac/wellcome/platform/archive/common/storage/models/StorageSpaceTest.scala
@@ -43,7 +43,10 @@ class StorageSpaceTest extends FunSpec with Matchers {
     )
   }
 
-  private def assertFailsRequirement(space: String, message: String): Assertion = {
+  private def assertFailsRequirement(
+    space: String,
+    message: String
+  ): Assertion = {
     val err = intercept[IllegalArgumentException] {
       StorageSpace(space)
     }


### PR DESCRIPTION
Since we're now doing validation of these strings, cover a couple of edge cases that would cause annoyance if you put them in the storage service.  In particular:

*   Don't allow slashes in a place that would cause double slashes in the S3 key (because that causes weirdness in the S3 Console, which is how a lot of people will browse the storage)
*   Don't allow an identifier to end with `/versions` (because that conflicts with the bags API endpoint)
*   Don't allow an identifier to include `/v1`, `/v2`, `/v3`, ... (because that makes the S3 bucket harder to navigate)

The storage service itself will cope fine with any of these things, but they'll cause confusion for the humans who have to use it!

If we find we actually need identifiers that look like this, we can consider removing them, and accept the possible confusion that might result.  But since we don't expect to use them any time soon, this should prevent programming bugs elsewhere causing confusion in the storage service!