### PR TITLE
Write a human-readable file size in the bag unpacker messages

### DIFF
--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/models/UnpackSummary.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/models/UnpackSummary.scala
@@ -19,12 +19,15 @@ case class UnpackSummary(
   def complete: UnpackSummary =
     this.copy(maybeEndTime = Some(Instant.now()))
 
+  def size: String =
+    FileUtils.byteCountToDisplaySize(bytesUnpacked)
+
   override val fieldsToLog: Seq[(String, Any)] =
     Seq(
       ("src", srcLocation),
       ("dst", dstLocation),
       ("files", fileCount),
       ("bytesUnpacked", bytesUnpacked),
-      ("size", FileUtils.byteCountToDisplaySize(bytesUnpacked))
+      ("size", size)
     )
 }

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
@@ -55,7 +55,7 @@ trait Unpacker extends Logging {
     result match {
       case Right(summary) =>
         val message =
-          s"Unpacked ${summary.bytesUnpacked} bytes from ${summary.fileCount} file${if (summary.fileCount != 1) "s"}"
+          s"Unpacked ${summary.size} from ${summary.fileCount} file${if (summary.fileCount != 1) "s"}"
         Success(
           IngestStepSucceeded(
             summary,

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/UnpackerFeatureTest.scala
@@ -71,7 +71,7 @@ class UnpackerFeatureTest
                   eventDescriptions should have size 2
 
                   eventDescriptions(0) shouldBe "Unpacker started"
-                  eventDescriptions(1) should fullyMatch regex """Unpacker succeeded - Unpacked \d+ bytes from \d+ files"""
+                  eventDescriptions(1) should fullyMatch regex """Unpacker succeeded - Unpacked \d+ [KM]B from \d+ files"""
                 }
               }
             }

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorkerTest.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/BagUnpackerWorkerTest.scala
@@ -79,7 +79,7 @@ class BagUnpackerWorkerTest
                 eventDescriptions should have size 2
 
                 eventDescriptions(0) shouldBe "Unpacker started"
-                eventDescriptions(1) should fullyMatch regex """Unpacker succeeded - Unpacked \d+ bytes from \d+ files"""
+                eventDescriptions(1) should fullyMatch regex """Unpacker succeeded - Unpacked \d+ KB from \d+ files"""
             }
           }
         }

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
@@ -54,7 +54,7 @@ trait UnpackerTestCases[Namespace]
             unpacked shouldBe a[IngestStepSucceeded[_]]
 
             unpacked.maybeUserFacingMessage.get should fullyMatch regex
-              """Unpacked \d+ bytes from \d+ files"""
+              """Unpacked \d+ [KM]B from \d+ files"""
 
             val summary = unpacked.summary
             summary.fileCount shouldBe filesInArchive.size
@@ -92,7 +92,7 @@ trait UnpackerTestCases[Namespace]
             unpacked shouldBe a[IngestStepSucceeded[_]]
 
             unpacked.maybeUserFacingMessage.get should fullyMatch regex
-              """Unpacked \d+ bytes from \d+ files"""
+              """Unpacked \d+ [KM]B from \d+ files"""
 
             val summary = unpacked.summary
             summary.fileCount shouldBe filesInArchive.size


### PR DESCRIPTION
Saying "unpacked 5 MB" is more pleasant than saying "unpacked 5000000 bytes". This message is only for human consumption and you can get the exact byte sizes from the storage manifest, so might as well make it friendly.

A quick improvement spotted while working on #432.