### PR TITLE
Fix an overflow bug when reporting the # of bytes unpacked

### DIFF
--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
@@ -103,8 +103,12 @@ trait Unpacker extends Logging {
         Left(UnpackerUnarchiverError(unarchiverError))
 
       case Right(iterator) =>
-        var totalFiles = 0
-        var totalBytes = 0
+
+        // For large bags, the standard Int type can overflow and report a negative
+        // number of bytes.  This is silly, so we ensure these are treated as Long.
+        // See https://github.com/wellcometrust/platform/issues/3947
+        var totalFiles: Long = 0
+        var totalBytes: Long = 0
 
         Try {
           iterator
@@ -119,7 +123,7 @@ trait Unpacker extends Logging {
                 )
 
                 totalFiles += 1
-                totalBytes += uploadedBytes.toInt
+                totalBytes += uploadedBytes
             }
 
           unpackSummary.copy(

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
@@ -103,7 +103,6 @@ trait Unpacker extends Logging {
         Left(UnpackerUnarchiverError(unarchiverError))
 
       case Right(iterator) =>
-
         // For large bags, the standard Int type can overflow and report a negative
         // number of bytes.  This is silly, so we ensure these are treated as Long.
         // See https://github.com/wellcometrust/platform/issues/3947


### PR DESCRIPTION
Debugging via Twitter: https://twitter.com/alexwlchan/status/1220075920284946444

I joked about seeing a message from this particular bug on Twitter, then went to have another look at the code.  Spotted it instantly, where previously it was totally invisible.

Closes #3947.