### PR TITLE
Format the file count in unpacker messages with a comma

### DIFF
--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
@@ -36,6 +36,10 @@ trait Unpacker extends Logging {
 
   def formatLocation(location: ObjectLocation): String
 
+  def createMessage(summary: UnpackSummary): String = {
+    s"Unpacked ${summary.size} from ${summary.fileCount} file${if (summary.fileCount != 1) "s" else ""}"
+  }
+
   def unpack(
     ingestId: IngestID,
     srcLocation: ObjectLocation,
@@ -54,12 +58,10 @@ trait Unpacker extends Logging {
 
     result match {
       case Right(summary) =>
-        val message =
-          s"Unpacked ${summary.size} from ${summary.fileCount} file${if (summary.fileCount != 1) "s"}"
         Success(
           IngestStepSucceeded(
             summary,
-            maybeUserFacingMessage = Some(message)
+            maybeUserFacingMessage = Some(createMessage(summary))
           )
         )
 

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
@@ -1,6 +1,7 @@
 package uk.ac.wellcome.platform.archive.bagunpacker.services
 
 import java.io.InputStream
+import java.text.NumberFormat
 import java.time.Instant
 
 import grizzled.slf4j.Logging
@@ -37,7 +38,8 @@ trait Unpacker extends Logging {
   def formatLocation(location: ObjectLocation): String
 
   def createMessage(summary: UnpackSummary): String = {
-    s"Unpacked ${summary.size} from ${summary.fileCount} file${if (summary.fileCount != 1) "s" else ""}"
+    val displayFileCount = NumberFormat.getInstance().format(summary.fileCount)
+    s"Unpacked ${summary.size} from $displayFileCount file${if (summary.fileCount != 1) "s" else ""}"
   }
 
   def unpack(

--- a/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
+++ b/bag_unpacker/src/main/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/Unpacker.scala
@@ -39,7 +39,8 @@ trait Unpacker extends Logging {
 
   def createMessage(summary: UnpackSummary): String = {
     val displayFileCount = NumberFormat.getInstance().format(summary.fileCount)
-    s"Unpacked ${summary.size} from $displayFileCount file${if (summary.fileCount != 1) "s" else ""}"
+    s"Unpacked ${summary.size} from $displayFileCount file${if (summary.fileCount != 1) "s"
+    else ""}"
   }
 
   def unpack(

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
@@ -177,6 +177,12 @@ trait UnpackerTestCases[Namespace]
       unpacker.createMessage(summary) should endWith("from 5 files")
     }
 
+    it("adds a comma to the file counts if appropriate") {
+      val summary = createUnpackSummaryWith(fileCount = 123456789)
+
+      unpacker.createMessage(summary) should endWith("from 123,456,789 files")
+    }
+
     it("pretty-prints the file size") {
       val summary = createUnpackSummaryWith(bytesUnpacked = 123456789)
 

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
@@ -189,7 +189,10 @@ trait UnpackerTestCases[Namespace]
       unpacker.createMessage(summary) should startWith("Unpacked 117 MB")
     }
 
-    def createUnpackSummaryWith(fileCount: Long = Random.nextLong(), bytesUnpacked: Long = Random.nextLong()): UnpackSummary =
+    def createUnpackSummaryWith(
+      fileCount: Long = Random.nextLong(),
+      bytesUnpacked: Long = Random.nextLong()
+    ): UnpackSummary =
       UnpackSummary(
         ingestId = createIngestID,
         srcLocation = createObjectLocation,

--- a/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
+++ b/bag_unpacker/src/test/scala/uk/ac/wellcome/platform/archive/bagunpacker/services/UnpackerTestCases.scala
@@ -2,6 +2,7 @@ package uk.ac.wellcome.platform.archive.bagunpacker.services
 
 import java.io.{File, FileInputStream}
 import java.nio.file.Paths
+import java.time.Instant
 
 import org.scalatest.{Assertion, FunSpec, Matchers, TryValues}
 import uk.ac.wellcome.fixtures.TestWith
@@ -18,6 +19,8 @@ import uk.ac.wellcome.storage.streaming.{
   StreamAssertions
 }
 import uk.ac.wellcome.storage.{ObjectLocation, ObjectLocationPrefix}
+
+import scala.util.Random
 
 trait UnpackerTestCases[Namespace]
     extends FunSpec
@@ -159,6 +162,36 @@ trait UnpackerTestCases[Namespace]
         )
       }
     }
+  }
+
+  describe("creates the correct message") {
+    it("handles a single file correctly") {
+      val summary = createUnpackSummaryWith(fileCount = 1)
+
+      unpacker.createMessage(summary) should endWith("from 1 file")
+    }
+
+    it("handles multiple files correctly") {
+      val summary = createUnpackSummaryWith(fileCount = 5)
+
+      unpacker.createMessage(summary) should endWith("from 5 files")
+    }
+
+    it("pretty-prints the file size") {
+      val summary = createUnpackSummaryWith(bytesUnpacked = 123456789)
+
+      unpacker.createMessage(summary) should startWith("Unpacked 117 MB")
+    }
+
+    def createUnpackSummaryWith(fileCount: Long = Random.nextLong(), bytesUnpacked: Long = Random.nextLong()): UnpackSummary =
+      UnpackSummary(
+        ingestId = createIngestID,
+        srcLocation = createObjectLocation,
+        dstLocation = createObjectLocationPrefix,
+        fileCount = fileCount,
+        bytesUnpacked = bytesUnpacked,
+        startTime = Instant.now()
+      )
   }
 
   def assertEqual(prefix: ObjectLocationPrefix, expectedFiles: Seq[File])(


### PR DESCRIPTION
```
Before:  Unpacked 7 GB from 49684 files
After:   Unpacked 7 GB from 49,684 files
```

Just to make it a bit easier for humans to read.