### PR TITLE
Store the replicas as Standard-IA

### DIFF
--- a/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3Replicator.scala
+++ b/bag_replicator/src/main/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3Replicator.scala
@@ -1,10 +1,11 @@
 package uk.ac.wellcome.platform.archive.bagreplicator.replicator.s3
 
 import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.model.StorageClass
 import uk.ac.wellcome.platform.archive.bagreplicator.replicator.Replicator
 import uk.ac.wellcome.storage.transfer.s3.S3PrefixTransfer
 
 class S3Replicator(implicit s3Client: AmazonS3) extends Replicator {
   implicit val prefixTransfer: S3PrefixTransfer =
-    S3PrefixTransfer()
+    S3PrefixTransfer(storageClass = StorageClass.StandardInfrequentAccess)
 }

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3ReplicatorTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3ReplicatorTest.scala
@@ -68,8 +68,10 @@ class S3ReplicatorTest
         contents
       )
 
-      val srcPrefix = ObjectLocationPrefix(namespace = bucket.name, path = "src/")
-      val dstPrefix = ObjectLocationPrefix(namespace = bucket.name, path = "dst/")
+      val srcPrefix =
+        ObjectLocationPrefix(namespace = bucket.name, path = "src/")
+      val dstPrefix =
+        ObjectLocationPrefix(namespace = bucket.name, path = "dst/")
 
       val result = new S3Replicator().replicate(
         ingestId = createIngestID,

--- a/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3ReplicatorTest.scala
+++ b/bag_replicator/src/test/scala/uk/ac/wellcome/platform/archive/bagreplicator/replicator/s3/S3ReplicatorTest.scala
@@ -56,6 +56,36 @@ class S3ReplicatorTest
     }
   }
 
+  it("stores the objects as Standard-IA") {
+    withLocalS3Bucket { bucket =>
+      val name = randomAlphanumeric
+      val location = createObjectLocationWith(bucket, key = s"src/$name")
+      val contents = randomAlphanumeric
+
+      s3Client.putObject(
+        location.namespace,
+        location.path,
+        contents
+      )
+
+      val srcPrefix = ObjectLocationPrefix(namespace = bucket.name, path = "src/")
+      val dstPrefix = ObjectLocationPrefix(namespace = bucket.name, path = "dst/")
+
+      val result = new S3Replicator().replicate(
+        ingestId = createIngestID,
+        request = ReplicationRequest(
+          srcPrefix = srcPrefix,
+          dstPrefix = dstPrefix
+        )
+      )
+
+      result shouldBe a[ReplicationSucceeded]
+
+      val metadata = s3Client.getObjectMetadata(bucket.name, s"dst/$name")
+      metadata.getStorageClass shouldBe "STANDARD_IA"
+    }
+  }
+
   it("fails if the underlying replication has an error") {
     val result = new S3Replicator().replicate(
       ingestId = createIngestID,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object WellcomeDependencies {
     val json = "1.1.1"
     val messaging = "5.3.1"
     val monitoring = "2.3.0"
-    val storage = "7.24.3"
+    val storage = "7.25.0"
     val typesafe = "1.0.0"
   }
 


### PR DESCRIPTION
Right now we store everything as Standard, which is unnecessarily expensive. The Glacier replica will get life-cycled out of Standard-IA to Glacier-DeepArchive eventually; the warm replica will remain IA.

For https://github.com/wellcometrust/platform/issues/4096