### PR TITLE
Remove the destination prefix from the bag unpacker

### DIFF
--- a/bag_unpacker/src/main/resources/application.conf
+++ b/bag_unpacker/src/main/resources/application.conf
@@ -4,5 +4,4 @@ aws.ingest.sns.topic.arn=${?ingest_topic_arn}
 aws.outgoing.sns.topic.arn=${?outgoing_topic_arn}
 aws.metrics.namespace=${?metrics_namespace}
 destination.namespace=${?destination_bucket_name}
-destination.prefix=unpacked
 operation.name=${?operation_name}

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/builders/BagLocationBuilder.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/builders/BagLocationBuilder.scala
@@ -17,7 +17,6 @@ object BagLocationBuilder {
       namespace = unpackerWorkerConfig.dstNamespace,
       path = Paths
         .get(
-          unpackerWorkerConfig.maybeDstPrefix.getOrElse(""),
           storageSpace.toString,
           ingestId.toString
         )

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/config/builders/UnpackerWorkerConfigBuilder.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/config/builders/UnpackerWorkerConfigBuilder.scala
@@ -7,7 +7,6 @@ import uk.ac.wellcome.typesafe.config.builders.EnrichConfig._
 object UnpackerWorkerConfigBuilder {
   def build(config: Config): BagUnpackerWorkerConfig = {
     val namespace = config.required[String]("destination.namespace")
-    val prefix = config.get[String]("destination.prefix")
-    BagUnpackerWorkerConfig(namespace, prefix)
+    BagUnpackerWorkerConfig(namespace)
   }
 }

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/config/models/BagUnpackerWorkerConfig.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/config/models/BagUnpackerWorkerConfig.scala
@@ -1,6 +1,5 @@
 package uk.ac.wellcome.platform.archive.bagunpacker.config.models
 
 case class BagUnpackerWorkerConfig(
-  dstNamespace: String,
-  maybeDstPrefix: Option[String] = None
+  dstNamespace: String
 )


### PR DESCRIPTION
We don't use it at all – we write unpacked bags into a dedicated bucket, so prefixing all the paths with "unpacked" doesn't add much. This patch will unpack into the root of the bucket.

Additionally, we didn't have any tests that check we were appending that prefix!